### PR TITLE
ci: daily PyPI smoke test matrix

### DIFF
--- a/.github/workflows/daily-smoke.yml
+++ b/.github/workflows/daily-smoke.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: "0 8 * * *"
   workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/daily-smoke.yml
 
 jobs:
   smoke:

--- a/.github/workflows/daily-smoke.yml
+++ b/.github/workflows/daily-smoke.yml
@@ -1,0 +1,51 @@
+name: Daily PyPI Smoke Tests
+
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: ${{ matrix.example }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: ${{ matrix.optional || false }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # --- quick demos: must pass ---
+          - example: basic_usage.py
+          - example: bitboard_compact_demo.py
+          - example: compact_state_demo.py
+          - example: compact_tree_demo.py
+          - example: legal_moves_demo.py
+          - example: opening_book_demo.py
+          - example: win_probability_analysis.py
+          - example: symmetry_reduction.py
+          # --- heavier examples: best-effort within 5 min ---
+          - example: mcts_demo.py
+            optional: true
+          - example: baseline_measurement.py
+            optional: true
+          - example: generate_puzzles.py
+            optional: true
+          - example: endgame_puzzle_generator.py
+            optional: true
+          # --- book generator: capped at depth 1 so it exits fast ---
+          - example: generate_opening_book.py
+            args: "--max-depth 1 --workers 1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install latest quantik-core from PyPI
+        run: pip install quantik-core
+
+      - name: Run ${{ matrix.example }}
+        run: python examples/${{ matrix.example }} ${{ matrix.args || '' }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/daily-smoke.yml` that runs every day at 08:00 UTC (and on `workflow_dispatch`)
- Installs the **latest published `quantik-core` from PyPI** fresh in each job — no local source
- Runs all 13 examples **in parallel**, one job per example

## Job behaviour

| Category | Examples | Pass policy |
|---|---|---|
| Quick demos | `basic_usage`, `bitboard_compact_demo`, `compact_state_demo`, `compact_tree_demo`, `legal_moves_demo`, `opening_book_demo`, `win_probability_analysis`, `symmetry_reduction` | must pass |
| Heavy / best-effort | `mcts_demo`, `baseline_measurement`, `generate_puzzles`, `endgame_puzzle_generator` | `continue-on-error: true`, 5-min timeout |
| Capped generator | `generate_opening_book --max-depth 1 --workers 1` | must pass |

## Test plan

- [ ] Trigger manually via `workflow_dispatch` after merge to verify all jobs start
- [ ] Confirm quick demos pass green
- [ ] Confirm heavy jobs time out gracefully without blocking the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)