### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
@@ -31,7 +31,7 @@ jobs:
         twine check dist/*
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dist
         path: dist/
@@ -46,12 +46,12 @@ jobs:
 
     steps:
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: dist
         path: dist/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@v7
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -35,10 +35,10 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -47,6 +47,6 @@ jobs:
         pytest tests/ -v --cov=quantik_core --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Bumps all `uses:` pins across `.github/workflows/` to their latest major versions, eliminating the Node 20 deprecation warnings. No input/output parameters changed in any of these bumps.

## Version matrix

| Action | Before | After | Breaking changes |
|--------|--------|-------|-----------------|
| `actions/checkout` | `v4` | `v7` | v5–v7: Node 24 runtime (runner ≥ 2.327.1); v7 also blocks fork-PR checkout for `pull_request_target`/`workflow_run` (security hardening, no workflow uses those triggers) |
| `actions/setup-python` | `v4` / `v5` | `v6` | v6: Node 24 runtime — no input/output renames |
| `actions/upload-artifact` | `v4` | `v7` | v5–v7: Node 24; v7 adds opt-in `archive: false` for direct uploads (unused here) |
| `actions/download-artifact` | `v4` | `v8` | v5: path behavior change for single-by-ID downloads — **not applicable** (we download by `name`); v8: hash mismatch now errors by default (stricter, not a breakage) |
| `codecov/codecov-action` | `v5` | `v7` | v6: Node 24; v7: keybase key rotation (`codecovsecurity` → `codecovsecops`) |
| `pypa/gh-action-pypi-publish` | `release/v1` | — | Floating tag — already tracks latest v1.x, no change needed |

## Note

`daily-smoke.yml` (on the open `ci/daily-pypi-smoke` branch) also uses `actions/checkout@v4` and `actions/setup-python@v5`. Those pins should be updated on that branch before or after merging this PR.

## Test plan

- [ ] Verify CI passes on this PR (build, test, integration workflows all trigger)
- [ ] Confirm no Node 20 deprecation warnings appear in workflow logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbwWse6D35ysEb6SGNS9FC