### PR TITLE
feat: parametrizable beam search engine for MCTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `quantik-core` are documented here.
 - Added `BeamSearchResult.ranked_root_moves()`, aggregating every collected leaf by its first move from the root into `RankedRootMove` entries (`best_value`, `mean_value`, `win_probability`, `leaf_count`, `has_terminal_win`) for ranking multiple midgame options.
 - Added `examples/beam_search_demo.py` showcasing full-depth terminal reachability, tactical win detection with the full winning principal variation, a beam-width memory sweep, a pluggable custom evaluator, and ranked root move statistics from a midgame position.
 - Added `docs/BEAM_SEARCH.md` documenting the algorithm, configuration, result fields, ranked root moves, memory model, and the caveats of sharing a `CompactGameTree` with `MCTSEngine`.
+- Added `BeamSearchConfig.beam_schedule`, a depth-dependent beam width (last entry extends to deeper levels) so a search can keep an exhaustive shallow prefix and switch to guided sampling once the canonical state space grows too large, plus the `UNIQUE_CANONICAL_STATES_PER_DEPTH` constant for building such schedules.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `quantik-core` are documented here.
 - Added `examples/beam_search_demo.py` showcasing full-depth terminal reachability, tactical win detection with the full winning principal variation, a beam-width memory sweep, a pluggable custom evaluator, and ranked root move statistics from a midgame position.
 - Added `docs/BEAM_SEARCH.md` documenting the algorithm, configuration, result fields, ranked root moves, memory model, and the caveats of sharing a `CompactGameTree` with `MCTSEngine`.
 - Added `BeamSearchConfig.beam_schedule`, a depth-dependent beam width (last entry extends to deeper levels) so a search can keep an exhaustive shallow prefix and switch to guided sampling once the canonical state space grows too large, plus the `UNIQUE_CANONICAL_STATES_PER_DEPTH` constant for building such schedules.
+- Added symmetry-multiplicity accounting: `BeamLeaf.multiplicity` and `RankedRootMove.total_multiplicity` track how many raw (pre-canonicalization) move sequences a leaf represents via path-count accumulation, `RankedRootMove.mean_value` is now multiplicity-weighted, and survivor/terminal tree nodes are inserted with their accumulated multiplicity instead of the previous implicit default of 1.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `quantik-core` are documented here.
 
+## Unreleased
+
+### Added
+
+- Added `BeamSearchEngine`, a parametrizable, memory-bounded beam search that guarantees reaching true terminal Quantik states (win/loss by blocked player) by deduplicating candidates per depth via `State.canonical_key()`, ranking them mover-relative, and pruning to a configurable `beam_width` while sharing the `CompactGameTree` structure used by MCTS.
+- Added `examples/beam_search_demo.py` showcasing full-depth terminal reachability, tactical win detection, a beam-width memory sweep, and a pluggable custom evaluator.
+- Added `docs/BEAM_SEARCH.md` documenting the algorithm, configuration, result fields, memory model, and the caveats of sharing a `CompactGameTree` with `MCTSEngine`.
+
 ## 1.0.0 - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `quantik-core` are documented here.
 
 - Added `BeamSearchEngine`, a parametrizable, memory-bounded beam search that guarantees reaching true terminal Quantik states (win/loss by blocked player) by deduplicating candidates per depth via `State.canonical_key()`, ranking them mover-relative, and pruning to a configurable `beam_width` while sharing the `CompactGameTree` structure used by MCTS.
 - Added `BeamSearchResult.root_player` and `BeamSearchResult.frontier_leaves` (the live, non-terminal leaves remaining at `max_depth_reached`).
+- Added `BeamSearchConfig.rollout_schedule` for a depth-dependent playout budget in the built-in evaluator (pairing with `beam_schedule` to be wide-and-cheap on exhaustive levels and precise on the pruned tail), plus a `stats["rollouts"]` counter exposing the exact playout spend.
 - Added `BeamSearchResult.ranked_root_moves()`, aggregating every collected leaf by its first move from the root into `RankedRootMove` entries (`best_value`, `mean_value`, `win_probability`, `leaf_count`, `has_terminal_win`) for ranking multiple midgame options.
 - Added `examples/beam_search_demo.py` showcasing full-depth terminal reachability, tactical win detection with the full winning principal variation, a beam-width memory sweep, a pluggable custom evaluator, and ranked root move statistics from a midgame position.
 - Added `docs/BEAM_SEARCH.md` documenting the algorithm, configuration, result fields, ranked root moves, memory model, and the caveats of sharing a `CompactGameTree` with `MCTSEngine`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ All notable changes to `quantik-core` are documented here.
 ### Added
 
 - Added `BeamSearchEngine`, a parametrizable, memory-bounded beam search that guarantees reaching true terminal Quantik states (win/loss by blocked player) by deduplicating candidates per depth via `State.canonical_key()`, ranking them mover-relative, and pruning to a configurable `beam_width` while sharing the `CompactGameTree` structure used by MCTS.
-- Added `examples/beam_search_demo.py` showcasing full-depth terminal reachability, tactical win detection, a beam-width memory sweep, and a pluggable custom evaluator.
-- Added `docs/BEAM_SEARCH.md` documenting the algorithm, configuration, result fields, memory model, and the caveats of sharing a `CompactGameTree` with `MCTSEngine`.
+- Added `BeamSearchResult.root_player` and `BeamSearchResult.frontier_leaves` (the live, non-terminal leaves remaining at `max_depth_reached`).
+- Added `BeamSearchResult.ranked_root_moves()`, aggregating every collected leaf by its first move from the root into `RankedRootMove` entries (`best_value`, `mean_value`, `win_probability`, `leaf_count`, `has_terminal_win`) for ranking multiple midgame options.
+- Added `examples/beam_search_demo.py` showcasing full-depth terminal reachability, tactical win detection with the full winning principal variation, a beam-width memory sweep, a pluggable custom evaluator, and ranked root move statistics from a midgame position.
+- Added `docs/BEAM_SEARCH.md` documenting the algorithm, configuration, result fields, ranked root moves, memory model, and the caveats of sharing a `CompactGameTree` with `MCTSEngine`.
+
+### Fixed
+
+- Fixed `examples/beam_search_demo.py`'s move formatting to reflect the actual mover (QFEN convention: uppercase = player 0, lowercase = player 1) instead of always rendering shapes uppercase.
 
 ## 1.0.0 - 2026-06-22
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ QFEN: "Ab.C/d.BA/.cb./D.a."
 This library provides the core foundation for building:
 
 - **Monte Carlo Tree Search (MCTS)** engines
+- **Parametrizable beam search** for memory-bounded terminal-state discovery
 - **Game analysis** and position evaluation systems  
 - **AI training** and recommendation engines
 - **Opening book** generation and endgame databases
@@ -137,6 +138,7 @@ This library provides the core foundation for building:
 - **Move Generation**: Full legal move generation with placement validation
 - **Game Logic**: Win detection, move validation, and game result checking
 - **MCTS Engine**: Monte Carlo Tree Search with UCB1 selection
+- **Beam Search Engine**: memory-bounded frontier search guaranteeing true terminal states
 - **Opening Book**: SQLite-backed position database with canonical deduplication
 - **Puzzle Generator**: Tactical puzzle generation with dropout-based search
 - **Serialization**: Binary, QFEN, and CBOR formats
@@ -209,6 +211,29 @@ state = State.from_qfen("..../..../..../....")
 # Find best move
 move, win_probability = engine.search(state)
 print(f"Best move: {move}, Win probability: {win_probability:.2%}")
+```
+
+### Beam Search
+
+```python
+from quantik_core import State
+from quantik_core.beam_search import BeamSearchEngine, BeamSearchConfig
+
+# Configure beam search (guarantees reaching true terminal states)
+config = BeamSearchConfig(
+    beam_width=8,
+    max_depth=16,
+    random_seed=42
+)
+
+# Create engine and search
+engine = BeamSearchEngine(config)
+state = State.from_qfen("..../..../..../....")
+
+# Find the best line for the root player
+result = engine.search(state)
+print(f"Reached terminal: {result.reached_terminal}")
+print(f"Best line: {result.best_leaf.moves}")
 ```
 
 ### Opening Book Database
@@ -289,6 +314,7 @@ binary = state.pack()  # Just 18 bytes
 ## Documentation
 
 - [MCTS Documentation](docs/MCTS.md) - Monte Carlo Tree Search implementation details
+- [Beam Search Documentation](docs/BEAM_SEARCH.md) - Memory-bounded terminal-state search
 - [Opening Book Guide](docs/OPENING_BOOK.md) - Position database usage and API
 - [Examples](examples/) - Complete working examples for all features
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,9 @@ print(f"Best move: {move}, Win probability: {win_probability:.2%}")
 from quantik_core import State
 from quantik_core.beam_search import BeamSearchEngine, BeamSearchConfig
 
-# Configure beam search (guarantees reaching true terminal states)
+# Configure beam search (guarantees reaching true terminal states).
+# beam_width can also be a depth-dependent beam_schedule=[...] — see
+# docs/BEAM_SEARCH.md's Tuning section for an exhaustive-prefix recipe.
 config = BeamSearchConfig(
     beam_width=8,
     max_depth=16,

--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ state = State.from_qfen("..../..../..../....")
 result = engine.search(state)
 print(f"Reached terminal: {result.reached_terminal}")
 print(f"Best line: {result.best_leaf.moves}")
+
+# Rank multiple root move options (beam-sampled, not proven minimax)
+for entry in result.ranked_root_moves(top_k=3):
+    print(f"{entry.move}: win_probability={entry.win_probability:.2%}")
 ```
 
 ### Opening Book Database

--- a/docs/BEAM_SEARCH.md
+++ b/docs/BEAM_SEARCH.md
@@ -74,9 +74,47 @@ class BeamSearchResult:
     stats: Dict[str, int]              # candidates_generated, candidates_deduped,
                                         # nodes_inserted, nodes_pruned,
                                         # evaluations, memory_usage
+    root_player: int = 0               # player to move at the root
+    frontier_leaves: List[BeamLeaf] = field(default_factory=list)
+    # ^ non-terminal leaves still live at max_depth_reached; empty once
+    #   reached_terminal is True
 ```
 
 `best_leaf` ranks every collected leaf — terminals plus, if the search hit `max_depth` with a live frontier, the final frontier entries — from the **root player's** fixed perspective (unlike the mover-relative pruning score used level by level). `search()` raises `ValueError` if the root state is already terminal or has no legal moves.
+
+### "Moves Till Win"
+
+When `best_leaf.is_terminal` is `True`, `best_leaf.moves` *is* the full principal variation to a proven win (or loss) — no further search needed:
+
+```python
+if result.best_leaf.is_terminal:
+    print(f"Forced result in {len(result.best_leaf.moves)} plies: {result.best_leaf.moves}")
+```
+
+## Ranked Root Moves
+
+For midgame positions with several reasonable options, `BeamSearchResult.ranked_root_moves(top_k=None)` aggregates every collected leaf (`terminal_leaves` plus `frontier_leaves`) by its first move from the root and summarizes each option:
+
+```python
+result = engine.search(state)
+for entry in result.ranked_root_moves(top_k=5):
+    print(entry.move, entry.best_value, entry.win_probability, entry.leaf_count)
+```
+
+Each `RankedRootMove` has:
+
+| Field | Description |
+|-------|-------------|
+| `move` | The first move from the root |
+| `best_value` | Max leaf value reached via this move (root-player perspective, `[-1, 1]`) |
+| `mean_value` | Mean leaf value via this move (root-player perspective) |
+| `win_probability` | Heuristic rescaling `(mean_value + 1) / 2`, in `[0, 1]` |
+| `leaf_count` | Number of collected leaves supporting this move |
+| `has_terminal_win` | A proven root-player-winning terminal exists via this move |
+
+Entries are sorted by `best_value`, then `mean_value`, then `leaf_count` (all descending), with a deterministic tiebreak on the move itself.
+
+**Important caveat**: these are beam-sampled statistics over whichever leaves this particular run happened to discover and keep — not a minimax-proven guarantee. A move can have `best_value == 1.0` (a winning line exists via it) alongside a low `win_probability` if most of the *other* leaves discovered via that move were mediocre; `win_probability` is a heuristic rescaling of `mean_value`, not a calibrated probability.
 
 ## Memory Model
 
@@ -112,6 +150,7 @@ Also note that `CompactGameTree`'s own transposition key is the literal `State.p
 See `examples/beam_search_demo.py` for complete working examples:
 
 - Full-depth search from the empty board reaching a true terminal
-- Tactical (immediate win) position analysis
+- Tactical (immediate win) position analysis, replaying the full winning line
 - Beam width sweep demonstrating the memory bound
 - Pluggable custom evaluator
+- Ranked root move statistics from a midgame position

--- a/docs/BEAM_SEARCH.md
+++ b/docs/BEAM_SEARCH.md
@@ -1,0 +1,117 @@
+# Beam Search Implementation
+
+This document describes the parametrizable beam search engine in Quantik Core: a memory-bounded search mode that guarantees reaching true terminal game states, complementing the statistical sampling of MCTS.
+
+## Overview
+
+`MCTSEngine` samples the game tree stochastically and its random playouts stop at `max_depth` without guaranteeing terminal resolution. Exhaustive expansion of the full game tree is infeasible (Quantik has ~2.2 × 10^12 legal move sequences). `BeamSearchEngine` fills the gap: a level-by-level frontier search that always descends to true terminal states (win, loss by blocked player) while bounding memory to a configurable width.
+
+### Algorithm Phases
+
+Per depth level (players strictly alternate, so every node at a given depth shares the same side to move):
+
+1. **Expand**: generate legal moves for each frontier entry and apply them. A frontier state with no legal moves is itself terminal (the player to move loses).
+2. **Classify**: any child that completes a winning line is recorded immediately as a terminal leaf and inserted into the tree — regardless of the beam width.
+3. **Deduplicate**: remaining non-terminal candidates are deduplicated per depth by `State.canonical_key()` (symmetry-aware; first path encountered wins).
+4. **Score**: each surviving candidate is evaluated and ranked **mover-relative** — from the perspective of the player who just moved (`score = value` for a P0 move, `-value` for a P1 move) — so the beam stays adversarially sensible at every level instead of optimizing one fixed player throughout.
+5. **Prune**: only the top `beam_width` candidates survive (stable ordering, so seeded runs are deterministic); pruned candidates never allocate a tree node.
+6. **Insert**: survivors are added to the shared `CompactGameTree` via `add_child_node` and become the next depth's frontier.
+
+Search stops when the frontier empties (every line resolved to a terminal) or `max_depth` is reached.
+
+## Quick Start
+
+```python
+from quantik_core import State
+from quantik_core.beam_search import BeamSearchEngine, BeamSearchConfig
+
+config = BeamSearchConfig(beam_width=8, max_depth=16, random_seed=42)
+engine = BeamSearchEngine(config)
+
+state = State.from_qfen("..../..../..../....")
+result = engine.search(state)
+
+print(f"Reached terminal: {result.reached_terminal}")
+print(f"Best line: {result.best_leaf.moves}")
+print(f"Value (P0 perspective): {result.best_leaf.value}")
+```
+
+## Configuration
+
+### BeamSearchConfig Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `beam_width` | int | 64 | Frontier nodes kept per depth (>= 1) |
+| `max_depth` | int | 16 | Plies from root; 16 = full Quantik game (1-16) |
+| `rollouts_per_candidate` | int | 8 | Rollout budget for the built-in evaluator (>= 1) |
+| `random_seed` | int\|None | None | Seeds a **private** `random.Random` — the global RNG is never touched |
+| `evaluator` | `Callable[[State], float]`\|None | None | Custom evaluator; falls back to random-rollout scoring when omitted |
+| `initial_tree_capacity` | int | 4096 | Initial `CompactGameTree` node capacity |
+
+Invalid values (`beam_width < 1`, `max_depth` outside `1..16`, `rollouts_per_candidate < 1`) raise `ValueError` from `BeamSearchEngine.__init__`.
+
+### Evaluator Contract
+
+`evaluator(state) -> float` returns a value in `[-1, 1]` from **player 0's perspective**, matching `MCTSEngine`'s convention. Values outside that range are clamped. When omitted, the engine uses the mean of `rollouts_per_candidate` uniform random playouts, each rolled out to a true terminal — a Quantik playout never exceeds 16 plies, so no depth-cutoff heuristic is needed.
+
+## Result
+
+```python
+@dataclass
+class BeamLeaf:
+    moves: Tuple[Move, ...]   # principal variation from the root
+    value: float              # P0 perspective; +/-1.0 for terminal leaves
+    depth: int
+    is_terminal: bool
+
+@dataclass
+class BeamSearchResult:
+    best_leaf: Optional[BeamLeaf]      # best for the ROOT player to move
+    terminal_leaves: List[BeamLeaf]    # all terminals discovered, best first
+    reached_terminal: bool
+    max_depth_reached: int
+    stats: Dict[str, int]              # candidates_generated, candidates_deduped,
+                                        # nodes_inserted, nodes_pruned,
+                                        # evaluations, memory_usage
+```
+
+`best_leaf` ranks every collected leaf — terminals plus, if the search hit `max_depth` with a live frontier, the final frontier entries — from the **root player's** fixed perspective (unlike the mover-relative pruning score used level by level). `search()` raises `ValueError` if the root state is already terminal or has no legal moves.
+
+## Memory Model
+
+Only surviving candidates allocate a tree node, so growth is bounded by `beam_width x depth` non-terminal nodes plus however many terminal leaves were discovered along the way — versus the unbounded growth of exhaustive expansion. Each node is the same 64-byte `CompactGameTreeNode` used by MCTS. `get_statistics()` mirrors `MCTSEngine.get_statistics()`, delegating to `tree.memory_usage()` and `tree.get_stats()`.
+
+## Sharing a Tree with MCTS
+
+`BeamSearchEngine` accepts an existing `CompactGameTree` (e.g. `mcts_engine.tree`) so both engines can enrich the same transposition structure:
+
+```python
+from quantik_core.mcts import MCTSEngine, MCTSConfig
+from quantik_core.beam_search import BeamSearchEngine, BeamSearchConfig
+
+mcts_engine = MCTSEngine(MCTSConfig())
+beam_engine = BeamSearchEngine(BeamSearchConfig(beam_width=8), tree=mcts_engine.tree)
+```
+
+**Caveat**: `CompactGameTree.create_root_node` hardcodes the root's `player_turn` to 0 and alternates from there. When sharing a tree, root the beam search at a position where **player 0 is to move** — otherwise every node's `player_turn` is inverted, which would corrupt MCTS's UCB calculation if it later resumes on the same tree.
+
+Also note that `CompactGameTree`'s own transposition key is the literal `State.pack()` bytes (its `canonical_state_data` field is *not* symmetry-reduced), while beam search's own deduplication (step 3 above) uses the coarser `State.canonical_key()`. The shared tree therefore isn't itself symmetry-reduced — beam search just feeds it canonically-distinct representatives per depth.
+
+## Comparison with MCTS
+
+| Aspect | Beam Search | MCTS |
+|--------|-------------|------|
+| **Terminal guarantee** | Always reaches true terminals (within `max_depth`) | Not guaranteed; playouts stop at `max_depth` |
+| **Exploration** | Deterministic frontier expansion, mover-relative pruning | Stochastic UCB1 sampling |
+| **Memory** | O(beam_width x depth) | Grows with iteration count |
+| **Best for** | Exhaustive-ish tactical verification under a memory budget | General-purpose anytime search |
+
+## Examples
+
+See `examples/beam_search_demo.py` for complete working examples:
+
+- Full-depth search from the empty board reaching a true terminal
+- Tactical (immediate win) position analysis
+- Beam width sweep demonstrating the memory bound
+- Pluggable custom evaluator

--- a/docs/BEAM_SEARCH.md
+++ b/docs/BEAM_SEARCH.md
@@ -49,8 +49,9 @@ print(f"Value (P0 perspective): {result.best_leaf.value}")
 | `evaluator` | `Callable[[State], float]`\|None | None | Custom evaluator; falls back to random-rollout scoring when omitted |
 | `initial_tree_capacity` | int | 4096 | Initial `CompactGameTree` node capacity |
 | `beam_schedule` | `Sequence[int]`\|None | None | Depth-dependent beam width (see Tuning below); `None` uses the flat `beam_width` everywhere |
+| `rollout_schedule` | `Sequence[int]`\|None | None | Depth-dependent rollout budget for the **built-in** evaluator only (custom evaluators ignore it); same indexing semantics as `beam_schedule`; `None` uses the flat `rollouts_per_candidate` everywhere |
 
-Invalid values (`beam_width < 1`, `max_depth` outside `1..16`, `rollouts_per_candidate < 1`, an empty `beam_schedule`, or any `beam_schedule` entry `< 1`) raise `ValueError` from `BeamSearchEngine.__init__`.
+Invalid values (`beam_width < 1`, `max_depth` outside `1..16`, `rollouts_per_candidate < 1`, an empty or non-positive `beam_schedule` or `rollout_schedule`) raise `ValueError` from `BeamSearchEngine.__init__`.
 
 ### Evaluator Contract
 
@@ -70,7 +71,18 @@ config = BeamSearchConfig(beam_schedule=schedule, max_depth=16)
 
 Width at depth `d` resolves to `beam_schedule[min(d - 1, len(beam_schedule) - 1)]`, so the schedule's last entry extends to every deeper level. A single-entry schedule (e.g. `beam_schedule=[8]`) is exactly equivalent to `beam_width=8`.
 
-**Cost model**: evaluations at level `d + 1` are proportional to `width(d) x branching_factor x rollouts_per_candidate` (or a single evaluator call each, if using a custom evaluator). An exhaustive prefix is cheap while the canonical count is small (3, then 51) but grows fast — by depth 4 (10,946 unique states) exhaustive search is usually no longer worth it; that's the point at which a schedule typically switches to a fixed guided width.
+**Cost model**: evaluations at level `d + 1` are proportional to `width(d) x branching_factor x rollouts(d + 1)` (or a single evaluator call each, if using a custom evaluator). An exhaustive prefix is cheap while the canonical count is small (3, then 51) but grows fast — by depth 4 (10,946 unique states) exhaustive search is usually no longer worth it; that's the point at which a schedule typically switches to a fixed guided width.
+
+**Wide-and-cheap early, narrow-and-precise late**: on a level where the width meets or exceeds the canonical state count, *nothing is pruned*, so evaluation precision there is wasted budget. `rollout_schedule` pairs with `beam_schedule` to spend playouts only where pruning decisions actually happen:
+
+```python
+config = BeamSearchConfig(
+    beam_schedule=[3, 51, 726, 64],   # exhaustive plies 1-3, width-64 tail
+    rollout_schedule=[1, 1, 1, 8],    # 1 playout on exhaustive levels, 8 after
+)
+```
+
+The exact playout spend is observable as `stats["rollouts"]` (0 when a custom evaluator is used).
 
 See `examples/beam_search_demo.py` (DEMO 3) for a worked comparison of a scheduled vs. flat-width run.
 

--- a/docs/BEAM_SEARCH.md
+++ b/docs/BEAM_SEARCH.md
@@ -83,6 +83,7 @@ class BeamLeaf:
     value: float              # P0 perspective; +/-1.0 for terminal leaves
     depth: int
     is_terminal: bool
+    multiplicity: int = 1      # raw move sequences this leaf represents
 
 @dataclass
 class BeamSearchResult:
@@ -126,14 +127,36 @@ Each `RankedRootMove` has:
 |-------|-------------|
 | `move` | The first move from the root |
 | `best_value` | Max leaf value reached via this move (root-player perspective, `[-1, 1]`) |
-| `mean_value` | Mean leaf value via this move (root-player perspective) |
+| `mean_value` | **Multiplicity-weighted** mean leaf value via this move (root-player perspective) |
 | `win_probability` | Heuristic rescaling `(mean_value + 1) / 2`, in `[0, 1]` |
-| `leaf_count` | Number of collected leaves supporting this move |
+| `leaf_count` | Number of collected leaves supporting this move (unweighted) |
+| `total_multiplicity` | Sum of `multiplicity` over supporting leaves — see Symmetry Multiplicity below |
 | `has_terminal_win` | A proven root-player-winning terminal exists via this move |
 
 Entries are sorted by `best_value`, then `mean_value`, then `leaf_count` (all descending), with a deterministic tiebreak on the move itself.
 
 **Important caveat**: these are beam-sampled statistics over whichever leaves this particular run happened to discover and keep — not a minimax-proven guarantee. A move can have `best_value == 1.0` (a winning line exists via it) alongside a low `win_probability` if most of the *other* leaves discovered via that move were mediocre; `win_probability` is a heuristic rescaling of `mean_value`, not a calibrated probability.
+
+## Symmetry Multiplicity
+
+Canonical deduplication (algorithm step 3) collapses whole symmetry orbits — rotations, reflections, and shape/color permutations — down to one representative per depth. That's essential for the memory bound, but it also means a naive leaf count under-represents how much of the raw game tree a move actually covers: a corner-adjacent move might stand in for 16 raw move sequences while an edge move stands in for 32, yet both count as "1 leaf" without multiplicity tracking.
+
+`BeamLeaf.multiplicity` restores that mass via **path-count accumulation**, not orbit-size math: the root starts at multiplicity 1, and every raw legal move carries its parent's multiplicity forward — accumulating (summing) whenever multiple raw moves collapse onto the same canonical child at a given depth. Terminal leaves and tree nodes (`CompactGameTreeNode.multiplicity`, via `add_child_node`'s existing additive transposition-merge) both get their share of this weight.
+
+```python
+from quantik_core.beam_search import UNIQUE_CANONICAL_STATES_PER_DEPTH
+
+config = BeamSearchConfig(beam_schedule=[3], max_depth=1, evaluator=lambda s: 0.0)
+result = BeamSearchEngine(config).search(State.from_qfen("..../..../..../...."))
+
+multiplicities = sorted(leaf.multiplicity for leaf in result.frontier_leaves)
+assert multiplicities == [16, 16, 32]  # corner/center orbits (4 pos x 4 shapes)
+assert sum(multiplicities) == 64        #  and the edge orbit (8 pos x 4 shapes)
+```
+
+This accounting is **exact when the beam was exhaustive at that depth** (e.g. a `beam_schedule` prefix matching `UNIQUE_CANONICAL_STATES_PER_DEPTH`) — the multiplicities then sum to the depth's true total legal-move count. Otherwise it's a **lower bound**: mass belonging to any canonical candidate that got pruned before its multiplicity could be counted is simply lost, not redistributed.
+
+Multiplicity is statistics only — it never influences scoring or pruning, which remain strictly value-based.
 
 ## Memory Model
 

--- a/docs/BEAM_SEARCH.md
+++ b/docs/BEAM_SEARCH.md
@@ -48,12 +48,31 @@ print(f"Value (P0 perspective): {result.best_leaf.value}")
 | `random_seed` | int\|None | None | Seeds a **private** `random.Random` — the global RNG is never touched |
 | `evaluator` | `Callable[[State], float]`\|None | None | Custom evaluator; falls back to random-rollout scoring when omitted |
 | `initial_tree_capacity` | int | 4096 | Initial `CompactGameTree` node capacity |
+| `beam_schedule` | `Sequence[int]`\|None | None | Depth-dependent beam width (see Tuning below); `None` uses the flat `beam_width` everywhere |
 
-Invalid values (`beam_width < 1`, `max_depth` outside `1..16`, `rollouts_per_candidate < 1`) raise `ValueError` from `BeamSearchEngine.__init__`.
+Invalid values (`beam_width < 1`, `max_depth` outside `1..16`, `rollouts_per_candidate < 1`, an empty `beam_schedule`, or any `beam_schedule` entry `< 1`) raise `ValueError` from `BeamSearchEngine.__init__`.
 
 ### Evaluator Contract
 
 `evaluator(state) -> float` returns a value in `[-1, 1]` from **player 0's perspective**, matching `MCTSEngine`'s convention. Values outside that range are clamped. When omitted, the engine uses the mean of `rollouts_per_candidate` uniform random playouts, each rolled out to a true terminal — a Quantik playout never exceeds 16 plies, so no depth-cutoff heuristic is needed.
+
+### Tuning: Depth-Dependent Beam Width
+
+Quantik's canonical state space is tiny early and explodes later — `UNIQUE_CANONICAL_STATES_PER_DEPTH` (from `GAME_TREE_ANALYSIS.md`) gives 3 / 51 / 726 / 10,946 unique canonical states at depths 1-4. A flat `beam_width` has to pick one number for every depth; `beam_schedule` lets it grow with the game tree instead:
+
+```python
+from quantik_core.beam_search import BeamSearchConfig, UNIQUE_CANONICAL_STATES_PER_DEPTH
+
+# Exhaustive through depth 3 (every legal line kept), then guided sampling.
+schedule = [UNIQUE_CANONICAL_STATES_PER_DEPTH[d] for d in (1, 2, 3)] + [64]
+config = BeamSearchConfig(beam_schedule=schedule, max_depth=16)
+```
+
+Width at depth `d` resolves to `beam_schedule[min(d - 1, len(beam_schedule) - 1)]`, so the schedule's last entry extends to every deeper level. A single-entry schedule (e.g. `beam_schedule=[8]`) is exactly equivalent to `beam_width=8`.
+
+**Cost model**: evaluations at level `d + 1` are proportional to `width(d) x branching_factor x rollouts_per_candidate` (or a single evaluator call each, if using a custom evaluator). An exhaustive prefix is cheap while the canonical count is small (3, then 51) but grows fast — by depth 4 (10,946 unique states) exhaustive search is usually no longer worth it; that's the point at which a schedule typically switches to a fixed guided width.
+
+See `examples/beam_search_demo.py` (DEMO 3) for a worked comparison of a scheduled vs. flat-width run.
 
 ## Result
 
@@ -151,6 +170,6 @@ See `examples/beam_search_demo.py` for complete working examples:
 
 - Full-depth search from the empty board reaching a true terminal
 - Tactical (immediate win) position analysis, replaying the full winning line
-- Beam width sweep demonstrating the memory bound
+- Beam width sweep demonstrating the memory bound, plus a scheduled vs. flat-width comparison
 - Pluggable custom evaluator
 - Ranked root move statistics from a midgame position

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -43,3 +43,16 @@ best_move, win_probability = engine.search(state)
 assert best_move is not None
 assert 0.0 <= win_probability <= 1.0
 ```
+
+## Beam Search
+
+```python
+from quantik_core import State
+from quantik_core.beam_search import BeamSearchConfig, BeamSearchEngine
+
+state = State.from_qfen("ABc./..../..../...a")
+engine = BeamSearchEngine(BeamSearchConfig(beam_width=4, max_depth=2, random_seed=1))
+result = engine.search(state)
+assert result.best_leaf is not None
+assert result.best_leaf.is_terminal
+```

--- a/docs/research/2026-07-07-beam-search-vs-mcts.md
+++ b/docs/research/2026-07-07-beam-search-vs-mcts.md
@@ -1,0 +1,463 @@
+# Bounded-Memory Beam Search over Canonical Game Trees: Design and an Empirical Comparison with UCT on Quantik
+
+*Working paper — quantik-core, July 2026. Prepared as ground material for a
+forthcoming article; numbers are reproducible from the scripts in the
+appendix.*
+
+## Abstract
+
+We describe the design, implementation, and empirical evaluation of a
+parametrizable beam search engine for Quantik, a 4×4 adversarial placement
+game whose raw game tree contains ≈2.24 × 10¹² legal move sequences. The
+engine combines three ideas: (i) a symmetry-reduced *canonical* state
+representation that collapses rotations, reflections, and piece
+substitutions (reduction factors of 21× to 1.2 × 10⁵× per ply); (ii) a
+level-synchronous beam frontier with a per-depth width schedule, which makes
+*exhaustive* enumeration of the shallow game affordable while sampling the
+deep game under a fixed budget; and (iii) *path-multiplicity accounting*,
+which restores the raw-line mass hidden by canonicalization so that branch
+statistics weight each canonical line by the number of concrete games it
+represents. We compare against the existing UCT (Monte Carlo Tree Search)
+engine sharing the same 64-byte compact node storage. On commodity hardware
+the beam engine resolves the full game (terminal frontier at every line) from
+the empty board in ~1–15 s using under 0.4 MB of tree memory, while UCT at
+matched wall-clock budgets concentrates its tree asymmetrically and does not
+guarantee a terminal frontier. We derive a practical cost model
+(evaluations at level *d+1* ∝ width(*d*) × branching × rollouts), give
+tuning recipes, and validate the multiplicity accounting against exact
+combinatorial ground truth from an independent full-tree enumeration.
+
+## 1. Introduction
+
+Quantik is a two-player, perfect-information, zero-sum placement game: each
+player owns two pieces of each of four shapes and places them on a 4×4
+board; a player wins by completing a row, column, or 2×2 zone containing
+all four *shapes* (regardless of owner); it is illegal to place a shape in a
+row/column/zone where the *opponent* already placed that shape. A player
+with no legal move loses. Games therefore last at most 16 plies.
+
+Despite the small board, the raw tree is large: an exact depth-wise
+enumeration (see `GAME_TREE_ANALYSIS.md` in this repository) counts
+2,235,929,747,584 legal move sequences, of which only 23,577,899 distinct
+*canonical* states remain after symmetry reduction through depth 8.
+
+The repository's existing search engine is a UCT-style Monte Carlo Tree
+Search (`quantik_core.mcts.MCTSEngine`). UCT is a strong anytime algorithm,
+but for two of our goals it is an awkward fit:
+
+1. **Reaching the end of the game.** UCT grows its tree one node per
+   iteration along the UCB-selected path. Coverage of terminal positions in
+   the *persistent tree* is incidental — playouts do reach terminals, but
+   their outcomes are aggregated into noisy value estimates rather than
+   materialized as explicit end-of-game lines with reconstructible move
+   sequences.
+2. **Predictable, bounded resource use.** The shape of a UCT tree depends on
+   the stochastic playouts; neither its depth profile nor its node count at
+   a given depth is controlled directly.
+
+Beam search inverts these trade-offs: it advances a whole frontier one ply
+at a time, prunes to a configured width with an evaluation function, and
+therefore reaches depth *D* (here, the true terminal frontier at *D* ≤ 16)
+with *O*(width × *D*) memory and a fully deterministic budget, at the price
+of irrevocable pruning (no backtracking past a level) and dependence on the
+evaluator's quality.
+
+This paper documents the implementation in `quantik_core.beam_search`,
+its parametrization, the symmetry-multiplicity statistics, and a controlled
+comparison with the UCT engine.
+
+## 2. Background
+
+### 2.1 State space and symmetry
+
+The canonical representation collapses three group actions:
+
+1. **Board symmetries** — the dihedral group of the square (rotations and
+   reflections, |D₄| = 8);
+2. **Shape substitution** — any permutation of the four shapes (|S₄| = 24),
+   since the rules are shape-agnostic;
+3. **(Implementation-defined) canonical ordering** — `State.canonical_key()`
+   selects a unique representative of each orbit.
+
+Depth-wise effect (excerpt from the exact enumeration):
+
+| Depth | Raw move sequences | Unique canonical | Reduction |
+|------:|-------------------:|-----------------:|----------:|
+| 1 | 64 | 3 | 21.3× |
+| 2 | 3,392 | 51 | 66.5× |
+| 3 | 167,552 | 726 | 230.8× |
+| 4 | 6,776,960 | 10,946 | 619.1× |
+| 5 | 231,883,776 | 105,632 | 2,195× |
+| 6 | 6,241,600,512 | 901,916 | 6,920× |
+| 7 | 1.32 × 10¹¹ | 4,658,465 | 28,422× |
+| 8 | 2.10 × 10¹² | 17,900,160 | 117,153× |
+
+Two consequences drive the design. First, the shallow game is *tiny* in
+canonical space — exhaustive search through ply 3 needs only 726 frontier
+states. Second, canonical classes have *unequal orbit sizes* (already at
+ply 1: the three classes — corner, edge, and center placements — represent
+16, 32, and 16 raw moves respectively), so statistics computed over
+canonical representatives are biased unless re-weighted (§3.4).
+
+### 2.2 Compact storage
+
+Both engines share `CompactGameTree`: nodes are packed into 64-byte rows of
+a contiguous NumPy array (18-byte packed state, tree topology, win/visit
+counters, a 32-bit `multiplicity` field, flags, and values), with a
+transposition dictionary keyed on the literal 18-byte packed state at a
+given depth. Note the storage's transposition key is *not* symmetry-reduced;
+symmetry reduction happens in the search layers that feed it. States
+themselves serialize to 18 bytes (`State.pack()`), so a million-node tree
+occupies ~64 MB of node storage before dictionary overhead.
+
+## 3. Method
+
+### 3.1 Algorithm
+
+Search proceeds level-synchronously from a validated non-terminal root
+(frontier = {root}, multiplicity 1). For each depth *d* = 1…`max_depth`:
+
+```
+for each frontier entry (state, moves, multiplicity):
+    if the mover has no legal move:            # blocked-player-loses rule
+        record terminal leaf (value ±1)         # opponent of mover wins
+        continue
+    for each legal move m:
+        child = apply(state, m)
+        if child is terminal (four shapes in a line/zone):
+            record terminal leaf; insert into tree with terminal flags
+        else:
+            k = canonical_key(child)
+            if k unseen this level: candidates[k] = (child, moves+m, mult)
+            else:                   candidates[k].multiplicity += mult
+score each candidate with the evaluator (value in [-1,1], P0 perspective)
+rank from the perspective of the player who just moved
+keep the top width(d) candidates; insert ONLY survivors into the tree
+survivors become the next frontier
+```
+
+Termination: frontier empty (every line resolved to a terminal) or
+`max_depth` reached; remaining frontier entries are reported as
+non-terminal leaves. Every leaf carries its full move sequence from the
+root, so principal variations are replayable without storing edge moves in
+the 64-byte nodes.
+
+Three details matter for correctness:
+
+- **Terminals bypass the beam.** Every terminal child of the frontier is
+  recorded regardless of width — the beam bounds only the *live* frontier.
+- **Mover-relative pruning.** Candidates at one level all share the same
+  mover (Quantik has strict alternation); ranking negates the P0-perspective
+  value when the mover is P1. This keeps the frontier adversarially
+  sensible: each level keeps the replies its own mover prefers. Final
+  results are then re-oriented to the *root* player's perspective. Both sign
+  conventions are pinned by mutation-verified regression tests (§5.3).
+- **Evaluate-then-insert.** Candidates are scored *before* tree insertion;
+  pruned candidates never allocate a node. This is what makes the memory
+  bound structural rather than aspirational.
+
+### 3.2 Parametrization and the width schedule
+
+`BeamSearchConfig` exposes: `beam_width` (flat width), `beam_schedule`
+(per-depth widths, last entry extending to deeper levels), `max_depth`
+(≤ 16), `rollouts_per_candidate`, `random_seed` (private RNG; the engine
+never touches global random state), and a pluggable
+`evaluator: State → [-1, 1]` (default: mean of seeded uniform random
+playouts, which in Quantik always reach a true terminal within 16 plies —
+no truncation heuristic is needed).
+
+The cost model is dominated by evaluation:
+
+> evaluations at level *d+1* ≈ min( width(*d*) × branching(*d*),
+> unique(*d+1*) )   with branching ≈ 40–60 in the early midgame,
+
+and each default evaluation costs `rollouts_per_candidate` playouts. A flat
+width therefore *cannot* express the natural strategy for Quantik —
+"enumerate the small shallow game exhaustively, then sample" — because the
+width needed for exhaustiveness at ply 3 (726) would multiply the cost of
+every deeper level by an order of magnitude. The schedule expresses it
+directly, e.g. with the exported `UNIQUE_CANONICAL_STATES_PER_DEPTH`
+constant:
+
+```python
+schedule = [3, 51, 726] + [64]   # exhaustive through ply 3, width-64 tail
+```
+
+By construction, levels whose width meets or exceeds the canonical count
+prune nothing; the search below an exhaustive prefix is a *complete* summary
+of the game to that depth.
+
+### 3.3 Result statistics: from optimistic leaves to ranked options
+
+`search()` returns every terminal leaf discovered plus the surviving
+frontier, each with value, depth, and move sequence. Two derived views:
+
+- **`best_leaf`** — the single leaf with the best root-perspective value.
+  This is deliberately *optimistic*: it answers "what is the best confirmed
+  end-of-game line found?", assuming the opponent follows that line. In
+  our experiments it is almost always a fastest-possible win (ply 5 from
+  the empty board), because the beam records every terminal it passes.
+- **`ranked_root_moves(top_k)`** — aggregates all leaves by their first
+  move, reporting per option the best and mean leaf value (root
+  perspective), a win-probability rescaling of the mean, support counts,
+  and whether a confirmed terminal win exists via that move. These are
+  beam-sampled statistics, not minimax-proven values, and are documented as
+  such.
+
+### 3.4 Symmetry multiplicity: putting the orbits back
+
+Canonical deduplication is essential for coverage but distorts statistics:
+a canonical line "one corner A, then …" stands for 16 raw openings while
+"one edge A, then …" stands for 32. Counting leaves equally over-weights
+small orbits.
+
+We restore the mass by *path-count accumulation*: the root carries weight 1;
+every raw legal move contributes its parent's weight to its canonical child;
+merges during per-level dedup *add* weights instead of discarding the
+duplicate. A leaf's `multiplicity` is then exactly the number of raw move
+sequences it represents, and `ranked_root_moves` weights its means by it.
+The tree's per-node `multiplicity` field receives the same quantities.
+
+Multiplicity is exact wherever the schedule is exhaustive and a lower bound
+below pruned levels (pruned branches' mass is invisible — an inherent
+property of any beam). Pruning itself remains value-based and unweighted;
+multiplicity is a *statistics* channel, not a search heuristic.
+
+This accounting admits unusually strong tests, because an independent exact
+enumeration of the game exists: with an exhaustive schedule and a constant
+evaluator, the summed frontier multiplicities must reproduce the raw
+sequence counts of §2.1 *exactly* — [16, 16, 32] at ply 1 (Σ = 64), 3,392 at
+ply 2, 167,552 at ply 3, and exactly 6,912 P1-winning sequences among ply-4
+terminals. The unit-test suite asserts these equalities.
+
+## 4. Relationship to prior work
+
+The ingredients are classical: beam search as breadth-limited best-first
+search; UCT as the reference MCTS variant (Kocsis & Szepesvári, 2006);
+symmetry reduction via canonical forms is standard in combinatorial game
+analysis; progressive widening and beam-MCTS hybrids address related
+budget-shaping concerns inside MCTS itself. The contribution here is an
+engineering synthesis and measurement on a concrete, exactly-enumerable
+domain: a beam whose width schedule aligns with known canonical-space sizes,
+whose statistics are made orbit-correct by path multiplicity, and which
+shares its node store with a UCT engine for direct comparison — plus
+mutation-verified tests anchored to exact combinatorial ground truth.
+
+## 5. Experimental evaluation
+
+### 5.1 Setup
+
+- Hardware/software: Apple Silicon (macOS, arm64), CPython 3.14, pure-Python
+  engines (NumPy used for node storage, not for search logic).
+- Root: empty board; `max_depth = 16`; seeds {0, 1, 2} per configuration.
+- Beam grid: width ∈ {4, 16, 64} × rollouts ∈ {2, 8}, flat widths (the
+  schedule feature is evaluated separately in §5.4).
+- UCT: iterations ∈ {2,000, 10,000, 25,000}, default exploration weight
+  √2, same seeds; wall-clock budgets bracket the beam runs.
+- Metrics: wall time, evaluator calls, candidates generated/deduped/pruned,
+  tree nodes inserted, allocated tree memory, terminal leaves discovered,
+  frontier resolution (did every line reach a terminal?), and best-root-move
+  agreement across seeds.
+
+### 5.2 Beam search results (flat widths)
+
+Median over 3 seeds; "term. leaves" is the count of distinct terminal lines
+materialized with full PVs.
+
+| width | rollouts | time (s) | evaluations | term. leaves | nodes | memory (MB) | resolved |
+|------:|---------:|---------:|------------:|-------------:|------:|------------:|:--------:|
+| 4 | 2 | 1.2 | ~670 | 28–62 | ~90 | 0.25 | 3/3 |
+| 4 | 8 | 4.3 | ~665 | 14–45 | ~70 | 0.25 | 3/3 |
+| 16 | 2 | 5.6 | ~2,540 | 186–231 | ~390 | 0.26 | 3/3 |
+| 16 | 8 | 17.2 | ~2,740 | 117–179 | ~335 | 0.26 | 3/3 |
+| 64 | 2 | 15.3 | ~9,920 | 667–774 | ~1,450 | 0.30 | 3/3 |
+| 64 | 8 | 57.5 | ~9,860 | 403–566 | ~1,250 | 0.30 | 2/3 |
+
+Observations:
+
+1. **Full-game reachability is routine.** Even width 4 resolves every line
+   to a true terminal from the empty board in ~1 s. (The single unresolved
+   width-64/rollouts-8 run had a live frontier remaining exactly at ply 16.)
+2. **Memory is not the constraint.** All configurations stay near the
+   initial 0.25 MB allocation; node counts (~10²–10³) are dwarfed by the
+   capacity. Time — almost entirely evaluator playouts — is the budget.
+   Wall time scales ≈ linearly in width × rollouts, at ~0.9–1.1 ms per
+   2-rollout evaluation.
+3. **Terminal yield scales ~linearly with width** (≈ 60 → 200 → 720 lines
+   at rollouts = 2).
+4. **`best_leaf` saturates.** Every run finds a value-+1.0 terminal at ply
+   5 — the earliest ply at which first-player wins exist (§2.1). Selecting
+   *among* root moves by `best_leaf` is therefore noise-driven; ranked,
+   multiplicity-weighted means are the appropriate signal (§3.3–3.4).
+5. **More rollouts did not stabilize the root choice at these scales**
+   (seed agreement did not improve from rollouts 2 → 8) — consistent with
+   the root of Quantik being far from decided, and with variance reduction
+   (σ ≈ 1/√n per candidate) being spent where value gaps are smaller than
+   the remaining noise. Given time ∝ width × rollouts, width (coverage)
+   is the better marginal purchase for scenario exploration; rollouts
+   matter when *ranking* survivors of a narrowed decision.
+
+### 5.3 Verification methodology
+
+Beyond conventional unit tests (35 at the time of the flat-width benchmark;
+grown since with the schedule and multiplicity suites), correctness-critical
+properties are *mutation-verified*: the reviewer or implementer flips the
+specific sign or drops the specific term (mover-relative pruning sign;
+root-perspective negation in ranked statistics; weighted vs. unweighted
+means; schedule depth indexing) and confirms that exactly the pinning test
+fails, then restores. The multiplicity suite is additionally anchored to
+exact enumeration ground truth (§3.4). The full gate (446+ tests, ≥90%
+coverage, mypy, flake8, packaging) runs per commit.
+
+### 5.4 UCT comparison
+
+Same root, same node storage, default UCT parameters, seeds {0, 1, 2}.
+
+Ranges over 3 seeds; "used" memory is node_count × 64 B (the engine
+pre-allocates a 100,000-node capacity, ≈6.4 MB, reported separately).
+
+| iterations | time (s) | nodes | max tree depth | terminal nodes in tree | memory used / alloc (MB) | best-move agreement |
+|-----------:|---------:|------:|---------------:|-----------------------:|------------:|:-------------------:|
+| 2,000 | 9.4–10.3 | ~1,770 | 5–6 | 0 | 0.11 / 6.3 | 3/3 |
+| 10,000 | 58–61 | ~8,590 | 6 | 0 | 0.55 / 6.6 | 3/3 |
+| 25,000 | 152–164 | ~21,370 | 7 | 0–4 | 1.37 / 7.1 | 3/3 |
+
+Observed throughput was ~150–210 iterations/s from the empty board (each
+iteration includes a full random playout). Three findings:
+
+1. **Terminal coverage is negligible.** UCT's persistent tree reaches at
+   most ply 7 after 25,000 iterations (~2.5 min) and materializes 0–4
+   terminal nodes; the width-4 beam materializes dozens of complete
+   terminal lines in ~1 s, the width-64 beam ~700 in ~15 s. For scenario
+   enumeration and endgame reachability, the beam is the right tool by
+   orders of magnitude.
+2. **Root-move choice is UCT's strength.** All nine UCT runs agree on the
+   same opening move with a tight value estimate (win probability
+   0.46–0.50), across a 12× budget range — *more* stable than the beam's
+   seed-sensitive root preference (§5.2, obs. 5). UCB's adaptive
+   reallocation is doing exactly what it is designed for.
+3. **Value calibration differs.** UCT's root estimate hovers near 0.49 —
+   a visit-weighted average acknowledging the root is far from decided —
+   while the beam's `best_leaf` saturates at +1.0 (best-case line). The
+   beam's multiplicity-weighted mean statistics (§3.4) are the comparable
+   quantity, not `best_leaf`.
+
+Structural comparison:
+
+| Property | Beam (this work) | UCT (`MCTSEngine`) |
+|---|---|---|
+| Depth profile | uniform frontier per ply, guaranteed to `max_depth`/terminals | asymmetric; deep only where UCB concentrates |
+| Terminal lines | materialized with replayable PVs, all encountered terminals kept | implicit in playout statistics; tree terminals incidental |
+| Memory | *O*(width × depth) structural bound, evaluate-then-insert | one node per iteration along selected path |
+| Budget shape | deterministic per level (width × branching × rollouts) | anytime; stop whenever |
+| Value estimates | evaluator applied once per surviving candidate | visit-averaged, improves with iterations at visited nodes |
+| Symmetry usage | canonical dedup per level + exact multiplicity weights | canonical dedup among siblings at expansion |
+| Failure mode | evaluator misranks → good line pruned irrevocably | insufficient iterations → shallow, high-variance tree |
+| Best use | coverage: scenario enumeration, endgame reachability, book building | move choice at a single position under a time budget |
+
+The engines compose rather than compete: they share `CompactGameTree`, so a
+beam pass can seed the transposition structure (terminal flags, values,
+multiplicities) that a subsequent UCT run exploits — with the caveat, noted
+in the code, that the current tree hard-codes a player-0-to-move root.
+
+### 5.5 Coverage: what does a width "buy"?
+
+Fraction of unique canonical states a width-*W* level can retain:
+
+| W \ depth | 1 | 2 | 3 | 4 | 5 |
+|---:|---:|---:|---:|---:|---:|
+| 4 | 1.00 | 0.08 | 0.006 | 0.0004 | — |
+| 16 | 1.00 | 0.31 | 0.022 | 0.0015 | — |
+| 64 | 1.00 | **1.00** | 0.088 | 0.006 | 0.0006 |
+| 256 | 1.00 | 1.00 | 0.35 | 0.023 | 0.002 |
+| 1,024 | 1.00 | 1.00 | **1.00** | 0.094 | 0.010 |
+
+Practical schedule recipes (measured ~1 ms per 2-rollout evaluation):
+
+- `[3, 51, 726] + [64]` — exhaustive through ply 3, sampled tail:
+  the expensive step is evaluating ≈10⁴ ply-4 candidates; ~20–30 s total.
+- `[3, 51, 726, 10946] + [64]` — exhaustive through ply 4: ~10⁵
+  evaluations at ply 5; minutes. Suitable for offline analysis and book
+  generation. Node storage at ply 4 is 10,946 × 64 B ≈ 0.7 MB — memory
+  remains a non-issue.
+- Exhaustive ply 5 (105,632 states) is the practical ceiling for the
+  pure-Python rollout evaluator (~hour); beyond it, replace the evaluator
+  (cheap heuristic, or rollouts = 1 on wide levels and more only on the
+  final level) rather than shrinking the prefix.
+
+## 6. Limitations and threats to validity
+
+- **Evaluator quality bounds line quality.** With few random rollouts the
+  frontier wanders; reported values are noisy estimates, and `best_leaf` is
+  best-case, not minimax. No claim of playing strength is made — no
+  engine-vs-engine matches were run (future work).
+- **Pruning loses mass.** Below the exhaustive prefix, multiplicities are
+  lower bounds and rankings are conditional on beam visibility.
+- **Single machine, wall-clock timing, pure Python.** Absolute times are
+  indicative; the *ratios* (time ∝ width × rollouts; memory flat) are the
+  robust findings.
+- **Root-position bias.** The empty board maximizes symmetry collapse;
+  midgame roots have smaller orbits and larger effective branching per
+  canonical state.
+- **Draw handling.** Quantik as modeled has no draws (a blocked player
+  loses); the value scale conflates "unknown" (0 from mixed rollouts) with
+  genuinely balanced.
+
+## 7. Applications: toward opening books
+
+The repository ships an SQLite-backed `OpeningBookDatabase` keyed by
+canonical states, with per-position win statistics and parent/child edges.
+Beam search with an exhaustive prefix is a natural book *generator*:
+
+1. Run with schedule `[3, 51, 726, 10946]` (exhaustive plies 1–4, exact
+   multiplicities) and a meaningful rollout budget on the tail.
+2. Export each frontier/terminal node: canonical key, depth, value
+   statistics, multiplicity, and the PV edges → `add_position`/`add_edges`.
+3. Defence lines fall out of the same data: because pruning is
+   mover-relative, the surviving replies at odd/even levels are precisely
+   the strongest options *for the side to move*; `ranked_root_moves` at any
+   book position yields graded recommendations with support counts.
+
+Persistence of the beam tree itself is deliberately out of scope: the
+`CompactGameTree` is an in-memory working set (contiguous NumPy rows —
+trivially dumpable, but without stable semantics across runs), while the
+opening book is the durable, queryable artifact. The 18-byte packed state
+and the multiplicity field are the bridge between the two.
+
+## 8. Future work
+
+Engine-vs-engine strength evaluation (beam-seeded UCT vs. plain UCT);
+learned or handcrafted evaluators to push exhaustive-equivalent quality
+past ply 5; beam-tree → opening-book exporter (§7); multiplicity-aware
+*pruning* (e.g., width in raw-mass rather than canonical count);
+draw/uncertainty separation in the value scale; removing the
+player-0-root restriction from the shared tree.
+
+## References
+
+- L. Kocsis, C. Szepesvári. *Bandit based Monte-Carlo Planning.* ECML 2006
+  (UCT).
+- C. Browne et al. *A Survey of Monte Carlo Tree Search Methods.* IEEE
+  TCIAIG 4(1), 2012.
+- R. Coulom. *Efficient Selectivity and Backup Operators in Monte-Carlo Tree
+  Search.* CG 2006.
+- P. S. Ow, T. E. Morton. *Filtered beam search in scheduling.* IJPR 26(1),
+  1988 (beam search formalization).
+- This repository: `GAME_TREE_ANALYSIS.md` (exact enumeration),
+  `SYMMETRY_REDUCTION_DEMONSTRATION.md`, `docs/MCTS.md`,
+  `docs/BEAM_SEARCH.md`, design spec
+  `docs/superpowers/specs/2026-07-07-beam-search-design.md`.
+
+## Appendix: reproducibility
+
+- Engines: `quantik_core.beam_search.BeamSearchEngine`,
+  `quantik_core.mcts.MCTSEngine` (this branch: `feat/mcts-beam-search`).
+- Beam sweep: widths {4, 16, 64} × rollouts {2, 8} × seeds {0, 1, 2},
+  `max_depth=16`, root `..../..../..../....`; metrics from
+  `BeamSearchResult.stats` and `get_statistics()`.
+- UCT sweep: iterations {2,000, 10,000, 25,000} × seeds {0, 1, 2}; tree
+  depth/terminal profiles scanned from `CompactGameTreeStorage.node_data`
+  (depth at bytes 22–24, flags at byte 25).
+- Exact anchors: unit tests in `tests/test_beam_search.py` (multiplicity
+  sums vs. enumeration; mutation-verified sign/weighting properties).
+- Demo: `examples/beam_search_demo.py`.

--- a/docs/research/2026-07-08-budget-shaping-schedules-vs-mcts-truncation.md
+++ b/docs/research/2026-07-08-budget-shaping-schedules-vs-mcts-truncation.md
@@ -135,14 +135,51 @@ than a choice:
    generate opening-book entries (canonical key, weighted values,
    multiplicities, PV edges). Online: UCT plays from book exits.
 
-## 6. Status and pending validation
+## 6. Empirical validation
 
-`beam_schedule` is implemented and tested (flat-equivalence, last-entry
-extension, exhaustive-prefix zero-pruning, off-by-one mutation tests);
-`rollout_schedule` is specified as above and being implemented with the
-same test discipline, including the exact 258-playout anchor. A scheduled
-vs. flat benchmark (recipe of §2 against flat width/rollouts at equal
-wall-clock) will be appended to this series once both knobs are merged.
+Both knobs are implemented and mutation-tested (flat-equivalence,
+last-entry extension, exhaustive-prefix zero-pruning, off-by-one anchors
+including the exact 258-playout count). Benchmark from the empty board,
+`max_depth = 16`, seeds {0, 1}, all runs fully resolved to terminal
+frontiers:
+
+| config | time (s) | evaluations | playouts | ply-4 terminal mass (exact: 6,912) | openings with substantial mass |
+|---|---:|---:|---:|---:|:--:|
+| flat width 64, rollouts 2 | ~16 | ~10.1k | ~20.3k | 768 (11%) | 1 of 3 |
+| sched `[3,51,726,64]`, rollouts `[1,1,1,2]` | ~38 | ~19.0k | ~37.1k | **6,912 (100%)** | 1 of 3 |
+| sched `[3,51,726,64]`, rollouts `[1,1,1,8]` | ~122 | ~18.9k | ~145.8k | **6,912 (100%)** | **3 of 3** |
+
+Findings:
+
+1. **Exactness confirmed.** Every exhaustive-prefix run reproduces the
+   enumeration's ply-4 terminal mass to the digit (6,912 first-player-loss
+   sequences), while the flat beam sees 11% of it. The multiplicity
+   accounting behaves as specified: exact where exhaustive, a lower bound
+   where pruned.
+2. **The schedule buys guaranteed shallow coverage for ~2×.** Exhaustive
+   plies 1–3 plus a width-64 tail costs ~38 s versus ~16 s flat at equal
+   tail precision — and converts "whatever the beam happened to keep" into
+   a complete summary of the early game.
+3. **Tail precision buys scenario diversity, not just ranking accuracy.**
+   With cheap tails (2 rollouts — flat or scheduled), the surviving deep
+   lines collapse onto a single canonical opening: one root move carries
+   >99% of the collected terminal mass. With `[1,1,1,8]`, all three
+   canonical openings retain substantial multiplicity-weighted mass
+   (e.g. seed 1: ~101k / ~181k / ~174k raw sequences). Noisy evaluation
+   doesn't merely misrank survivors — it silently *narrows* what the beam
+   explores, because early lucky rollouts snowball level after level.
+4. **Root values remain honestly undecided.** Multiplicity-weighted win
+   probabilities for the three openings span 0.36–0.54 across seeds under
+   the random-play model — consistent with UCT's ~0.49 root estimate and
+   with the opening not being trivially winning; seed-to-seed ordering of
+   the three openings still fluctuates at this budget, so publishing
+   opening *rankings* would need either more tail rollouts or a stronger
+   evaluator.
+
+The practical recipe stands, refined: spend width on the exhaustive
+prefix (cheap, exact), spend rollouts on the tail — and if the goal is
+*scenario diversity* rather than a single line, the tail rollouts are the
+knob that prevents beam collapse.
 
 ## References
 

--- a/docs/research/2026-07-08-budget-shaping-schedules-vs-mcts-truncation.md
+++ b/docs/research/2026-07-08-budget-shaping-schedules-vs-mcts-truncation.md
@@ -1,0 +1,153 @@
+# Budget Shaping in Quantik Search: Per-Depth Schedules versus Simulation Truncation
+
+*Working paper #2 — quantik-core, 2026-07-08. Follows
+[2026-07-07-beam-search-vs-mcts.md](2026-07-07-beam-search-vs-mcts.md);
+part of an incremental series preserving the design conversation. This note
+motivates and specifies the per-depth rollout schedule, contrasts it with
+the UCT engine's simulation-truncation parameter, and explains how the two
+engines' budget-shaping knobs compose.*
+
+## 1. The problem: one budget, two competing uses
+
+A search budget buys two different goods:
+
+- **Coverage** — how many distinct scenarios (canonical branches) are kept
+  alive per ply;
+- **Precision** — how accurately each kept scenario is valued.
+
+For the default rollout evaluator, total cost decomposes per level:
+
+> cost ≈ Σ_d  evaluations(*d*) × rollouts(*d*) × cost_per_playout,
+> with evaluations(*d*) ≈ min( width(*d−1*) × branching, unique(*d*) ).
+
+The companion paper established the coverage side: Quantik's canonical
+space is tiny through ply 3 (3 / 51 / 726 states) and explodes afterwards,
+so `beam_schedule` buys *exhaustive* shallow coverage cheaply — e.g.
+`[3, 51, 726] + [64]` at roughly 20–30 s with 2-rollout evaluations
+(~10⁴ ply-4 candidate evaluations dominating), and `[3, 51, 726, 10946] +
+[64]` in minutes (~10⁵ ply-5 evaluations). Exhaustive ply 5 (105,632
+states) marks the practical pure-Python ceiling, on the order of an hour.
+
+What a width schedule alone *cannot* express is the precision side of the
+trade. With a flat `rollouts_per_candidate`, every level pays the same
+per-candidate evaluation price — but the wide, exhaustive levels do not
+need precise values at all (nothing is pruned there: when width ≥ canonical
+count, the evaluator's ranking is irrelevant to survival), while the narrow
+tail, where pruning actually bites, benefits from every additional rollout
+(per-candidate noise σ ≈ 1/√n for ±1 playout outcomes).
+
+## 2. `rollout_schedule`: wide-and-cheap early, narrow-and-precise late
+
+We therefore add the precision twin of `beam_schedule`:
+
+```python
+BeamSearchConfig(
+    beam_schedule=[3, 51, 726, 64],   # exhaustive plies 1–3, width-64 tail
+    rollout_schedule=[1, 1, 1, 8],    # 1 playout on exhaustive levels,
+)                                     # 8 on the pruned tail (last extends)
+```
+
+Semantics mirror `beam_schedule`: entry *i* applies at depth *i + 1*; the
+last entry extends to all deeper levels; `None` falls back to the flat
+`rollouts_per_candidate`. The schedule affects only the built-in rollout
+evaluator — a custom `evaluator: State → [-1, 1]` owns its own cost model
+and ignores it. A `stats["rollouts"]` counter exposes the exact number of
+playouts performed, which both makes the budget observable and admits an
+exact regression test: with `beam_schedule=[3, 51]`, `max_depth=2`,
+`rollout_schedule=[1, 5]`, exactly 3×1 + 51×5 = 258 playouts must occur —
+any depth-indexing error produces a different integer.
+
+Cost illustration for the exhaustive-ply-3 recipe (measured ~0.5 ms per
+single playout): flat 8 rollouts ≈ (3 + 51 + 726 + ~10⁴ + tail) × 8
+playouts, dominated by ~8×10⁴ playouts at ply 4; scheduled `[1, 1, 1, 8]`
+pays ~10⁴ playouts at ply 4 — the same exhaustive coverage and the same
+tail precision for roughly an eighth of the dominant term. The general
+recipe: **spend width wherever unique(*d*) is affordable, spend rollouts
+only where pruning decisions are made.**
+
+## 3. The UCT engine's "drop-out": `MCTSConfig.max_depth`
+
+The existing UCT engine has the truncation parameter the reader may recall:
+`MCTSConfig.max_depth` (default 16). Its `_simulate` plays uniformly random
+moves from the selected node and stops early when the *absolute* ply count
+reaches `max_depth`, returning 0.0 — a neutral, draw-like value — for
+unresolved playouts.
+
+Three properties are worth spelling out:
+
+1. **At the default 16 it never triggers.** Quantik games end by ply 16
+   at the latest (blocked player loses; a full board blocks the mover), so
+   `max_depth=16` means playouts always reach a true terminal — same as the
+   beam engine's evaluator, which needs no cutoff at all.
+2. **Below 16 it is a simulation drop-out, and it biases.** Truncated
+   playouts inject 0.0 into the visit-averaged values, pulling estimates
+   toward "balanced" in exactly the deep regions where truncation fires
+   most. The bias is silent: nothing in the result distinguishes "genuinely
+   contested" from "unresolved because we stopped simulating."
+3. **The beam analogue is explicit, not silent.** The beam's `max_depth`
+   bounds *frontier advancement*, and unresolved lines are returned as
+   first-class `frontier_leaves` with their evaluated values and full move
+   sequences — the caller sees precisely which scenarios were left open.
+   (`reached_terminal` summarizes it.) This observability difference, not
+   the cutoff itself, is the substantive contrast.
+
+(One housekeeping note for completeness: `MCTSConfig.use_transposition_table`
+is declared but not consulted by the current engine implementation; the
+transposition behavior actually in effect is the storage-level merge in
+`CompactGameTree.add_child_node`.)
+
+## 4. How the knobs line up
+
+| Concern | Beam engine | UCT engine |
+|---|---|---|
+| Breadth per ply | `beam_schedule` / `beam_width` (hard, deterministic) | emergent from UCB visit allocation (soft) |
+| Evaluation precision | `rollout_schedule` / `rollouts_per_candidate` per *candidate* | one playout per iteration; precision accrues at *visited* nodes over iterations |
+| Horizon | `max_depth` bounds the frontier; leftovers reported explicitly | `max_depth` truncates playouts; leftovers folded into values as 0.0 |
+| Budget unit | playouts, exactly countable ex ante (`stats["rollouts"]`) | iterations, anytime-interruptible |
+| Where noise hurts | misranking at pruned levels (irrevocable) | under-visited subtrees (recoverable with more iterations) |
+
+The deeper duality: UCT *adapts* its breadth/precision split online via UCB
+— which is optimal when the budget must be spent at a single decision point
+— while the beam fixes the split *structurally* via schedules — which is
+what you want when the goal is reproducible, quantified coverage of the
+scenario space (exhaustive prefixes, exact multiplicity mass, materialized
+terminal lines).
+
+## 5. Fitting the two approaches together
+
+Empirically (companion paper, §5.4): at matched budgets from the empty
+board, UCT concentrates ~2×10³–2×10⁴ nodes within plies ≤ 6–7 and
+materializes essentially no terminals (first ones appear around 25k
+iterations, ~150 s), while the beam resolves the full game in seconds but
+with a noisier root preference. That suggests composition patterns rather
+than a choice:
+
+1. **Beam-seeded UCT (shared tree).** Run a scheduled beam pass first —
+   exhaustive prefix, multiplicity-weighted statistics, terminal flags —
+   into the shared `CompactGameTree`; then let UCT refine the root decision
+   over a structure that already knows where the terminals are. (Current
+   restriction: the shared tree assumes a player-0-to-move root.)
+2. **UCT as the beam's evaluator.** The `evaluator` hook accepts any
+   `State → [-1, 1]`; a small fixed-iteration UCT probe per candidate
+   trades the rollout schedule for adaptive per-candidate precision.
+   Costly, but expressible today without engine changes.
+3. **Beam for the book, UCT for the move.** Offline: scheduled beam passes
+   generate opening-book entries (canonical key, weighted values,
+   multiplicities, PV edges). Online: UCT plays from book exits.
+
+## 6. Status and pending validation
+
+`beam_schedule` is implemented and tested (flat-equivalence, last-entry
+extension, exhaustive-prefix zero-pruning, off-by-one mutation tests);
+`rollout_schedule` is specified as above and being implemented with the
+same test discipline, including the exact 258-playout anchor. A scheduled
+vs. flat benchmark (recipe of §2 against flat width/rollouts at equal
+wall-clock) will be appended to this series once both knobs are merged.
+
+## References
+
+- Companion: [2026-07-07-beam-search-vs-mcts.md](2026-07-07-beam-search-vs-mcts.md)
+  (design, flat-width benchmarks, UCT comparison, multiplicity accounting).
+- `docs/BEAM_SEARCH.md` (user-facing configuration reference),
+  `docs/MCTS.md`, `GAME_TREE_ANALYSIS.md` (exact enumeration).
+- L. Kocsis, C. Szepesvári. *Bandit based Monte-Carlo Planning.* ECML 2006.

--- a/docs/superpowers/plans/2026-07-07-beam-search-plan.md
+++ b/docs/superpowers/plans/2026-07-07-beam-search-plan.md
@@ -1,0 +1,40 @@
+# Implementation Plan — Beam Search for Quantik MCTS
+
+Spec: `docs/superpowers/specs/2026-07-07-beam-search-design.md` (read it first; it is the contract).
+
+Working directory: this worktree. Python: `.venv/bin/python` (already provisioned with `pip install -e ".[dev,cbor]"`).
+
+## Task 1 — Tests first (TDD)
+
+Create `tests/test_beam_search.py` covering the 10 scenarios in the spec's Testing
+section. Model structure and fixtures on `tests/test_mcts.py` (QFEN strings, seeded
+configs, small iteration/beam budgets so the suite stays fast — target < 20s for the
+file). Run them: they must fail with `ModuleNotFoundError` / assertion errors, not
+collection errors.
+
+## Task 2 — Implementation
+
+Create `src/quantik_core/beam_search.py` implementing `BeamSearchConfig`,
+`BeamLeaf`, `BeamSearchResult`, `BeamSearchEngine` exactly per spec. Reuse:
+
+- `quantik_core`: `State`, `Move`, `generate_legal_moves`, `apply_move`
+- `quantik_core.game_utils`: `check_game_winner`, `WinStatus`
+- `quantik_core.memory.compact_tree`: `CompactGameTree`, `NODE_FLAG_*`
+
+Match the style of `src/quantik_core/mcts.py` (docstrings, typing, numpy scalar
+handling when writing node fields). Private `random.Random(config.random_seed)`
+— do NOT seed the global RNG.
+
+## Task 3 — Quality gates
+
+1. `./auto-lint.sh`
+2. `./dev-check.sh` (runs full suite; 90% total coverage gate, mypy, flake8 must pass)
+3. Commit in two commits: tests, then implementation (or one commit if the runner
+   requires green; then squash message `feat: parametrizable beam search engine`).
+
+## Guardrails
+
+- Do not modify `mcts.py`, `compact_tree.py`, `__init__.py`, or any existing test.
+- No new dependencies.
+- All commands prefixed with `rtk` where applicable (see CLAUDE.md).
+- Commit messages end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.

--- a/docs/superpowers/specs/2026-07-07-beam-search-design.md
+++ b/docs/superpowers/specs/2026-07-07-beam-search-design.md
@@ -1,0 +1,187 @@
+# Parametrizable Beam Search for Quantik MCTS — Design
+
+**Date:** 2026-07-07
+**Status:** Approved (autonomous orchestration per user /goal directive)
+**Branch:** `feat/mcts-beam-search`
+
+## Problem
+
+The existing `MCTSEngine` (UCT) samples the game tree stochastically and its
+random playouts stop at `max_depth` without guaranteeing terminal resolution.
+Exhaustive expansion is infeasible: Quantik has ~2.2 × 10^12 legal move
+sequences (23.6M unique canonical states through depth 8 alone, see
+`GAME_TREE_ANALYSIS.md`). We need a search mode that:
+
+1. **Reaches end leaves** — descends to true terminal states (win / loss by
+   blocked player), up to the full game length of 16 plies.
+2. **Bounds memory** — keeps a memory-efficient representation of the game,
+   reusing the 18-byte `State.pack()` encoding and the 64-byte
+   `CompactGameTree` nodes already used by MCTS.
+3. **Is parametrizable** — beam width, depth, evaluation policy, rollout
+   budget, seed are all configuration.
+
+## Approaches considered
+
+- **A. Standalone beam engine sharing `CompactGameTree` (chosen).** A
+  level-by-level frontier search: expand all children of the current frontier,
+  score them, keep the top `beam_width`, insert only survivors into the
+  compact tree. Memory is O(beam_width × depth) tree nodes. Composes with
+  MCTS by accepting an existing `CompactGameTree` (e.g. `mcts_engine.tree`)
+  so beam results (terminal flags, values) enrich the same transposition
+  structure.
+- **B. Beam-limited MCTS (progressive pruning inside `MCTSEngine`).**
+  Rejected: changes the semantics of the existing, tested engine; UCT and
+  beam pruning interact badly at low iteration counts; harder to reason about.
+- **C. Post-hoc beam over MCTS statistics.** Rejected: needs MCTS to have
+  visited deep nodes already, so it cannot *guarantee* reaching terminal
+  leaves — the original goal.
+
+## Design
+
+New module `src/quantik_core/beam_search.py` (public via
+`quantik_core.beam_search`, same convention as `quantik_core.mcts` which is
+not re-exported at package top level).
+
+### Configuration
+
+```python
+@dataclass
+class BeamSearchConfig:
+    beam_width: int = 64            # frontier nodes kept per depth (>= 1)
+    max_depth: int = 16             # plies from root; 16 = full Quantik game
+    rollouts_per_candidate: int = 8 # rollout budget for the default evaluator (>= 1)
+    random_seed: Optional[int] = None
+    evaluator: Optional[Callable[[State], float]] = None
+    initial_tree_capacity: int = 4096
+```
+
+- `evaluator(state) -> float` returns a value in [-1, 1] **from player 0's
+  perspective** (same convention as `MCTSEngine._simulate` /
+  `terminal_value`). When `None`, the engine uses its built-in random-rollout
+  evaluator: mean of `rollouts_per_candidate` uniform playouts, each rolled
+  out to true terminal (a playout never needs more than 16 plies, so no
+  depth cutoff heuristic is required).
+- Config values are validated in `BeamSearchEngine.__init__`
+  (`beam_width >= 1`, `1 <= max_depth <= 16`, `rollouts_per_candidate >= 1`);
+  invalid values raise `ValueError`.
+- `random_seed` seeds a **private** `random.Random` instance (unlike
+  `MCTSConfig`, which seeds the global RNG — do not copy that behaviour;
+  a private RNG keeps the engine reproducible and side-effect free).
+
+### Engine and algorithm
+
+```python
+class BeamSearchEngine:
+    def __init__(self, config: BeamSearchConfig,
+                 tree: Optional[CompactGameTree] = None): ...
+    def search(self, initial_state: State) -> BeamSearchResult: ...
+    def get_statistics(self) -> dict: ...
+```
+
+Frontier entry: `(node_id, bitboard, moves)` where `moves` is the tuple of
+`Move`s from the root (≤ 16 small dataclasses — this is what makes principal
+variations reconstructible without storing moves in the 64-byte node, which
+has no edge-move field).
+
+Per depth level `d` (players strictly alternate in Quantik; every node at a
+given depth has the same side to move):
+
+1. **Expand:** for each frontier entry, generate legal moves
+   (`generate_legal_moves`), apply each, and classify the child with
+   `check_game_winner`. A frontier state with *no* legal moves is terminal —
+   the player to move loses (same rule as `MCTSEngine._expand`).
+2. **Terminal handling:** terminal children are recorded into the tree with
+   `NODE_FLAG_TERMINAL` + `NODE_FLAG_WINNING_P0/P1` and `terminal_value`
+   (±1.0), collected as result leaves, and **not** carried into the next
+   frontier.
+3. **Deduplicate:** non-terminal candidates are deduplicated per depth by
+   `State.canonical_key()` (symmetry-aware — reduction factors of 21×–10⁵×
+   per `GAME_TREE_ANALYSIS.md`; first path encountered wins).
+4. **Score:** each surviving candidate is evaluated with the evaluator and
+   ranked **from the perspective of the player who just moved** (score =
+   value for P0-mover, −value for P1-mover). This gives beam search an
+   adversarially sensible frontier at every level instead of optimizing one
+   fixed player throughout.
+5. **Prune:** keep the top `beam_width` candidates (stable ordering for ties,
+   so seeded runs are deterministic). **Only survivors are inserted** into
+   the `CompactGameTree` (via `add_child_node`, which also merges
+   transpositions); pruned candidates never allocate a node. Survivors'
+   `best_value`/`visit_count` are updated with their evaluation so the shared
+   tree is useful to MCTS afterwards.
+6. Stop when the frontier is empty (all lines resolved to terminal) or
+   `max_depth` is reached.
+
+### Result
+
+```python
+@dataclass
+class BeamLeaf:
+    moves: Tuple[Move, ...]   # principal variation from the root
+    value: float              # P0 perspective; ±1.0 for terminal leaves
+    depth: int
+    is_terminal: bool
+
+@dataclass
+class BeamSearchResult:
+    best_leaf: Optional[BeamLeaf]      # best for the ROOT player to move
+    terminal_leaves: List[BeamLeaf]    # all terminals discovered, best first
+    reached_terminal: bool
+    max_depth_reached: int
+    stats: Dict[str, int]              # candidates_generated, candidates_deduped,
+                                       # nodes_inserted, nodes_pruned,
+                                       # evaluations, memory_usage
+```
+
+`best_leaf` ranks all collected leaves (terminals plus, if the search hit
+`max_depth` with a live frontier, the final frontier entries) by value from
+the **root player's** perspective. `search` raises `ValueError` if the root
+state is already terminal.
+
+### Memory model
+
+- ≤ `beam_width` non-terminal nodes inserted per depth + terminal leaves
+  found among their children ⇒ tree nodes grow O(beam_width × depth), each
+  64 bytes, versus the unbounded growth of exhaustive expansion.
+- Frontier bookkeeping is O(beam_width) packed states + move tuples.
+- `get_statistics()` mirrors `MCTSEngine.get_statistics()` (delegates to
+  `tree.memory_usage()` / `tree.get_stats()`).
+
+### Error handling
+
+- Config validation as above (`ValueError`).
+- Root already terminal → `ValueError` with clear message.
+- Evaluator returning values outside [-1, 1] is clamped (defensive; documented).
+
+### Testing (tests/test_beam_search.py)
+
+Follow `tests/test_mcts.py` structure (class-per-concern, seeded configs).
+Project gate: full suite ≥ 90% coverage (`./dev-check.sh`), mypy + flake8 clean.
+
+1. Config defaults, custom values, validation errors.
+2. Immediate win found: near-win fixture (reuse QFEN patterns from
+   `test_mcts.py`) → `best_leaf` is the winning terminal at depth 1 with the
+   correct move.
+3. Full-game reachability: from the empty board with small beam
+   (e.g. width 4, seeded), `reached_terminal` is True and every terminal
+   leaf's PV replays legally (`apply_move` chain) to a state where
+   `check_game_winner` ≠ NO_WIN or the mover is blocked.
+4. Symmetry dedup: from the empty board, depth-1 candidates collapse from
+   64 moves to 3 canonical states (per `GAME_TREE_ANALYSIS.md`).
+5. Memory bound: nodes_inserted ≤ beam_width × depth + terminal leaf count;
+   compare stats for beam_width 2 vs 16.
+6. Determinism: same seed ⇒ identical result; different seed may differ.
+7. Pluggable evaluator: custom callable is used (call count > 0) and biases
+   the beam as expected; out-of-range values clamped.
+8. Adversarial perspective: a position where the side to move at depth 1 is
+   P1 and P1 has a winning reply — the beam must keep it (score is
+   mover-relative, not P0-fixed).
+9. Shared tree integration: pass `MCTSEngine(config).tree` (or a fresh
+   `CompactGameTree`), run beam search, verify terminal flags/values were
+   written into it and node count grew within the bound.
+10. Root terminal / no-legal-moves root → `ValueError`.
+
+### Out of scope (YAGNI)
+
+- No changes to `MCTSEngine` or `CompactGameTree`.
+- No top-level `__init__.py` re-export (matches `mcts` precedent).
+- No parallel evaluation, no persistence of beam results.

--- a/examples/beam_search_demo.py
+++ b/examples/beam_search_demo.py
@@ -251,19 +251,23 @@ def demo_ranked_root_moves():
         f"Top {len(ranked)} root moves (beam-sampled statistics, not proven minimax):"
     )
     print(
-        f"\n{'Move':<28} {'Best Value':<12} {'Win Prob':<10} {'Leaves':<8} {'Terminal Win'}"
+        f"\n{'Move':<28} {'Best Value':<12} {'Win Prob':<10} {'Leaves':<8} "
+        f"{'Mult.':<7} {'Terminal Win'}"
     )
-    print("-" * 75)
+    print("-" * 82)
     for entry in ranked:
         print(
             f"{format_move(entry.move):<28} {entry.best_value:>+10.2f}  "
             f"{entry.win_probability:>8.2%}  {entry.leaf_count:<8} "
-            f"{entry.has_terminal_win}"
+            f"{entry.total_multiplicity:<7} {entry.has_terminal_win}"
         )
 
     print("\nNote: best_value is the best leaf found via that move (optimistic,")
-    print("beam-sampled); win_probability is a heuristic rescaling of the mean")
-    print("leaf value, not a calibrated probability.")
+    print("beam-sampled); win_probability is a heuristic rescaling of the")
+    print("multiplicity-weighted mean leaf value, not a calibrated probability.")
+    print("total_multiplicity sums how many raw (pre-canonicalization) move")
+    print("sequences the collected leaves for that move represent — exact only")
+    print("if the beam was exhaustive at that depth, a lower bound otherwise.")
 
 
 def main():

--- a/examples/beam_search_demo.py
+++ b/examples/beam_search_demo.py
@@ -7,6 +7,7 @@ Demonstrates:
 2. Tactical position analysis (immediate win found at depth 1)
 3. Beam width sweep showing the O(beam_width x depth) memory bound
 4. Pluggable custom evaluator
+5. Ranked root move statistics via BeamSearchResult.ranked_root_moves()
 """
 
 import time
@@ -16,11 +17,17 @@ from quantik_core.beam_search import BeamSearchConfig, BeamSearchEngine
 
 
 def format_move(move: Move) -> str:
-    """Format move for display."""
-    shape_name = chr(ord("A") + move.shape)
+    """Format move for display, player-aware.
+
+    QFEN convention: uppercase shape letters are player 0, lowercase are
+    player 1 (see `State.to_qfen`), so the letter case here follows suit.
+    """
+    shape_letter = chr(ord("A") + move.shape)
+    if move.player == 1:
+        shape_letter = shape_letter.lower()
     row = move.position // 4
     col = move.position % 4
-    return f"{shape_name} at ({row}, {col}) [pos {move.position}]"
+    return f"P{move.player} {shape_letter} at ({row}, {col}) [pos {move.position}]"
 
 
 def print_board(state: State):
@@ -89,6 +96,7 @@ def demo_tactical_position():
     # P0: A at (0,0), B at (0,1); P1: c at (0,2), a at (3,3).
     # Row 0 has shapes A, B, C — P0 wins in one move by placing D at (0,3).
     state = State.from_qfen("ABc./..../..../...a")
+
     print(f"\nPosition: {state.to_qfen()}")
     print_board(state)
 
@@ -99,10 +107,18 @@ def demo_tactical_position():
     result = engine.search(state)
 
     assert result.best_leaf is not None
-    print(f"Best move found: {format_move(result.best_leaf.moves[0])}")
     print(f"Terminal: {result.best_leaf.is_terminal}")
     print(f"Value (P0 perspective): {result.best_leaf.value:+.1f}")
     print(f"Depth: {result.best_leaf.depth}")
+
+    print(f"\nFull principal variation to the win ({len(result.best_leaf.moves)} ply):")
+    replay_state = state
+    for ply, move in enumerate(result.best_leaf.moves, start=1):
+        new_bb = apply_move(replay_state.bb, move)
+        replay_state = State(new_bb)
+        print(f"  Ply {ply}: {format_move(move)}")
+
+    print_board(replay_state)
 
 
 def demo_beam_width_sweep():
@@ -174,6 +190,44 @@ def demo_custom_evaluator():
         print(f"  Ply {ply}: {format_move(move)}")
 
 
+def demo_ranked_root_moves():
+    """Demonstrate ranking multiple root move options from a midgame position."""
+    print(f"\n{'=' * 80}")
+    print("DEMO 5: Ranked Root Moves (Midgame Position)")
+    print(f"{'=' * 80}")
+
+    # P0: A at (0,0), B at (1,1); P1: c at (2,2), d at (3,3) — one piece per
+    # player per row/column/zone, no immediate threats either way.
+    state = State.from_qfen("A.../.B../..c./...d")
+    print(f"\nPosition: {state.to_qfen()}")
+    print_board(state)
+
+    config = BeamSearchConfig(
+        beam_width=16, max_depth=4, rollouts_per_candidate=2, random_seed=11
+    )
+    engine = BeamSearchEngine(config)
+    result = engine.search(state)
+
+    ranked = result.ranked_root_moves(top_k=5)
+    print(
+        f"Top {len(ranked)} root moves (beam-sampled statistics, not proven minimax):"
+    )
+    print(
+        f"\n{'Move':<28} {'Best Value':<12} {'Win Prob':<10} {'Leaves':<8} {'Terminal Win'}"
+    )
+    print("-" * 75)
+    for entry in ranked:
+        print(
+            f"{format_move(entry.move):<28} {entry.best_value:>+10.2f}  "
+            f"{entry.win_probability:>8.2%}  {entry.leaf_count:<8} "
+            f"{entry.has_terminal_win}"
+        )
+
+    print("\nNote: best_value is the best leaf found via that move (optimistic,")
+    print("beam-sampled); win_probability is a heuristic rescaling of the mean")
+    print("leaf value, not a calibrated probability.")
+
+
 def main():
     """Run all demonstrations."""
     print("QUANTIK BEAM SEARCH DEMONSTRATION")
@@ -184,12 +238,14 @@ def main():
     print("- Tactical (immediate win) position analysis")
     print("- Beam width sweep and its memory bound")
     print("- Pluggable custom evaluators")
+    print("- Ranked root move statistics from a midgame position")
     print()
 
     demo_full_game_reachability()
     demo_tactical_position()
     demo_beam_width_sweep()
     demo_custom_evaluator()
+    demo_ranked_root_moves()
 
     print(f"\n{'=' * 80}")
     print("ALL DEMONSTRATIONS COMPLETE")

--- a/examples/beam_search_demo.py
+++ b/examples/beam_search_demo.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Beam Search Demo for Quantik
+
+Demonstrates:
+1. Full-depth search from the empty board, reaching a true terminal
+2. Tactical position analysis (immediate win found at depth 1)
+3. Beam width sweep showing the O(beam_width x depth) memory bound
+4. Pluggable custom evaluator
+"""
+
+import time
+
+from quantik_core import State, Move, apply_move
+from quantik_core.beam_search import BeamSearchConfig, BeamSearchEngine
+
+
+def format_move(move: Move) -> str:
+    """Format move for display."""
+    shape_name = chr(ord("A") + move.shape)
+    row = move.position // 4
+    col = move.position % 4
+    return f"{shape_name} at ({row}, {col}) [pos {move.position}]"
+
+
+def print_board(state: State):
+    """Print board in a readable format."""
+    qfen = state.to_qfen()
+    rows = qfen.split("/")
+
+    print("\n  0 1 2 3")
+    for i, row in enumerate(rows):
+        print(f"{i} ", end="")
+        for cell in row:
+            if cell == ".":
+                print(". ", end="")
+            else:
+                print(f"{cell} ", end="")
+        print()
+    print()
+
+
+def demo_full_game_reachability():
+    """Demonstrate reaching a true terminal from the empty board."""
+    print(f"\n{'=' * 80}")
+    print("DEMO 1: Full-Depth Search from Empty Board")
+    print(f"{'=' * 80}")
+
+    config = BeamSearchConfig(
+        beam_width=4, max_depth=16, rollouts_per_candidate=2, random_seed=42
+    )
+    engine = BeamSearchEngine(config)
+    state = State.from_qfen("..../..../..../....")
+
+    print("\nSearch parameters:")
+    print(f"  Beam width: {config.beam_width}")
+    print(f"  Max depth: {config.max_depth}")
+    print(f"  Rollouts per candidate: {config.rollouts_per_candidate}")
+
+    start_time = time.time()
+    result = engine.search(state)
+    search_time = time.time() - start_time
+
+    print(f"\nSearch completed in {search_time:.3f} seconds")
+    print(f"Reached terminal: {result.reached_terminal}")
+    print(f"Max depth reached: {result.max_depth_reached}")
+    print(f"Terminal leaves found: {len(result.terminal_leaves)}")
+    print(f"Stats: {result.stats}")
+
+    assert result.best_leaf is not None
+    print(f"\nBest line for the root player ({len(result.best_leaf.moves)} plies):")
+    print(f"  Final value (P0 perspective): {result.best_leaf.value:+.1f}")
+
+    replay_state = state
+    for ply, move in enumerate(result.best_leaf.moves, start=1):
+        new_bb = apply_move(replay_state.bb, move)
+        replay_state = State(new_bb)
+        print(f"  Ply {ply}: {format_move(move)}")
+
+    print_board(replay_state)
+
+
+def demo_tactical_position():
+    """Demonstrate beam search finding an immediate win."""
+    print(f"\n{'=' * 80}")
+    print("DEMO 2: Tactical Position Analysis (Immediate Win)")
+    print(f"{'=' * 80}")
+
+    # P0: A at (0,0), B at (0,1); P1: c at (0,2), a at (3,3).
+    # Row 0 has shapes A, B, C — P0 wins in one move by placing D at (0,3).
+    state = State.from_qfen("ABc./..../..../...a")
+    print(f"\nPosition: {state.to_qfen()}")
+    print_board(state)
+
+    config = BeamSearchConfig(
+        beam_width=4, max_depth=2, rollouts_per_candidate=2, random_seed=1
+    )
+    engine = BeamSearchEngine(config)
+    result = engine.search(state)
+
+    assert result.best_leaf is not None
+    print(f"Best move found: {format_move(result.best_leaf.moves[0])}")
+    print(f"Terminal: {result.best_leaf.is_terminal}")
+    print(f"Value (P0 perspective): {result.best_leaf.value:+.1f}")
+    print(f"Depth: {result.best_leaf.depth}")
+
+
+def demo_beam_width_sweep():
+    """Demonstrate the O(beam_width x depth) memory bound."""
+    print(f"\n{'=' * 80}")
+    print("DEMO 3: Beam Width Sweep (Memory Bound)")
+    print(f"{'=' * 80}")
+
+    state = State.from_qfen("..../..../..../....")
+
+    print(f"\n{'Beam Width':<12} {'Nodes Inserted':<16} {'Memory Usage (bytes)'}")
+    print("-" * 50)
+
+    for beam_width in (2, 8, 32):
+        config = BeamSearchConfig(
+            beam_width=beam_width,
+            max_depth=6,
+            rollouts_per_candidate=2,
+            random_seed=7,
+            # A small initial capacity makes memory growth visible in this
+            # demo; production searches should size this to the expected
+            # tree (see BeamSearchConfig.initial_tree_capacity docs).
+            initial_tree_capacity=64,
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(state)
+
+        print(
+            f"{beam_width:<12} {result.stats['nodes_inserted']:<16} "
+            f"{result.stats['memory_usage']:,}"
+        )
+
+    print("\nNodes inserted grows with beam_width, bounded by beam_width * depth")
+    print("plus the number of terminal leaves discovered along the way.")
+
+
+def demo_custom_evaluator():
+    """Demonstrate a pluggable, non-default evaluator."""
+    print(f"\n{'=' * 80}")
+    print("DEMO 4: Pluggable Custom Evaluator")
+    print(f"{'=' * 80}")
+
+    def material_evaluator(state: State) -> float:
+        """Toy evaluator: favors player 0 having placed more pieces.
+
+        Not a serious Quantik heuristic (piece count alone says little
+        about winning chances) — this only demonstrates that any
+        `Callable[[State], float]` can replace the built-in random-rollout
+        evaluator.
+        """
+        bb = state.bb
+        p0_pieces = sum(bin(b).count("1") for b in bb[:4])
+        p1_pieces = sum(bin(b).count("1") for b in bb[4:])
+        return max(-1.0, min(1.0, (p0_pieces - p1_pieces) / 4.0))
+
+    config = BeamSearchConfig(
+        beam_width=4, max_depth=4, evaluator=material_evaluator, random_seed=3
+    )
+    engine = BeamSearchEngine(config)
+    state = State.from_qfen("..../..../..../....")
+
+    result = engine.search(state)
+
+    print(f"\nEvaluator calls made: {result.stats['evaluations']}")
+    assert result.stats["evaluations"] > 0
+    assert result.best_leaf is not None
+    print(f"Best line found ({len(result.best_leaf.moves)} plies):")
+    for ply, move in enumerate(result.best_leaf.moves, start=1):
+        print(f"  Ply {ply}: {format_move(move)}")
+
+
+def main():
+    """Run all demonstrations."""
+    print("QUANTIK BEAM SEARCH DEMONSTRATION")
+    print("=" * 80)
+    print()
+    print("This demo showcases the parametrizable beam search engine:")
+    print("- Full-depth search reaching a true terminal state")
+    print("- Tactical (immediate win) position analysis")
+    print("- Beam width sweep and its memory bound")
+    print("- Pluggable custom evaluators")
+    print()
+
+    demo_full_game_reachability()
+    demo_tactical_position()
+    demo_beam_width_sweep()
+    demo_custom_evaluator()
+
+    print(f"\n{'=' * 80}")
+    print("ALL DEMONSTRATIONS COMPLETE")
+    print(f"{'=' * 80}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/beam_search_demo.py
+++ b/examples/beam_search_demo.py
@@ -154,6 +154,44 @@ def demo_beam_width_sweep():
     print("\nNodes inserted grows with beam_width, bounded by beam_width * depth")
     print("plus the number of terminal leaves discovered along the way.")
 
+    print("\nDepth-dependent schedule vs. flat width (exhaustive shallow prefix):")
+    print(f"{'Config':<28} {'Inserted':<10} {'Evaluations':<13} {'Terminals'}")
+    print("-" * 65)
+
+    # A constant evaluator keeps this comparison fast even though the
+    # schedule is exhaustive through depth 3 (3 / 51 / 726 unique canonical
+    # states per UNIQUE_CANONICAL_STATES_PER_DEPTH) before switching to a
+    # guided width of 16.
+    runs = [
+        (
+            "schedule [3,51,726,16]",
+            BeamSearchConfig(
+                beam_schedule=[3, 51, 726, 16],
+                max_depth=4,
+                evaluator=lambda s: 0.0,
+                random_seed=1,
+            ),
+        ),
+        (
+            "flat width 64",
+            BeamSearchConfig(
+                beam_width=64, max_depth=4, evaluator=lambda s: 0.0, random_seed=1
+            ),
+        ),
+    ]
+    for label, run_config in runs:
+        run_result = BeamSearchEngine(run_config).search(state)
+        print(
+            f"{label:<28} {run_result.stats['nodes_inserted']:<10} "
+            f"{run_result.stats['evaluations']:<13} "
+            f"{len(run_result.terminal_leaves)}"
+        )
+
+    print("\nThe schedule spends far more evaluations to stay exhaustive through")
+    print("depth 3, then narrows to width 16 — a flat width this small would")
+    print("have pruned candidates at depths 1-3 where nearly every line is")
+    print("still reachable.")
+
 
 def demo_custom_evaluator():
     """Demonstrate a pluggable, non-default evaluator."""

--- a/src/quantik_core/beam_search.py
+++ b/src/quantik_core/beam_search.py
@@ -11,7 +11,7 @@ transposition table.
 
 import random
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
@@ -36,6 +36,14 @@ class BeamSearchConfig:
     random_seed: Optional[int] = None
     evaluator: Optional[Callable[[State], float]] = None
     initial_tree_capacity: int = 4096
+    # Depth-dependent beam width: width at depth d = beam_schedule[min(d-1,
+    # len(beam_schedule)-1)], so the last entry extends to all deeper
+    # levels. None (default) applies the flat `beam_width` everywhere.
+    # Quantik's canonical state space is tiny early and explodes later
+    # (see UNIQUE_CANONICAL_STATES_PER_DEPTH), so a schedule can afford an
+    # exhaustive shallow prefix followed by guided sampling, e.g.:
+    #   schedule = [UNIQUE_CANONICAL_STATES_PER_DEPTH[d] for d in (1, 2, 3)] + [64]
+    beam_schedule: Optional[Sequence[int]] = None
 
 
 @dataclass
@@ -157,6 +165,26 @@ _FrontierEntry = Tuple[int, Bitboard, Tuple[Move, ...], float]
 _Candidate = Tuple[int, Bitboard, Tuple[Move, ...], int]
 
 
+UNIQUE_CANONICAL_STATES_PER_DEPTH: Dict[int, int] = {
+    1: 3,
+    2: 51,
+    3: 726,
+    4: 10946,
+    5: 105632,
+    6: 901916,
+    7: 4658465,
+    8: 17900160,
+}
+"""Unique canonical states per depth (see `GAME_TREE_ANALYSIS.md`).
+
+Useful for building an exhaustive-prefix `BeamSearchConfig.beam_schedule`
+that keeps every legal line up to some depth before switching to guided
+sampling, e.g.:
+
+    schedule = [UNIQUE_CANONICAL_STATES_PER_DEPTH[d] for d in (1, 2, 3)] + [64]
+"""
+
+
 class BeamSearchEngine:
     """Level-by-level beam search over the Quantik game tree."""
 
@@ -187,6 +215,11 @@ class BeamSearchEngine:
             raise ValueError("max_depth must be between 1 and 16")
         if config.rollouts_per_candidate < 1:
             raise ValueError("rollouts_per_candidate must be >= 1")
+        if config.beam_schedule is not None:
+            if len(config.beam_schedule) == 0:
+                raise ValueError("beam_schedule must not be empty")
+            if any(width < 1 for width in config.beam_schedule):
+                raise ValueError("beam_schedule entries must all be >= 1")
 
         self.config = config
         self.tree = (
@@ -229,7 +262,8 @@ class BeamSearchEngine:
                 break
 
             candidates = self._expand_frontier(frontier, depth, stats, terminal_leaves)
-            frontier = self._score_and_prune(candidates, stats)
+            beam_width = self._beam_width_for_depth(depth)
+            frontier = self._score_and_prune(candidates, stats, beam_width)
             max_depth_reached = depth
 
         stats["memory_usage"] = self.tree.memory_usage()
@@ -270,6 +304,19 @@ class BeamSearchEngine:
         if not any(moves_by_shape.values()):
             raise ValueError("Cannot search from a root state with no legal moves.")
         return int(root_player)
+
+    def _beam_width_for_depth(self, depth: int) -> int:
+        """Resolve the beam width to use at a given depth (1-indexed).
+
+        Without a `beam_schedule`, the flat `beam_width` applies everywhere.
+        With one, `depth` indexes into it (`depth - 1`, clamped to the last
+        entry), so the schedule's final value extends to all deeper levels.
+        """
+        schedule = self.config.beam_schedule
+        if schedule is None:
+            return self.config.beam_width
+        index = min(depth - 1, len(schedule) - 1)
+        return schedule[index]
 
     def _expand_frontier(
         self,
@@ -359,7 +406,10 @@ class BeamSearchEngine:
             candidates[key] = (node_id, new_bb, child_moves, move.player)
 
     def _score_and_prune(
-        self, candidates: Dict[bytes, _Candidate], stats: Dict[str, int]
+        self,
+        candidates: Dict[bytes, _Candidate],
+        stats: Dict[str, int],
+        beam_width: int,
     ) -> List[_FrontierEntry]:
         """Evaluate candidates, keep the top `beam_width`, insert survivors."""
         scored: List[Tuple[float, int, bytes, float]] = []
@@ -370,7 +420,7 @@ class BeamSearchEngine:
             scored.append((score, index, key, raw_value))
 
         scored.sort(key=lambda item: (-item[0], item[1]))
-        survivors = scored[: self.config.beam_width]
+        survivors = scored[:beam_width]
         stats["nodes_pruned"] += max(0, len(scored) - len(survivors))
 
         next_frontier: List[_FrontierEntry] = []

--- a/src/quantik_core/beam_search.py
+++ b/src/quantik_core/beam_search.py
@@ -10,7 +10,7 @@ transposition table.
 """
 
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -49,6 +49,25 @@ class BeamLeaf:
 
 
 @dataclass
+class RankedRootMove:
+    """Aggregated beam-sampled statistics for one first move from the root.
+
+    These are optimistic, beam-sampled statistics computed over whichever
+    leaves this particular engine run happened to discover and keep — they
+    are **not** a minimax-proven guarantee, just a summary of the lines the
+    beam actually explored. `win_probability` is a heuristic rescaling of
+    `mean_value` into `[0, 1]`, not a calibrated probability.
+    """
+
+    move: Move
+    best_value: float  # max leaf value via this move, root-player perspective
+    mean_value: float  # mean leaf value via this move, root-player perspective
+    win_probability: float  # heuristic rescaling: (mean_value + 1) / 2
+    leaf_count: int  # number of collected leaves supporting this move
+    has_terminal_win: bool  # a proven root-player-winning terminal exists
+
+
+@dataclass
 class BeamSearchResult:
     """Result of a beam search run."""
 
@@ -57,6 +76,74 @@ class BeamSearchResult:
     reached_terminal: bool
     max_depth_reached: int
     stats: Dict[str, int]
+    root_player: int = 0  # player to move at the root
+    # Non-terminal leaves still live at max_depth_reached; empty once the
+    # search fully resolves (reached_terminal is True).
+    frontier_leaves: List[BeamLeaf] = field(default_factory=list)
+
+    def ranked_root_moves(self, top_k: Optional[int] = None) -> List[RankedRootMove]:
+        """Aggregate every collected leaf by its first move from the root.
+
+        Groups `terminal_leaves` and `frontier_leaves` by the first move of
+        each leaf's principal variation and summarizes each group's value
+        from the root player's perspective. See `RankedRootMove` for the
+        important caveat: these are beam-sampled statistics, not proven
+        minimax values.
+
+        Args:
+            top_k: If given, return only the top `top_k` ranked moves.
+
+        Returns:
+            One `RankedRootMove` per distinct first move seen, sorted by
+            `best_value`, then `mean_value`, then `leaf_count` (all
+            descending), with a deterministic final tiebreak on the move
+            itself.
+        """
+        groups: Dict[Tuple[int, int, int], List[BeamLeaf]] = {}
+        move_by_key: Dict[Tuple[int, int, int], Move] = {}
+
+        for leaf in (*self.terminal_leaves, *self.frontier_leaves):
+            if not leaf.moves:
+                continue
+            first_move = leaf.moves[0]
+            key = (first_move.player, first_move.shape, first_move.position)
+            groups.setdefault(key, []).append(leaf)
+            move_by_key.setdefault(key, first_move)
+
+        def root_perspective(leaf: BeamLeaf) -> float:
+            return leaf.value if self.root_player == 0 else -leaf.value
+
+        ranked: List[RankedRootMove] = []
+        for group_key, leaves in groups.items():
+            values = [root_perspective(leaf) for leaf in leaves]
+            best_value = max(values)
+            mean_value = sum(values) / len(values)
+            has_terminal_win = any(
+                leaf.is_terminal and value == 1.0 for leaf, value in zip(leaves, values)
+            )
+            ranked.append(
+                RankedRootMove(
+                    move=move_by_key[group_key],
+                    best_value=best_value,
+                    mean_value=mean_value,
+                    win_probability=(mean_value + 1.0) / 2.0,
+                    leaf_count=len(leaves),
+                    has_terminal_win=has_terminal_win,
+                )
+            )
+
+        ranked.sort(
+            key=lambda r: (
+                -r.best_value,
+                -r.mean_value,
+                -r.leaf_count,
+                (r.move.player, r.move.shape, r.move.position),
+            )
+        )
+
+        if top_k is not None:
+            ranked = ranked[:top_k]
+        return ranked
 
 
 # Frontier entry: node id in the tree, its bitboard, the move sequence from
@@ -150,13 +237,13 @@ class BeamSearchEngine:
         def root_perspective(leaf: BeamLeaf) -> float:
             return leaf.value if root_player == 0 else -leaf.value
 
-        leaves = list(terminal_leaves)
-        leaves.extend(
+        frontier_leaves: List[BeamLeaf] = [
             BeamLeaf(
                 moves=moves, value=value, depth=max_depth_reached, is_terminal=False
             )
             for _, _, moves, value in frontier
-        )
+        ]
+        leaves = list(terminal_leaves) + frontier_leaves
         best_leaf = max(leaves, key=root_perspective) if leaves else None
         terminal_leaves.sort(key=root_perspective, reverse=True)
 
@@ -166,6 +253,8 @@ class BeamSearchEngine:
             reached_terminal=not frontier,
             max_depth_reached=max_depth_reached,
             stats=stats,
+            root_player=root_player,
+            frontier_leaves=frontier_leaves,
         )
 
     def _require_non_terminal_root(self, initial_state: State) -> int:

--- a/src/quantik_core/beam_search.py
+++ b/src/quantik_core/beam_search.py
@@ -54,6 +54,11 @@ class BeamLeaf:
     value: float  # P0 perspective; +/-1.0 for terminal leaves
     depth: int
     is_terminal: bool
+    # Number of raw (pre-canonicalization) move sequences this leaf stands
+    # in for, accumulated by summing parent multiplicities across every
+    # dedup hit on the path from the root. 1 for a leaf whose whole PV was
+    # never merged with a symmetric sibling.
+    multiplicity: int = 1
 
 
 @dataclass
@@ -64,14 +69,18 @@ class RankedRootMove:
     leaves this particular engine run happened to discover and keep — they
     are **not** a minimax-proven guarantee, just a summary of the lines the
     beam actually explored. `win_probability` is a heuristic rescaling of
-    `mean_value` into `[0, 1]`, not a calibrated probability.
+    `mean_value` into `[0, 1]`, not a calibrated probability. `mean_value`
+    is weighted by each leaf's `multiplicity` — the number of raw move
+    sequences it represents (beam-visible only: mass belonging to pruned
+    branches is lost unless the beam was exhaustive at that depth).
     """
 
     move: Move
     best_value: float  # max leaf value via this move, root-player perspective
-    mean_value: float  # mean leaf value via this move, root-player perspective
+    mean_value: float  # multiplicity-weighted mean, root-player perspective
     win_probability: float  # heuristic rescaling: (mean_value + 1) / 2
     leaf_count: int  # number of collected leaves supporting this move
+    total_multiplicity: int  # sum of multiplicity over supporting leaves
     has_terminal_win: bool  # a proven root-player-winning terminal exists
 
 
@@ -124,8 +133,13 @@ class BeamSearchResult:
         ranked: List[RankedRootMove] = []
         for group_key, leaves in groups.items():
             values = [root_perspective(leaf) for leaf in leaves]
+            weights = [leaf.multiplicity for leaf in leaves]
+            total_multiplicity = sum(weights)
             best_value = max(values)
-            mean_value = sum(values) / len(values)
+            mean_value = (
+                sum(value * weight for value, weight in zip(values, weights))
+                / total_multiplicity
+            )
             has_terminal_win = any(
                 leaf.is_terminal and value == 1.0 for leaf, value in zip(leaves, values)
             )
@@ -136,6 +150,7 @@ class BeamSearchResult:
                     mean_value=mean_value,
                     win_probability=(mean_value + 1.0) / 2.0,
                     leaf_count=len(leaves),
+                    total_multiplicity=total_multiplicity,
                     has_terminal_win=has_terminal_win,
                 )
             )
@@ -155,14 +170,15 @@ class BeamSearchResult:
 
 
 # Frontier entry: node id in the tree, its bitboard, the move sequence from
-# the root, and its evaluated value (player-0 perspective; 0.0 for the root,
-# which is never scored).
-_FrontierEntry = Tuple[int, Bitboard, Tuple[Move, ...], float]
+# the root, its evaluated value (player-0 perspective; 0.0 for the root,
+# which is never scored), and its accumulated multiplicity (see BeamLeaf).
+_FrontierEntry = Tuple[int, Bitboard, Tuple[Move, ...], float, int]
 
 # Candidate entry keyed by `State.canonical_key()`: parent node id, the
-# candidate's bitboard, its move sequence from the root, and the id of the
-# player who made the move leading to it.
-_Candidate = Tuple[int, Bitboard, Tuple[Move, ...], int]
+# candidate's bitboard, its move sequence from the root, the id of the
+# player who made the move leading to it, and its accumulated multiplicity
+# (summed across every raw move that dedups onto this same canonical key).
+_Candidate = Tuple[int, Bitboard, Tuple[Move, ...], int, int]
 
 
 UNIQUE_CANONICAL_STATES_PER_DEPTH: Dict[int, int] = {
@@ -254,7 +270,7 @@ class BeamSearchEngine:
             "evaluations": 0,
         }
         terminal_leaves: List[BeamLeaf] = []
-        frontier: List[_FrontierEntry] = [(root_id, initial_state.bb, (), 0.0)]
+        frontier: List[_FrontierEntry] = [(root_id, initial_state.bb, (), 0.0, 1)]
         max_depth_reached = 0
 
         for depth in range(1, self.config.max_depth + 1):
@@ -273,9 +289,13 @@ class BeamSearchEngine:
 
         frontier_leaves: List[BeamLeaf] = [
             BeamLeaf(
-                moves=moves, value=value, depth=max_depth_reached, is_terminal=False
+                moves=moves,
+                value=value,
+                depth=max_depth_reached,
+                is_terminal=False,
+                multiplicity=multiplicity,
             )
-            for _, _, moves, value in frontier
+            for _, _, moves, value, multiplicity in frontier
         ]
         leaves = list(terminal_leaves) + frontier_leaves
         best_leaf = max(leaves, key=root_perspective) if leaves else None
@@ -328,7 +348,7 @@ class BeamSearchEngine:
         """Expand every frontier entry, recording terminals and candidates."""
         candidates: Dict[bytes, _Candidate] = {}
 
-        for node_id, bb, moves, _ in frontier:
+        for node_id, bb, moves, _, multiplicity in frontier:
             current_player, moves_by_shape = generate_legal_moves(bb)
             all_moves = [
                 m for shape_moves in moves_by_shape.values() for m in shape_moves
@@ -345,14 +365,26 @@ class BeamSearchEngine:
                 self._mark_terminal(node_id, extra_flag, value)
                 terminal_leaves.append(
                     BeamLeaf(
-                        moves=moves, value=value, depth=depth - 1, is_terminal=True
+                        moves=moves,
+                        value=value,
+                        depth=depth - 1,
+                        is_terminal=True,
+                        multiplicity=multiplicity,
                     )
                 )
                 continue
 
             stats["candidates_generated"] += len(all_moves)
             self._expand_moves(
-                node_id, bb, moves, all_moves, depth, stats, terminal_leaves, candidates
+                node_id,
+                bb,
+                moves,
+                all_moves,
+                depth,
+                stats,
+                terminal_leaves,
+                candidates,
+                multiplicity,
             )
 
         return candidates
@@ -367,8 +399,18 @@ class BeamSearchEngine:
         stats: Dict[str, int],
         terminal_leaves: List[BeamLeaf],
         candidates: Dict[bytes, _Candidate],
+        multiplicity: int,
     ) -> None:
-        """Apply each legal move, splitting terminal children from candidates."""
+        """Apply each legal move, splitting terminal children from candidates.
+
+        Every raw legal move contributes the parent's `multiplicity` to
+        whatever it produces: its own terminal `BeamLeaf`, or — on a
+        canonical dedup hit — accumulated into the existing candidate's
+        multiplicity (the first-encountered move/parent is kept for the
+        principal variation; only the weight accumulates). Multiplicity is
+        pure statistics: scoring and pruning below remain value-based and
+        unaffected by it.
+        """
         for move in all_moves:
             new_bb: Bitboard = apply_move(bb, move)  # type: ignore[assignment]
             new_state = State(new_bb)
@@ -386,15 +428,23 @@ class BeamSearchEngine:
                 # State.pack() bytes (its "canonical_state_data" field is
                 # not symmetry-reduced), while beam dedup above/below keys
                 # on the coarser State.canonical_key(); two different
-                # parents can therefore merge into one tree node here.
+                # parents can therefore merge into one tree node here. Its
+                # multiplicity= merges additively on such a hit, matching
+                # the path-count semantics used throughout this method.
                 nodes_before = self.tree.storage.node_count
-                child_id = self.tree.add_child_node(node_id, new_state)
+                child_id = self.tree.add_child_node(
+                    node_id, new_state, multiplicity=multiplicity
+                )
                 self._mark_terminal(child_id, extra_flag, value)
                 if self.tree.storage.node_count > nodes_before:
                     stats["nodes_inserted"] += 1
                 terminal_leaves.append(
                     BeamLeaf(
-                        moves=child_moves, value=value, depth=depth, is_terminal=True
+                        moves=child_moves,
+                        value=value,
+                        depth=depth,
+                        is_terminal=True,
+                        multiplicity=multiplicity,
                     )
                 )
                 continue
@@ -402,8 +452,22 @@ class BeamSearchEngine:
             key = new_state.canonical_key()
             if key in candidates:
                 stats["candidates_deduped"] += 1
+                (
+                    existing_node_id,
+                    existing_bb,
+                    existing_moves,
+                    existing_mover,
+                    existing_multiplicity,
+                ) = candidates[key]
+                candidates[key] = (
+                    existing_node_id,
+                    existing_bb,
+                    existing_moves,
+                    existing_mover,
+                    existing_multiplicity + multiplicity,
+                )
                 continue
-            candidates[key] = (node_id, new_bb, child_moves, move.player)
+            candidates[key] = (node_id, new_bb, child_moves, move.player, multiplicity)
 
     def _score_and_prune(
         self,
@@ -411,9 +475,14 @@ class BeamSearchEngine:
         stats: Dict[str, int],
         beam_width: int,
     ) -> List[_FrontierEntry]:
-        """Evaluate candidates, keep the top `beam_width`, insert survivors."""
+        """Evaluate candidates, keep the top `beam_width`, insert survivors.
+
+        Scoring and pruning are purely value-based; each candidate's
+        multiplicity is carried through unweighted and only affects the
+        statistics attached to the resulting tree node and frontier entry.
+        """
         scored: List[Tuple[float, int, bytes, float]] = []
-        for index, (key, (_, bb, _, mover)) in enumerate(candidates.items()):
+        for index, (key, (_, bb, _, mover, _)) in enumerate(candidates.items()):
             raw_value = self._evaluate(State(bb))
             stats["evaluations"] += 1
             score = raw_value if mover == 0 else -raw_value
@@ -425,16 +494,18 @@ class BeamSearchEngine:
 
         next_frontier: List[_FrontierEntry] = []
         for _, _, key, raw_value in survivors:
-            parent_id, bb, moves, _ = candidates[key]
+            parent_id, bb, moves, _, multiplicity = candidates[key]
             nodes_before = self.tree.storage.node_count
-            child_id = self.tree.add_child_node(parent_id, State(bb))
+            child_id = self.tree.add_child_node(
+                parent_id, State(bb), multiplicity=multiplicity
+            )
             node = self.tree.get_node(child_id)
             node.best_value = np.float32(raw_value)
             node.visit_count = np.uint32(node.visit_count + 1)
             self.tree.storage.store_node(child_id, node)
             if self.tree.storage.node_count > nodes_before:
                 stats["nodes_inserted"] += 1
-            next_frontier.append((child_id, bb, moves, raw_value))
+            next_frontier.append((child_id, bb, moves, raw_value, multiplicity))
 
         return next_frontier
 

--- a/src/quantik_core/beam_search.py
+++ b/src/quantik_core/beam_search.py
@@ -1,0 +1,340 @@
+"""
+Parametrizable beam search for Quantik.
+
+Descends level-by-level from a root state, keeping only the top
+`beam_width` non-terminal candidates per depth (breadth pruning) while
+always discovering and recording every true terminal state encountered,
+regardless of the beam width. Shares the `CompactGameTree` structure used
+by `MCTSEngine` so results from both engines can enrich the same
+transposition table.
+"""
+
+import random
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from quantik_core import State, Move, generate_legal_moves, apply_move
+from quantik_core.commons import Bitboard
+from quantik_core.game_utils import check_game_winner, WinStatus
+from quantik_core.memory.compact_tree import (
+    CompactGameTree,
+    NODE_FLAG_TERMINAL,
+    NODE_FLAG_WINNING_P0,
+    NODE_FLAG_WINNING_P1,
+)
+
+
+@dataclass
+class BeamSearchConfig:
+    """Configuration for the beam search algorithm."""
+
+    beam_width: int = 64  # frontier nodes kept per depth (>= 1)
+    max_depth: int = 16  # plies from root; 16 = full Quantik game
+    rollouts_per_candidate: int = 8  # rollout budget for the default evaluator (>= 1)
+    random_seed: Optional[int] = None
+    evaluator: Optional[Callable[[State], float]] = None
+    initial_tree_capacity: int = 4096
+
+
+@dataclass
+class BeamLeaf:
+    """A single collected leaf: a principal variation and its value."""
+
+    moves: Tuple[Move, ...]  # principal variation from the root
+    value: float  # P0 perspective; +/-1.0 for terminal leaves
+    depth: int
+    is_terminal: bool
+
+
+@dataclass
+class BeamSearchResult:
+    """Result of a beam search run."""
+
+    best_leaf: Optional[BeamLeaf]  # best for the ROOT player to move
+    terminal_leaves: List[BeamLeaf]  # all terminals discovered, best first
+    reached_terminal: bool
+    max_depth_reached: int
+    stats: Dict[str, int]
+
+
+# Frontier entry: node id in the tree, its bitboard, the move sequence from
+# the root, and its evaluated value (player-0 perspective; 0.0 for the root,
+# which is never scored).
+_FrontierEntry = Tuple[int, Bitboard, Tuple[Move, ...], float]
+
+# Candidate entry keyed by `State.canonical_key()`: parent node id, the
+# candidate's bitboard, its move sequence from the root, and the id of the
+# player who made the move leading to it.
+_Candidate = Tuple[int, Bitboard, Tuple[Move, ...], int]
+
+
+class BeamSearchEngine:
+    """Level-by-level beam search over the Quantik game tree."""
+
+    def __init__(
+        self, config: BeamSearchConfig, tree: Optional[CompactGameTree] = None
+    ) -> None:
+        """Initialize the engine, validating configuration.
+
+        Args:
+            config: Beam search configuration.
+            tree: Optional existing `CompactGameTree` to reuse (e.g. an
+                `MCTSEngine`'s tree), so results from both engines enrich
+                the same transposition structure. A fresh tree is created
+                when omitted.
+
+        Raises:
+            ValueError: if any configuration value is out of range.
+        """
+        if config.beam_width < 1:
+            raise ValueError("beam_width must be >= 1")
+        if not (1 <= config.max_depth <= 16):
+            raise ValueError("max_depth must be between 1 and 16")
+        if config.rollouts_per_candidate < 1:
+            raise ValueError("rollouts_per_candidate must be >= 1")
+
+        self.config = config
+        self.tree = (
+            tree
+            if tree is not None
+            else CompactGameTree(initial_capacity=config.initial_tree_capacity)
+        )
+        self._rng = random.Random(config.random_seed)
+
+    def search(self, initial_state: State) -> BeamSearchResult:
+        """Run beam search from `initial_state`.
+
+        Args:
+            initial_state: Starting game state.
+
+        Returns:
+            A `BeamSearchResult` describing the best line found, every
+            terminal leaf discovered, and search statistics.
+
+        Raises:
+            ValueError: if the root state is already terminal or has no
+                legal moves.
+        """
+        root_player = self._require_non_terminal_root(initial_state)
+
+        root_id = self.tree.create_root_node(initial_state)
+        stats: Dict[str, int] = {
+            "candidates_generated": 0,
+            "candidates_deduped": 0,
+            "nodes_inserted": 0,
+            "nodes_pruned": 0,
+            "evaluations": 0,
+        }
+        terminal_leaves: List[BeamLeaf] = []
+        frontier: List[_FrontierEntry] = [(root_id, initial_state.bb, (), 0.0)]
+        max_depth_reached = 0
+
+        for depth in range(1, self.config.max_depth + 1):
+            if not frontier:
+                break
+
+            candidates = self._expand_frontier(frontier, depth, stats, terminal_leaves)
+            frontier = self._score_and_prune(candidates, stats)
+            max_depth_reached = depth
+
+        stats["memory_usage"] = self.tree.memory_usage()
+
+        def root_perspective(leaf: BeamLeaf) -> float:
+            return leaf.value if root_player == 0 else -leaf.value
+
+        leaves = list(terminal_leaves)
+        leaves.extend(
+            BeamLeaf(
+                moves=moves, value=value, depth=max_depth_reached, is_terminal=False
+            )
+            for _, _, moves, value in frontier
+        )
+        best_leaf = max(leaves, key=root_perspective) if leaves else None
+        terminal_leaves.sort(key=root_perspective, reverse=True)
+
+        return BeamSearchResult(
+            best_leaf=best_leaf,
+            terminal_leaves=terminal_leaves,
+            reached_terminal=not frontier,
+            max_depth_reached=max_depth_reached,
+            stats=stats,
+        )
+
+    def _require_non_terminal_root(self, initial_state: State) -> int:
+        """Validate the root state and return the player to move.
+
+        Raises:
+            ValueError: if the root is already won or has no legal moves.
+        """
+        if check_game_winner(initial_state.bb) != WinStatus.NO_WIN:
+            raise ValueError("Cannot search from an already-terminal root state.")
+
+        root_player, moves_by_shape = generate_legal_moves(initial_state.bb)
+        if not any(moves_by_shape.values()):
+            raise ValueError("Cannot search from a root state with no legal moves.")
+        return int(root_player)
+
+    def _expand_frontier(
+        self,
+        frontier: List[_FrontierEntry],
+        depth: int,
+        stats: Dict[str, int],
+        terminal_leaves: List[BeamLeaf],
+    ) -> Dict[bytes, _Candidate]:
+        """Expand every frontier entry, recording terminals and candidates."""
+        candidates: Dict[bytes, _Candidate] = {}
+
+        for node_id, bb, moves, _ in frontier:
+            current_player, moves_by_shape = generate_legal_moves(bb)
+            all_moves = [
+                m for shape_moves in moves_by_shape.values() for m in shape_moves
+            ]
+
+            if not all_moves:
+                # Mover has no legal moves: the other player wins.
+                value = 1.0 if current_player == 1 else -1.0
+                extra_flag = (
+                    NODE_FLAG_WINNING_P0
+                    if current_player == 1
+                    else NODE_FLAG_WINNING_P1
+                )
+                self._mark_terminal(node_id, extra_flag, value)
+                terminal_leaves.append(
+                    BeamLeaf(
+                        moves=moves, value=value, depth=depth - 1, is_terminal=True
+                    )
+                )
+                continue
+
+            stats["candidates_generated"] += len(all_moves)
+            self._expand_moves(
+                node_id, bb, moves, all_moves, depth, stats, terminal_leaves, candidates
+            )
+
+        return candidates
+
+    def _expand_moves(
+        self,
+        node_id: int,
+        bb: Bitboard,
+        moves: Tuple[Move, ...],
+        all_moves: List[Move],
+        depth: int,
+        stats: Dict[str, int],
+        terminal_leaves: List[BeamLeaf],
+        candidates: Dict[bytes, _Candidate],
+    ) -> None:
+        """Apply each legal move, splitting terminal children from candidates."""
+        for move in all_moves:
+            new_bb: Bitboard = apply_move(bb, move)  # type: ignore[assignment]
+            new_state = State(new_bb)
+            child_moves = moves + (move,)
+            winner = check_game_winner(new_bb)
+
+            if winner != WinStatus.NO_WIN:
+                value = 1.0 if winner == WinStatus.PLAYER_0_WINS else -1.0
+                extra_flag = (
+                    NODE_FLAG_WINNING_P0
+                    if winner == WinStatus.PLAYER_0_WINS
+                    else NODE_FLAG_WINNING_P1
+                )
+                child_id = self.tree.add_child_node(node_id, new_state)
+                self._mark_terminal(child_id, extra_flag, value)
+                stats["nodes_inserted"] += 1
+                terminal_leaves.append(
+                    BeamLeaf(
+                        moves=child_moves, value=value, depth=depth, is_terminal=True
+                    )
+                )
+                continue
+
+            key = new_state.canonical_key()
+            if key in candidates:
+                stats["candidates_deduped"] += 1
+                continue
+            candidates[key] = (node_id, new_bb, child_moves, move.player)
+
+    def _score_and_prune(
+        self, candidates: Dict[bytes, _Candidate], stats: Dict[str, int]
+    ) -> List[_FrontierEntry]:
+        """Evaluate candidates, keep the top `beam_width`, insert survivors."""
+        scored: List[Tuple[float, int, bytes, float]] = []
+        for index, (key, (_, bb, _, mover)) in enumerate(candidates.items()):
+            raw_value = self._evaluate(State(bb))
+            stats["evaluations"] += 1
+            score = raw_value if mover == 0 else -raw_value
+            scored.append((score, index, key, raw_value))
+
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        survivors = scored[: self.config.beam_width]
+        stats["nodes_pruned"] += max(0, len(scored) - len(survivors))
+
+        next_frontier: List[_FrontierEntry] = []
+        for _, _, key, raw_value in survivors:
+            parent_id, bb, moves, _ = candidates[key]
+            child_id = self.tree.add_child_node(parent_id, State(bb))
+            node = self.tree.get_node(child_id)
+            node.best_value = np.float32(raw_value)
+            node.visit_count = np.uint32(node.visit_count + 1)
+            self.tree.storage.store_node(child_id, node)
+            stats["nodes_inserted"] += 1
+            next_frontier.append((child_id, bb, moves, raw_value))
+
+        return next_frontier
+
+    def _mark_terminal(self, node_id: int, extra_flag: int, value: float) -> None:
+        """Flag a node terminal with the given winner flag and value."""
+        node = self.tree.get_node(node_id)
+        node.flags = np.uint8(node.flags | NODE_FLAG_TERMINAL | extra_flag)
+        node.terminal_value = np.float32(value)
+        node.best_value = np.float32(value)
+        node.visit_count = np.uint32(node.visit_count + 1)
+        self.tree.storage.store_node(node_id, node)
+
+    def _evaluate(self, state: State) -> float:
+        """Evaluate a state from player 0's perspective, clamped to [-1, 1]."""
+        if self.config.evaluator is not None:
+            raw_value = self.config.evaluator(state)
+        else:
+            raw_value = self._default_evaluate(state)
+        return max(-1.0, min(1.0, float(raw_value)))
+
+    def _default_evaluate(self, state: State) -> float:
+        """Mean of `rollouts_per_candidate` random playouts to a true terminal."""
+        total = 0.0
+        for _ in range(self.config.rollouts_per_candidate):
+            total += self._rollout(state.bb)
+        return total / self.config.rollouts_per_candidate
+
+    def _rollout(self, bb: Bitboard) -> float:
+        """Play uniformly random legal moves until a terminal state.
+
+        A Quantik playout always resolves within 16 plies (each player has
+        8 pieces total and the board has 16 cells), so no depth cutoff is
+        required.
+        """
+        current_bb = bb
+        while True:
+            winner = check_game_winner(current_bb)
+            if winner != WinStatus.NO_WIN:
+                return 1.0 if winner == WinStatus.PLAYER_0_WINS else -1.0
+
+            current_player, moves_by_shape = generate_legal_moves(current_bb)
+            all_moves = [
+                m for shape_moves in moves_by_shape.values() for m in shape_moves
+            ]
+            if not all_moves:
+                return -1.0 if current_player == 0 else 1.0
+
+            move = self._rng.choice(all_moves)
+            current_bb = apply_move(current_bb, move)  # type: ignore[assignment]
+
+    def get_statistics(self) -> dict:
+        """Get beam search tree statistics (mirrors `MCTSEngine.get_statistics`)."""
+        return {
+            "nodes_created": self.tree.storage.node_count,
+            "memory_usage": self.tree.memory_usage(),
+            "tree_stats": self.tree.get_stats(),
+        }

--- a/src/quantik_core/beam_search.py
+++ b/src/quantik_core/beam_search.py
@@ -44,6 +44,17 @@ class BeamSearchConfig:
     # exhaustive shallow prefix followed by guided sampling, e.g.:
     #   schedule = [UNIQUE_CANONICAL_STATES_PER_DEPTH[d] for d in (1, 2, 3)] + [64]
     beam_schedule: Optional[Sequence[int]] = None
+    # Depth-dependent rollout budget for the BUILT-IN random-rollout
+    # evaluator only — a custom `evaluator` callable keeps its plain
+    # `State -> float` signature and ignores this entirely. Semantics
+    # mirror `beam_schedule`: rollouts at depth d = rollout_schedule[min(
+    # d-1, len(rollout_schedule)-1)], so the last entry extends to all
+    # deeper levels. None (default) applies the flat
+    # `rollouts_per_candidate` everywhere. Lets a search be
+    # wide-and-cheap early (few rollouts while beam_schedule keeps many
+    # candidates) and narrow-and-precise late, e.g. rollout_schedule=
+    # [1, 1, 1, 8] alongside beam_schedule=[3, 51, 726, 64].
+    rollout_schedule: Optional[Sequence[int]] = None
 
 
 @dataclass
@@ -236,6 +247,11 @@ class BeamSearchEngine:
                 raise ValueError("beam_schedule must not be empty")
             if any(width < 1 for width in config.beam_schedule):
                 raise ValueError("beam_schedule entries must all be >= 1")
+        if config.rollout_schedule is not None:
+            if len(config.rollout_schedule) == 0:
+                raise ValueError("rollout_schedule must not be empty")
+            if any(count < 1 for count in config.rollout_schedule):
+                raise ValueError("rollout_schedule entries must all be >= 1")
 
         self.config = config
         self.tree = (
@@ -268,6 +284,7 @@ class BeamSearchEngine:
             "nodes_inserted": 0,
             "nodes_pruned": 0,
             "evaluations": 0,
+            "rollouts": 0,
         }
         terminal_leaves: List[BeamLeaf] = []
         frontier: List[_FrontierEntry] = [(root_id, initial_state.bb, (), 0.0, 1)]
@@ -279,7 +296,8 @@ class BeamSearchEngine:
 
             candidates = self._expand_frontier(frontier, depth, stats, terminal_leaves)
             beam_width = self._beam_width_for_depth(depth)
-            frontier = self._score_and_prune(candidates, stats, beam_width)
+            rollouts = self._rollouts_for_depth(depth)
+            frontier = self._score_and_prune(candidates, stats, beam_width, rollouts)
             max_depth_reached = depth
 
         stats["memory_usage"] = self.tree.memory_usage()
@@ -335,6 +353,20 @@ class BeamSearchEngine:
         schedule = self.config.beam_schedule
         if schedule is None:
             return self.config.beam_width
+        index = min(depth - 1, len(schedule) - 1)
+        return schedule[index]
+
+    def _rollouts_for_depth(self, depth: int) -> int:
+        """Resolve the built-in evaluator's rollout count at a depth (1-indexed).
+
+        Mirrors `_beam_width_for_depth`: without a `rollout_schedule` the
+        flat `rollouts_per_candidate` applies everywhere; with one, `depth`
+        indexes into it clamped to the last entry. Irrelevant when a custom
+        `evaluator` is configured.
+        """
+        schedule = self.config.rollout_schedule
+        if schedule is None:
+            return self.config.rollouts_per_candidate
         index = min(depth - 1, len(schedule) - 1)
         return schedule[index]
 
@@ -474,16 +506,19 @@ class BeamSearchEngine:
         candidates: Dict[bytes, _Candidate],
         stats: Dict[str, int],
         beam_width: int,
+        rollouts: int,
     ) -> List[_FrontierEntry]:
         """Evaluate candidates, keep the top `beam_width`, insert survivors.
 
         Scoring and pruning are purely value-based; each candidate's
         multiplicity is carried through unweighted and only affects the
         statistics attached to the resulting tree node and frontier entry.
+        `rollouts` is the per-candidate playout budget for the built-in
+        evaluator at this depth (ignored by a custom evaluator).
         """
         scored: List[Tuple[float, int, bytes, float]] = []
         for index, (key, (_, bb, _, mover, _)) in enumerate(candidates.items()):
-            raw_value = self._evaluate(State(bb))
+            raw_value = self._evaluate(State(bb), rollouts, stats)
             stats["evaluations"] += 1
             score = raw_value if mover == 0 else -raw_value
             scored.append((score, index, key, raw_value))
@@ -518,20 +553,28 @@ class BeamSearchEngine:
         node.visit_count = np.uint32(node.visit_count + 1)
         self.tree.storage.store_node(node_id, node)
 
-    def _evaluate(self, state: State) -> float:
-        """Evaluate a state from player 0's perspective, clamped to [-1, 1]."""
+    def _evaluate(self, state: State, rollouts: int, stats: Dict[str, int]) -> float:
+        """Evaluate a state from player 0's perspective, clamped to [-1, 1].
+
+        A custom evaluator is called as-is (its cost model is its own, so
+        `rollouts` is ignored and `stats["rollouts"]` stays untouched);
+        otherwise the built-in evaluator runs `rollouts` playouts.
+        """
         if self.config.evaluator is not None:
             raw_value = self.config.evaluator(state)
         else:
-            raw_value = self._default_evaluate(state)
+            raw_value = self._default_evaluate(state, rollouts, stats)
         return max(-1.0, min(1.0, float(raw_value)))
 
-    def _default_evaluate(self, state: State) -> float:
-        """Mean of `rollouts_per_candidate` random playouts to a true terminal."""
+    def _default_evaluate(
+        self, state: State, rollouts: int, stats: Dict[str, int]
+    ) -> float:
+        """Mean of `rollouts` random playouts to a true terminal."""
         total = 0.0
-        for _ in range(self.config.rollouts_per_candidate):
+        for _ in range(rollouts):
             total += self._rollout(state.bb)
-        return total / self.config.rollouts_per_candidate
+        stats["rollouts"] += rollouts
+        return total / rollouts
 
     def _rollout(self, bb: Bitboard) -> float:
         """Play uniformly random legal moves until a terminal state.

--- a/src/quantik_core/beam_search.py
+++ b/src/quantik_core/beam_search.py
@@ -83,7 +83,13 @@ class BeamSearchEngine:
             tree: Optional existing `CompactGameTree` to reuse (e.g. an
                 `MCTSEngine`'s tree), so results from both engines enrich
                 the same transposition structure. A fresh tree is created
-                when omitted.
+                when omitted. Note: `CompactGameTree.create_root_node`
+                hardcodes the root's `player_turn` to 0 and alternates from
+                there, so when sharing a tree with an `MCTSEngine`, root the
+                beam search at a position where player 0 is to move —
+                otherwise every node's `player_turn` is inverted, which
+                would corrupt MCTS's UCB calculation if that engine later
+                resumes on the same tree.
 
         Raises:
             ValueError: if any configuration value is out of range.
@@ -240,9 +246,16 @@ class BeamSearchEngine:
                     if winner == WinStatus.PLAYER_0_WINS
                     else NODE_FLAG_WINNING_P1
                 )
+                # add_child_node keys transpositions on the literal
+                # State.pack() bytes (its "canonical_state_data" field is
+                # not symmetry-reduced), while beam dedup above/below keys
+                # on the coarser State.canonical_key(); two different
+                # parents can therefore merge into one tree node here.
+                nodes_before = self.tree.storage.node_count
                 child_id = self.tree.add_child_node(node_id, new_state)
                 self._mark_terminal(child_id, extra_flag, value)
-                stats["nodes_inserted"] += 1
+                if self.tree.storage.node_count > nodes_before:
+                    stats["nodes_inserted"] += 1
                 terminal_leaves.append(
                     BeamLeaf(
                         moves=child_moves, value=value, depth=depth, is_terminal=True
@@ -274,12 +287,14 @@ class BeamSearchEngine:
         next_frontier: List[_FrontierEntry] = []
         for _, _, key, raw_value in survivors:
             parent_id, bb, moves, _ = candidates[key]
+            nodes_before = self.tree.storage.node_count
             child_id = self.tree.add_child_node(parent_id, State(bb))
             node = self.tree.get_node(child_id)
             node.best_value = np.float32(raw_value)
             node.visit_count = np.uint32(node.visit_count + 1)
             self.tree.storage.store_node(child_id, node)
-            stats["nodes_inserted"] += 1
+            if self.tree.storage.node_count > nodes_before:
+                stats["nodes_inserted"] += 1
             next_frontier.append((child_id, bb, moves, raw_value))
 
         return next_frontier

--- a/tests/test_beam_search.py
+++ b/tests/test_beam_search.py
@@ -1,0 +1,432 @@
+"""Tests for the parametrizable beam search engine."""
+
+from typing import List
+
+import pytest
+
+from quantik_core import State, apply_move
+from quantik_core.beam_search import BeamSearchConfig, BeamSearchEngine, BeamLeaf
+from quantik_core.mcts import MCTSEngine, MCTSConfig
+from quantik_core.memory.compact_tree import (
+    CompactGameTree,
+    NODE_FLAG_TERMINAL,
+    NODE_FLAG_WINNING_P0,
+    NODE_FLAG_WINNING_P1,
+)
+from quantik_core.game_utils import check_game_winner, WinStatus
+
+EMPTY_QFEN = "..../..../..../...."
+
+
+class TestBeamSearchConfig:
+    """Test beam search configuration defaults, custom values, validation."""
+
+    def test_default_config(self):
+        config = BeamSearchConfig()
+        assert config.beam_width == 64
+        assert config.max_depth == 16
+        assert config.rollouts_per_candidate == 8
+        assert config.random_seed is None
+        assert config.evaluator is None
+        assert config.initial_tree_capacity == 4096
+
+    def test_custom_config(self):
+        def evaluator(state: State) -> float:
+            return 0.0
+
+        config = BeamSearchConfig(
+            beam_width=8,
+            max_depth=4,
+            rollouts_per_candidate=2,
+            random_seed=7,
+            evaluator=evaluator,
+            initial_tree_capacity=128,
+        )
+        assert config.beam_width == 8
+        assert config.max_depth == 4
+        assert config.rollouts_per_candidate == 2
+        assert config.random_seed == 7
+        assert config.evaluator is evaluator
+        assert config.initial_tree_capacity == 128
+
+    def test_invalid_beam_width(self):
+        with pytest.raises(ValueError):
+            BeamSearchEngine(BeamSearchConfig(beam_width=0))
+
+    def test_invalid_max_depth_too_low(self):
+        with pytest.raises(ValueError):
+            BeamSearchEngine(BeamSearchConfig(max_depth=0))
+
+    def test_invalid_max_depth_too_high(self):
+        with pytest.raises(ValueError):
+            BeamSearchEngine(BeamSearchConfig(max_depth=17))
+
+    def test_invalid_rollouts_per_candidate(self):
+        with pytest.raises(ValueError):
+            BeamSearchEngine(BeamSearchConfig(rollouts_per_candidate=0))
+
+
+class TestBeamSearchEngine:
+    """Test core beam search behavior."""
+
+    def test_immediate_win_found(self):
+        """Near-win fixture: best_leaf is the winning terminal at depth 1."""
+        # P0: A at (0,0), B at (0,1); P1: c at (0,2), a at (3,3).
+        # Row 0 has shapes A, B, C — P0 can win by placing D at (0,3), and
+        # this is the *only* one-move win available from this position.
+        config = BeamSearchConfig(
+            beam_width=4, max_depth=2, rollouts_per_candidate=2, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+
+        state = State.from_qfen("ABc./..../..../...a")
+        result = engine.search(state)
+
+        assert result.best_leaf is not None
+        assert result.best_leaf.is_terminal
+        assert result.best_leaf.depth == 1
+        assert result.best_leaf.value == pytest.approx(1.0)
+        assert len(result.best_leaf.moves) == 1
+        winning_move = result.best_leaf.moves[0]
+        assert winning_move.player == 0
+        assert winning_move.shape == 3  # D
+        assert winning_move.position == 3  # (0,3)
+
+    def test_full_game_reachability(self):
+        """From the empty board, a small seeded beam reaches true terminals."""
+        config = BeamSearchConfig(
+            beam_width=4, max_depth=16, rollouts_per_candidate=2, random_seed=42
+        )
+        engine = BeamSearchEngine(config)
+
+        state = State.from_qfen(EMPTY_QFEN)
+        result = engine.search(state)
+
+        assert result.reached_terminal is True
+        assert len(result.terminal_leaves) > 0
+
+        for leaf in result.terminal_leaves:
+            bb = state.bb
+            for move in leaf.moves:
+                bb = apply_move(bb, move)
+            winner = check_game_winner(bb)
+            if winner == WinStatus.NO_WIN:
+                # Mover-blocked terminal: the player to move has no legal moves.
+                from quantik_core import generate_legal_moves
+
+                current_player, moves_by_shape = generate_legal_moves(bb)
+                all_moves = [m for ms in moves_by_shape.values() for m in ms]
+                assert not all_moves
+            else:
+                assert winner != WinStatus.NO_WIN
+
+    def test_symmetry_dedup_depth_one(self):
+        """From the empty board, 64 depth-1 moves collapse to 3 canonical states."""
+        config = BeamSearchConfig(
+            beam_width=64, max_depth=1, rollouts_per_candidate=1, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+
+        state = State.from_qfen(EMPTY_QFEN)
+        result = engine.search(state)
+
+        assert result.stats["candidates_generated"] == 64
+        # 64 candidates - 3 unique canonical states = 61 deduped
+        assert result.stats["candidates_deduped"] == 61
+        assert result.stats["nodes_inserted"] == 3
+
+    def test_memory_bound(self):
+        """nodes_inserted stays within the beam_width * depth + terminals bound."""
+        state = State.from_qfen(EMPTY_QFEN)
+
+        config_small = BeamSearchConfig(
+            beam_width=2, max_depth=4, rollouts_per_candidate=1, random_seed=3
+        )
+        engine_small = BeamSearchEngine(config_small)
+        result_small = engine_small.search(state)
+
+        config_large = BeamSearchConfig(
+            beam_width=16, max_depth=4, rollouts_per_candidate=1, random_seed=3
+        )
+        engine_large = BeamSearchEngine(config_large)
+        result_large = engine_large.search(state)
+
+        terminal_count_small = len(result_small.terminal_leaves)
+        terminal_count_large = len(result_large.terminal_leaves)
+
+        assert result_small.stats["nodes_inserted"] <= (
+            config_small.beam_width * result_small.max_depth_reached
+            + terminal_count_small
+        )
+        assert result_large.stats["nodes_inserted"] <= (
+            config_large.beam_width * result_large.max_depth_reached
+            + terminal_count_large
+        )
+
+    def test_determinism_same_seed(self):
+        """Same seed produces an identical result."""
+        state = State.from_qfen(EMPTY_QFEN)
+
+        config1 = BeamSearchConfig(
+            beam_width=4, max_depth=6, rollouts_per_candidate=2, random_seed=99
+        )
+        result1 = BeamSearchEngine(config1).search(state)
+
+        config2 = BeamSearchConfig(
+            beam_width=4, max_depth=6, rollouts_per_candidate=2, random_seed=99
+        )
+        result2 = BeamSearchEngine(config2).search(state)
+
+        assert result1.stats == result2.stats
+        assert result1.max_depth_reached == result2.max_depth_reached
+        assert result1.reached_terminal == result2.reached_terminal
+        assert [leaf.moves for leaf in result1.terminal_leaves] == [
+            leaf.moves for leaf in result2.terminal_leaves
+        ]
+        assert result1.best_leaf is not None and result2.best_leaf is not None
+        assert result1.best_leaf.moves == result2.best_leaf.moves
+        assert result1.best_leaf.value == pytest.approx(result2.best_leaf.value)
+
+    def test_determinism_different_seed_may_differ(self):
+        """Different seeds are allowed to (and typically do) diverge."""
+        state = State.from_qfen(EMPTY_QFEN)
+
+        config1 = BeamSearchConfig(
+            beam_width=3, max_depth=6, rollouts_per_candidate=3, random_seed=1
+        )
+        result1 = BeamSearchEngine(config1).search(state)
+
+        config2 = BeamSearchConfig(
+            beam_width=3, max_depth=6, rollouts_per_candidate=3, random_seed=2
+        )
+        result2 = BeamSearchEngine(config2).search(state)
+
+        # Spec only guarantees same-seed determinism; different seeds are
+        # merely allowed (not required) to diverge. Just assert both runs
+        # complete and produce well-formed, independently valid results.
+        assert result1.best_leaf is not None
+        assert result2.best_leaf is not None
+        assert result1.stats["evaluations"] > 0
+        assert result2.stats["evaluations"] > 0
+
+    def test_pluggable_evaluator_is_used(self):
+        """A custom evaluator callable is invoked and biases the beam."""
+        calls: List[State] = []
+
+        def evaluator(state: State) -> float:
+            calls.append(state)
+            return 1.0  # always favor player 0
+
+        config = BeamSearchConfig(
+            beam_width=1, max_depth=2, evaluator=evaluator, random_seed=5
+        )
+        engine = BeamSearchEngine(config)
+
+        state = State.from_qfen(EMPTY_QFEN)
+        engine.search(state)
+
+        assert len(calls) > 0
+
+    def test_evaluator_clamping(self):
+        """Evaluator values outside [-1, 1] are clamped."""
+
+        def evaluator(state: State) -> float:
+            return 5.0
+
+        config = BeamSearchConfig(
+            beam_width=2, max_depth=1, evaluator=evaluator, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+
+        state = State.from_qfen(EMPTY_QFEN)
+        result = engine.search(state)
+
+        for node_id in engine.tree.get_children(engine.tree.root_id):
+            node = engine.tree.get_node(node_id)
+            if not (node.flags & NODE_FLAG_TERMINAL):
+                assert float(node.best_value) <= 1.0
+
+        assert result is not None
+
+    def test_adversarial_perspective_p1_winning_reply(self):
+        """When P1 is to move at depth 1 and has a winning reply, beam keeps it."""
+        # P0 has placed A at (0,0). P1 to move.
+        # Give P1 a winning reply: place B, C, D such that the row completes.
+        # Row 0: A . . . ; P1 places b at 1, c at 2, then can win with d at 3
+        # is too many moves; instead build a position where p1 has an
+        # immediate one-move win: row 0 has A B C already (P0, P0, P1) and
+        # it's P1's turn - wait shape D must be placed by whoever completes.
+        # Use: P0 A at 0, B at 1; P1 c at 2. It's P1's turn (counts 2 vs 1).
+        state = State.from_qfen("ABc./..../..../....")
+
+        config = BeamSearchConfig(
+            beam_width=2, max_depth=1, rollouts_per_candidate=1, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(state)
+
+        # P1 wins by placing shape D (index 3) at position 3.
+        winning_moves = [
+            leaf for leaf in result.terminal_leaves if leaf.value == pytest.approx(-1.0)
+        ]
+        assert len(winning_moves) > 0
+        assert any(
+            leaf.moves[0].player == 1
+            and leaf.moves[0].shape == 3
+            and leaf.moves[0].position == 3
+            for leaf in winning_moves
+        )
+
+    def test_shared_tree_integration(self):
+        """Passing an existing CompactGameTree writes terminal data into it."""
+        mcts_config = MCTSConfig(random_seed=1)
+        mcts_engine = MCTSEngine(mcts_config)
+
+        config = BeamSearchConfig(
+            beam_width=4, max_depth=2, rollouts_per_candidate=1, random_seed=1
+        )
+        engine = BeamSearchEngine(config, tree=mcts_engine.tree)
+        assert engine.tree is mcts_engine.tree
+
+        state = State.from_qfen("ABc./d.../..../....")
+        result = engine.search(state)
+
+        assert result.best_leaf is not None
+        found_terminal_flag = False
+        for node_id in range(engine.tree.storage.node_count):
+            node = engine.tree.get_node(node_id)
+            if node.flags & NODE_FLAG_TERMINAL:
+                found_terminal_flag = True
+                assert (node.flags & NODE_FLAG_WINNING_P0) or (
+                    node.flags & NODE_FLAG_WINNING_P1
+                )
+        assert found_terminal_flag
+        assert (
+            engine.tree.storage.node_count
+            <= config.beam_width * 2 + len(result.terminal_leaves) + 1
+        )  # +1 for the root
+
+    def test_shared_tree_with_fresh_compact_tree(self):
+        """A fresh CompactGameTree instance can also be shared."""
+        tree = CompactGameTree(initial_capacity=64)
+        config = BeamSearchConfig(
+            beam_width=2, max_depth=1, rollouts_per_candidate=1, random_seed=1
+        )
+        engine = BeamSearchEngine(config, tree=tree)
+
+        state = State.from_qfen(EMPTY_QFEN)
+        result = engine.search(state)
+
+        assert engine.tree is tree
+        assert result.stats["nodes_inserted"] > 0
+
+    def test_root_already_terminal_raises(self):
+        """Root state with a winning line raises ValueError."""
+        config = BeamSearchConfig(random_seed=1)
+        engine = BeamSearchEngine(config)
+
+        state = State.from_qfen("ABCD/..../..../....")
+        with pytest.raises(ValueError):
+            engine.search(state)
+
+    def test_root_no_legal_moves_raises(self):
+        """Root state with no legal moves raises ValueError."""
+        config = BeamSearchConfig(random_seed=1)
+        engine = BeamSearchEngine(config)
+
+        state = State.from_qfen(EMPTY_QFEN)
+        from unittest.mock import patch
+
+        with patch(
+            "quantik_core.beam_search.generate_legal_moves", return_value=(0, {})
+        ):
+            with pytest.raises(ValueError):
+                engine.search(state)
+
+    def test_get_statistics(self):
+        """get_statistics mirrors MCTSEngine's tree-delegated statistics."""
+        config = BeamSearchConfig(
+            beam_width=4, max_depth=2, rollouts_per_candidate=1, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+
+        state = State.from_qfen(EMPTY_QFEN)
+        engine.search(state)
+
+        stats = engine.get_statistics()
+        assert stats["nodes_created"] > 0
+        assert stats["memory_usage"] > 0
+        assert "tree_stats" in stats
+
+    def test_beam_leaf_fields(self):
+        """BeamLeaf exposes the documented fields."""
+        leaf = BeamLeaf(moves=(), value=1.0, depth=0, is_terminal=True)
+        assert leaf.moves == ()
+        assert leaf.value == 1.0
+        assert leaf.depth == 0
+        assert leaf.is_terminal is True
+
+    def test_stalemate_frontier_entry_marked_terminal(self):
+        """A frontier state with no legal moves is terminal (mover loses)."""
+        config = BeamSearchConfig(
+            beam_width=2, max_depth=2, rollouts_per_candidate=1, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+
+        state = State.from_qfen(EMPTY_QFEN)
+
+        from unittest.mock import patch
+
+        call_count = {"n": 0}
+        real_generate = None
+
+        import quantik_core.beam_search as beam_search_module
+
+        real_generate = beam_search_module.generate_legal_moves
+
+        def fake_generate(bb, player_id=None):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                # Force the second call (root expansion happened already via
+                # validation, so this hits the first frontier-entry expansion)
+                # to look like a stalemate.
+                current_player, _ = real_generate(bb, player_id)
+                return current_player, {0: [], 1: [], 2: [], 3: []}
+            return real_generate(bb, player_id)
+
+        with patch(
+            "quantik_core.beam_search.generate_legal_moves", side_effect=fake_generate
+        ):
+            result = engine.search(state)
+
+        assert any(leaf.depth == 0 for leaf in result.terminal_leaves)
+
+
+class TestBeamSearchResultRanking:
+    """Test result ranking/best_leaf selection semantics."""
+
+    def test_best_leaf_prefers_root_player_perspective(self):
+        """best_leaf is ranked from the root player's perspective, not P0-fixed."""
+        # P1 to move; give P1 an immediate winning reply among the candidates.
+        state = State.from_qfen("ABc./..../..../....")
+        config = BeamSearchConfig(
+            beam_width=4, max_depth=1, rollouts_per_candidate=1, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+
+        result = engine.search(state)
+
+        assert result.best_leaf is not None
+        assert result.best_leaf.value == pytest.approx(
+            -1.0
+        )  # P1 (mover) wins -> P0-perspective -1
+
+    def test_best_leaf_none_only_when_no_leaves(self):
+        """best_leaf is derived from collected leaves; sanity check the invariant."""
+        config = BeamSearchConfig(
+            beam_width=1, max_depth=1, rollouts_per_candidate=1, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+        state = State.from_qfen(EMPTY_QFEN)
+        result = engine.search(state)
+        assert result.best_leaf is not None

--- a/tests/test_beam_search.py
+++ b/tests/test_beam_search.py
@@ -1,6 +1,6 @@
 """Tests for the parametrizable beam search engine."""
 
-from typing import List
+from typing import Dict, List
 
 import pytest
 
@@ -795,3 +795,190 @@ class TestBeamSchedule:
         # 3 + 51 + 726 unique canonical survivors across the three depths
         # (no wins are possible this early, so nothing is a terminal leaf).
         assert result.stats["nodes_inserted"] == 3 + 51 + 726
+
+
+class TestSymmetryMultiplicity:
+    """Test path-multiplicity accounting for beam-visible symmetry orbits.
+
+    A constant evaluator (`lambda s: 0.0`) is used throughout so exhaustive
+    shallow-depth runs stay cheap (no rollouts).
+    """
+
+    def test_depth_1_exact_orbits(self):
+        """64 raw depth-1 moves split into 3 canonical orbits of size 16/16/32."""
+        config = BeamSearchConfig(
+            beam_schedule=[3], max_depth=1, evaluator=lambda s: 0.0, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(State.from_qfen(EMPTY_QFEN))
+
+        assert len(result.frontier_leaves) == 3
+        multiplicities = sorted(leaf.multiplicity for leaf in result.frontier_leaves)
+        assert multiplicities == [16, 16, 32]
+        assert sum(multiplicities) == 64
+
+    def test_depth_2_exact_multiplicity_sum(self):
+        """Depth-2 multiplicities sum to the 3,392 total legal moves at depth 2."""
+        config = BeamSearchConfig(
+            beam_schedule=[3, 51], max_depth=2, evaluator=lambda s: 0.0, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(State.from_qfen(EMPTY_QFEN))
+
+        assert len(result.frontier_leaves) == 51
+        assert sum(leaf.multiplicity for leaf in result.frontier_leaves) == 3392
+
+    def test_depth_3_exact_multiplicity_sum(self):
+        """Depth-3 multiplicities sum to the 167,552 total legal moves at depth 3."""
+        config = BeamSearchConfig(
+            beam_schedule=[3, 51, 726],
+            max_depth=3,
+            evaluator=lambda s: 0.0,
+            random_seed=1,
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(State.from_qfen(EMPTY_QFEN))
+
+        assert len(result.frontier_leaves) == 726
+        assert sum(leaf.multiplicity for leaf in result.frontier_leaves) == 167552
+
+    @pytest.mark.slow
+    def test_depth_4_exact_terminal_and_frontier_mass(self):
+        """Depth-4 terminal mass (all P1 wins) plus frontier mass sum to the
+        6,776,960 total legal moves at depth 4 (per GAME_TREE_ANALYSIS.md)."""
+        config = BeamSearchConfig(
+            beam_schedule=[3, 51, 726, 10946],
+            max_depth=4,
+            evaluator=lambda s: 0.0,
+            random_seed=1,
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(State.from_qfen(EMPTY_QFEN))
+
+        depth_4_terminals = [leaf for leaf in result.terminal_leaves if leaf.depth == 4]
+        assert sum(leaf.multiplicity for leaf in depth_4_terminals) == 6912
+        assert all(leaf.value == -1.0 for leaf in depth_4_terminals)
+
+        assert len(result.frontier_leaves) == 10946
+        assert (
+            sum(leaf.multiplicity for leaf in result.frontier_leaves) == 6776960 - 6912
+        )
+
+    def test_every_leaf_multiplicity_at_least_one(self):
+        """Regression: every collected leaf has multiplicity >= 1."""
+        config = BeamSearchConfig(
+            beam_width=6, max_depth=4, rollouts_per_candidate=1, random_seed=3
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(State.from_qfen(EMPTY_QFEN))
+
+        for leaf in (*result.terminal_leaves, *result.frontier_leaves):
+            assert leaf.multiplicity >= 1
+
+    def test_ranked_root_moves_weighted_mean_differs_from_unweighted(self):
+        """Multiplicity-weighted mean must differ from a naive unweighted mean.
+
+        Mutation guard: if `ranked_root_moves` reverted to an unweighted
+        `sum(values) / len(values)`, this test's exact mean_value assertion
+        would fail.
+        """
+        move = Move(player=0, shape=0, position=0)
+        leaf_light = BeamLeaf(
+            moves=(move,), value=1.0, depth=1, is_terminal=False, multiplicity=1
+        )
+        leaf_heavy = BeamLeaf(
+            moves=(move,), value=-1.0, depth=1, is_terminal=False, multiplicity=9
+        )
+
+        result = BeamSearchResult(
+            best_leaf=None,
+            terminal_leaves=[],
+            reached_terminal=False,
+            max_depth_reached=1,
+            stats={},
+            root_player=0,
+            frontier_leaves=[leaf_light, leaf_heavy],
+        )
+
+        ranked = result.ranked_root_moves()
+        assert len(ranked) == 1
+        entry = ranked[0]
+
+        # Weighted mean: (1 * 1.0 + 9 * -1.0) / 10 = -0.8
+        assert entry.mean_value == pytest.approx(-0.8)
+        assert entry.total_multiplicity == 10
+
+        unweighted_mean = (1.0 + -1.0) / 2  # 0.0 - a materially different number
+        assert entry.mean_value != pytest.approx(unweighted_mean)
+
+    def test_tree_node_multiplicity_matches_leaf(self):
+        """Survivor tree nodes are inserted with their accumulated multiplicity."""
+        config = BeamSearchConfig(
+            beam_schedule=[3], max_depth=1, evaluator=lambda s: 0.0, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+        state = State.from_qfen(EMPTY_QFEN)
+        result = engine.search(state)
+
+        assert len(result.frontier_leaves) == 3
+        children = engine.tree.get_children(engine.tree.root_id)
+        assert len(children) == 3
+
+        leaf_multiplicity_by_key = {}
+        for leaf in result.frontier_leaves:
+            child_bb = apply_move(state.bb, leaf.moves[0])
+            leaf_multiplicity_by_key[State(child_bb).canonical_key()] = (
+                leaf.multiplicity
+            )
+
+        for child_id in children:
+            child_state = engine.tree.get_state(child_id)
+            node = engine.tree.get_node(child_id)
+            expected = leaf_multiplicity_by_key[child_state.canonical_key()]
+            assert int(node.multiplicity) == expected
+
+    def test_tree_multiplicity_merges_across_parents(self):
+        """Two different parents whose completing moves reach the exact same
+        literal terminal board have their multiplicities summed on the
+        merged tree node (CompactGameTree.add_child_node's own additive
+        transposition-merge semantics)."""
+        config = BeamSearchConfig(evaluator=lambda s: 0.0, random_seed=1)
+        engine = BeamSearchEngine(config)
+
+        # Both miss exactly one piece of the same row-0 win "AbCd"; P1 to
+        # move in both, completing with the piece each is missing.
+        predecessor_1 = State.from_qfen("A.Cd/..../..../....")  # missing b@1
+        predecessor_2 = State.from_qfen("AbC./..../..../....")  # missing d@3
+
+        node_1 = engine.tree.create_root_node(predecessor_1)
+        node_2 = engine.tree.create_root_node(predecessor_2)
+
+        stats: Dict[str, int] = {
+            "candidates_generated": 0,
+            "candidates_deduped": 0,
+            "nodes_inserted": 0,
+            "nodes_pruned": 0,
+            "evaluations": 0,
+        }
+        terminal_leaves: List[BeamLeaf] = []
+        frontier = [
+            (node_1, predecessor_1.bb, (), 0.0, 5),
+            (node_2, predecessor_2.bb, (), 0.0, 7),
+        ]
+        engine._expand_frontier(frontier, 1, stats, terminal_leaves)
+
+        winning_bb = apply_move(predecessor_1.bb, Move(player=1, shape=1, position=1))
+        merged_id = engine.tree.storage.find_node_by_canonical_state(
+            State(winning_bb).pack(), 1
+        )
+        assert merged_id is not None
+        merged_node = engine.tree.get_node(merged_id)
+        assert int(merged_node.multiplicity) == 5 + 7
+
+        # Both raw completions were recorded as their own terminal leaves,
+        # each carrying only its own parent's multiplicity (not the merged
+        # total) — the merge happens on the shared tree node, not the leaf.
+        matching_leaves = [
+            leaf for leaf in terminal_leaves if leaf.value == pytest.approx(-1.0)
+        ]
+        assert sorted(leaf.multiplicity for leaf in matching_leaves) == [5, 7]

--- a/tests/test_beam_search.py
+++ b/tests/test_beam_search.py
@@ -11,6 +11,7 @@ from quantik_core.beam_search import (
     BeamSearchResult,
     BeamLeaf,
     RankedRootMove,
+    UNIQUE_CANONICAL_STATES_PER_DEPTH,
 )
 from quantik_core.mcts import MCTSEngine, MCTSConfig
 from quantik_core.memory.compact_tree import (
@@ -35,6 +36,7 @@ class TestBeamSearchConfig:
         assert config.random_seed is None
         assert config.evaluator is None
         assert config.initial_tree_capacity == 4096
+        assert config.beam_schedule is None
 
     def test_custom_config(self):
         def evaluator(state: State) -> float:
@@ -47,6 +49,7 @@ class TestBeamSearchConfig:
             random_seed=7,
             evaluator=evaluator,
             initial_tree_capacity=128,
+            beam_schedule=[3, 51, 8],
         )
         assert config.beam_width == 8
         assert config.max_depth == 4
@@ -54,6 +57,7 @@ class TestBeamSearchConfig:
         assert config.random_seed == 7
         assert config.evaluator is evaluator
         assert config.initial_tree_capacity == 128
+        assert config.beam_schedule == [3, 51, 8]
 
     def test_invalid_beam_width(self):
         with pytest.raises(ValueError):
@@ -70,6 +74,18 @@ class TestBeamSearchConfig:
     def test_invalid_rollouts_per_candidate(self):
         with pytest.raises(ValueError):
             BeamSearchEngine(BeamSearchConfig(rollouts_per_candidate=0))
+
+    def test_invalid_beam_schedule_empty(self):
+        with pytest.raises(ValueError):
+            BeamSearchEngine(BeamSearchConfig(beam_schedule=[]))
+
+    def test_invalid_beam_schedule_zero_entry(self):
+        with pytest.raises(ValueError):
+            BeamSearchEngine(BeamSearchConfig(beam_schedule=[3, 0, 5]))
+
+    def test_invalid_beam_schedule_negative_entry(self):
+        with pytest.raises(ValueError):
+            BeamSearchEngine(BeamSearchConfig(beam_schedule=[3, -1]))
 
 
 class TestBeamSearchEngine:
@@ -697,3 +713,85 @@ class TestRankedRootMoves:
         for entry in ranked:
             assert 0.0 <= entry.win_probability <= 1.0
             assert entry.leaf_count > 0
+
+
+class TestBeamSchedule:
+    """Test the depth-dependent beam_schedule config field."""
+
+    def test_unique_canonical_states_per_depth_constant(self):
+        """Sanity-check the published constant against GAME_TREE_ANALYSIS.md."""
+        assert UNIQUE_CANONICAL_STATES_PER_DEPTH[1] == 3
+        assert UNIQUE_CANONICAL_STATES_PER_DEPTH[2] == 51
+        assert UNIQUE_CANONICAL_STATES_PER_DEPTH[3] == 726
+        schedule = [UNIQUE_CANONICAL_STATES_PER_DEPTH[d] for d in (1, 2, 3)] + [64]
+        assert schedule == [3, 51, 726, 64]
+
+    def test_width_resolution_last_entry_extension(self):
+        """Depths beyond the schedule's length reuse its last entry."""
+        config = BeamSearchConfig(beam_schedule=[3, 51, 8])
+        engine = BeamSearchEngine(config)
+        assert engine._beam_width_for_depth(1) == 3
+        assert engine._beam_width_for_depth(2) == 51
+        assert engine._beam_width_for_depth(3) == 8
+        assert engine._beam_width_for_depth(4) == 8
+        assert engine._beam_width_for_depth(5) == 8
+
+    def test_width_resolution_flat_when_no_schedule(self):
+        """Without a schedule, every depth resolves to the flat beam_width."""
+        config = BeamSearchConfig(beam_width=7)
+        engine = BeamSearchEngine(config)
+        assert engine._beam_width_for_depth(1) == 7
+        assert engine._beam_width_for_depth(10) == 7
+
+    def test_schedule_depth_indexing_not_off_by_one(self):
+        """Regression/mutation guard: depth 1 must resolve to schedule[0].
+
+        If `_beam_width_for_depth` used `depth` instead of `depth - 1` (an
+        off-by-one), depth 1 would incorrectly resolve to schedule[1] = 999,
+        keeping all 3 available canonical candidates instead of being capped
+        to schedule[0] = 1.
+        """
+        config = BeamSearchConfig(
+            beam_schedule=[1, 999], max_depth=1, evaluator=lambda s: 0.0, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(State.from_qfen(EMPTY_QFEN))
+        assert len(result.frontier_leaves) == 1
+
+    def test_schedule_flat_equivalent_to_beam_width(self):
+        """A single-entry schedule matches flat beam_width behavior exactly."""
+        state = State.from_qfen(EMPTY_QFEN)
+
+        config_flat = BeamSearchConfig(
+            beam_width=4, max_depth=4, rollouts_per_candidate=2, random_seed=5
+        )
+        result_flat = BeamSearchEngine(config_flat).search(state)
+
+        config_schedule = BeamSearchConfig(
+            beam_schedule=[4], max_depth=4, rollouts_per_candidate=2, random_seed=5
+        )
+        result_schedule = BeamSearchEngine(config_schedule).search(state)
+
+        assert result_flat.stats == result_schedule.stats
+        assert result_flat.max_depth_reached == result_schedule.max_depth_reached
+        assert result_flat.reached_terminal == result_schedule.reached_terminal
+        assert [leaf.moves for leaf in result_flat.terminal_leaves] == [
+            leaf.moves for leaf in result_schedule.terminal_leaves
+        ]
+
+    def test_exhaustive_prefix_no_pruning(self):
+        """A schedule matching each depth's exact unique-canonical count keeps
+        every candidate: nodes_pruned == 0 for a fully exhaustive prefix."""
+        config = BeamSearchConfig(
+            beam_schedule=[3, 51, 726],
+            max_depth=3,
+            evaluator=lambda s: 0.0,
+            random_seed=1,
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(State.from_qfen(EMPTY_QFEN))
+
+        assert result.stats["nodes_pruned"] == 0
+        # 3 + 51 + 726 unique canonical survivors across the three depths
+        # (no wins are possible this early, so nothing is a terminal leaf).
+        assert result.stats["nodes_inserted"] == 3 + 51 + 726

--- a/tests/test_beam_search.py
+++ b/tests/test_beam_search.py
@@ -982,3 +982,89 @@ class TestSymmetryMultiplicity:
             leaf for leaf in terminal_leaves if leaf.value == pytest.approx(-1.0)
         ]
         assert sorted(leaf.multiplicity for leaf in matching_leaves) == [5, 7]
+
+
+class TestRolloutSchedule:
+    """Per-depth rollout budget for the built-in evaluator."""
+
+    def test_default_is_none(self):
+        assert BeamSearchConfig().rollout_schedule is None
+
+    def test_invalid_rollout_schedule_empty(self):
+        with pytest.raises(ValueError):
+            BeamSearchEngine(BeamSearchConfig(rollout_schedule=[]))
+
+    def test_invalid_rollout_schedule_zero_entry(self):
+        with pytest.raises(ValueError):
+            BeamSearchEngine(BeamSearchConfig(rollout_schedule=[2, 0]))
+
+    def test_flat_equivalence_with_rollouts_per_candidate(self):
+        """rollout_schedule=[n] must behave exactly like a flat n."""
+        flat = BeamSearchEngine(
+            BeamSearchConfig(
+                beam_width=4, max_depth=3, rollouts_per_candidate=3, random_seed=5
+            )
+        ).search(State.from_qfen("..../..../..../...."))
+        scheduled = BeamSearchEngine(
+            BeamSearchConfig(
+                beam_width=4,
+                max_depth=3,
+                rollouts_per_candidate=3,
+                rollout_schedule=[3],
+                random_seed=5,
+            )
+        ).search(State.from_qfen("..../..../..../...."))
+
+        assert scheduled.best_leaf is not None and flat.best_leaf is not None
+        assert scheduled.best_leaf.moves == flat.best_leaf.moves
+        assert scheduled.best_leaf.value == pytest.approx(flat.best_leaf.value)
+        assert scheduled.stats == flat.stats
+
+    def test_exact_rollout_count_pins_depth_indexing(self):
+        """beam_schedule=[3,51] + rollout_schedule=[1,5] performs exactly
+        3x1 + 51x5 = 258 playouts; an off-by-one depth indexing would give
+        3x5 + 51x1 = 66 and must fail here."""
+        config = BeamSearchConfig(
+            beam_schedule=[3, 51],
+            max_depth=2,
+            rollout_schedule=[1, 5],
+            random_seed=0,
+        )
+        result = BeamSearchEngine(config).search(State.from_qfen("..../..../..../...."))
+        assert result.stats["evaluations"] == 3 + 51
+        assert result.stats["rollouts"] == 3 * 1 + 51 * 5
+
+    def test_last_entry_extends_to_deeper_levels(self):
+        config = BeamSearchConfig(
+            beam_schedule=[3, 51, 4],
+            max_depth=3,
+            rollout_schedule=[2],
+            random_seed=1,
+        )
+        result = BeamSearchEngine(config).search(State.from_qfen("..../..../..../...."))
+        assert result.stats["rollouts"] == 2 * result.stats["evaluations"]
+
+    def test_custom_evaluator_ignores_rollout_schedule(self):
+        def evaluator(state: State) -> float:
+            return 0.25
+
+        base = BeamSearchConfig(
+            beam_width=4, max_depth=2, evaluator=evaluator, random_seed=9
+        )
+        with_schedule = BeamSearchConfig(
+            beam_width=4,
+            max_depth=2,
+            evaluator=evaluator,
+            rollout_schedule=[7, 7],
+            random_seed=9,
+        )
+        result_a = BeamSearchEngine(base).search(State.from_qfen("..../..../..../...."))
+        result_b = BeamSearchEngine(with_schedule).search(
+            State.from_qfen("..../..../..../....")
+        )
+
+        assert result_a.stats["rollouts"] == 0
+        assert result_b.stats["rollouts"] == 0
+        assert result_a.stats == result_b.stats
+        assert result_a.best_leaf is not None and result_b.best_leaf is not None
+        assert result_a.best_leaf.moves == result_b.best_leaf.moves

--- a/tests/test_beam_search.py
+++ b/tests/test_beam_search.py
@@ -4,7 +4,7 @@ from typing import List
 
 import pytest
 
-from quantik_core import State, apply_move
+from quantik_core import State, apply_move, generate_legal_moves
 from quantik_core.beam_search import BeamSearchConfig, BeamSearchEngine, BeamLeaf
 from quantik_core.mcts import MCTSEngine, MCTSConfig
 from quantik_core.memory.compact_tree import (
@@ -276,6 +276,53 @@ class TestBeamSearchEngine:
             and leaf.moves[0].position == 3
             for leaf in winning_moves
         )
+
+    def test_pruning_uses_mover_relative_score(self):
+        """_score_and_prune must rank candidates mover-relative, not P0-fixed.
+
+        Regression test: with only depth-1 TERMINAL wins exercised elsewhere,
+        a mutant that drops the P1 sign flip (`score = raw_value` instead of
+        `score = raw_value if mover == 0 else -raw_value`) still passes every
+        other test in this file. This fixture forces every depth-1 reply to
+        be NON-terminal, so the survivor must come from the mover-relative
+        ranking in `_score_and_prune`, not from terminal-leaf handling.
+        """
+        # P0 has already placed A at (0,0); it is P1's turn. With only 2
+        # pieces on the board after any reply, no line can be completed, so
+        # every depth-1 candidate is non-terminal.
+        root_state = State.from_qfen("A.../..../..../....")
+        root_player, moves_by_shape = generate_legal_moves(root_state.bb)
+        assert root_player == 1
+        all_moves = [m for ms in moves_by_shape.values() for m in ms]
+        assert len(all_moves) > 1
+
+        # Assign each resulting state a distinct, known P0-perspective value.
+        value_by_bb = {}
+        for i, move in enumerate(all_moves):
+            new_bb = apply_move(root_state.bb, move)
+            value_by_bb[new_bb] = -1.0 + (2.0 * i) / len(all_moves)
+
+        min_value = min(value_by_bb.values())
+        max_value = max(value_by_bb.values())
+        assert min_value != max_value  # sanity: evaluator actually discriminates
+
+        def evaluator(state: State) -> float:
+            return value_by_bb[state.bb]
+
+        config = BeamSearchConfig(
+            beam_width=1, max_depth=1, evaluator=evaluator, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(root_state)
+
+        # P1 is the mover; P1 wants the most negative P0-perspective value.
+        # A correct mover-relative score keeps exactly that survivor. A
+        # P0-fixed (unsigned) score would instead keep the candidate with
+        # max_value, which is what this test guards against.
+        assert result.best_leaf is not None
+        assert not result.best_leaf.is_terminal
+        assert result.best_leaf.value == pytest.approx(min_value)
+        assert result.best_leaf.value != pytest.approx(max_value)
 
     def test_shared_tree_integration(self):
         """Passing an existing CompactGameTree writes terminal data into it."""

--- a/tests/test_beam_search.py
+++ b/tests/test_beam_search.py
@@ -4,8 +4,14 @@ from typing import List
 
 import pytest
 
-from quantik_core import State, apply_move, generate_legal_moves
-from quantik_core.beam_search import BeamSearchConfig, BeamSearchEngine, BeamLeaf
+from quantik_core import State, Move, apply_move, generate_legal_moves
+from quantik_core.beam_search import (
+    BeamSearchConfig,
+    BeamSearchEngine,
+    BeamSearchResult,
+    BeamLeaf,
+    RankedRootMove,
+)
 from quantik_core.mcts import MCTSEngine, MCTSConfig
 from quantik_core.memory.compact_tree import (
     CompactGameTree,
@@ -477,3 +483,217 @@ class TestBeamSearchResultRanking:
         state = State.from_qfen(EMPTY_QFEN)
         result = engine.search(state)
         assert result.best_leaf is not None
+
+
+class TestBeamSearchResultNewFields:
+    """Test the root_player and frontier_leaves result fields."""
+
+    def test_root_player_populated(self):
+        """root_player reflects who is actually to move at the root."""
+        state = State.from_qfen("ABc./..../..../....")  # P1 to move
+        config = BeamSearchConfig(
+            beam_width=2, max_depth=1, rollouts_per_candidate=1, random_seed=1
+        )
+        result = BeamSearchEngine(config).search(state)
+        assert result.root_player == 1
+
+        state0 = State.from_qfen(EMPTY_QFEN)  # P0 to move
+        result0 = BeamSearchEngine(config).search(state0)
+        assert result0.root_player == 0
+
+    def test_frontier_leaves_populated_when_unresolved(self):
+        """frontier_leaves holds the live, non-terminal leaves when max_depth
+        cuts the search short of full resolution."""
+        config = BeamSearchConfig(
+            beam_width=2, max_depth=2, rollouts_per_candidate=1, random_seed=1
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(State.from_qfen(EMPTY_QFEN))
+
+        assert result.reached_terminal is False
+        assert len(result.frontier_leaves) > 0
+        assert all(not leaf.is_terminal for leaf in result.frontier_leaves)
+
+    def test_frontier_leaves_empty_when_resolved(self):
+        """frontier_leaves is empty once every line resolves to a terminal."""
+        config = BeamSearchConfig(
+            beam_width=4, max_depth=16, rollouts_per_candidate=2, random_seed=42
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(State.from_qfen(EMPTY_QFEN))
+
+        assert result.reached_terminal is True
+        assert result.frontier_leaves == []
+
+
+class TestRankedRootMoves:
+    """Test BeamSearchResult.ranked_root_moves() aggregation."""
+
+    def test_aggregation_correctness(self):
+        """Leaves are grouped by first move; stats aggregate correctly."""
+        move_a = Move(player=0, shape=0, position=0)
+        move_b = Move(player=0, shape=1, position=1)
+
+        leaf_a_win = BeamLeaf(
+            moves=(move_a, Move(0, 2, 2)), value=1.0, depth=2, is_terminal=True
+        )
+        leaf_a_live = BeamLeaf(
+            moves=(move_a, Move(0, 3, 3)), value=0.5, depth=2, is_terminal=False
+        )
+        leaf_b = BeamLeaf(moves=(move_b,), value=-0.2, depth=1, is_terminal=False)
+
+        result = BeamSearchResult(
+            best_leaf=None,
+            terminal_leaves=[leaf_a_win],
+            reached_terminal=False,
+            max_depth_reached=2,
+            stats={},
+            root_player=0,
+            frontier_leaves=[leaf_a_live, leaf_b],
+        )
+
+        ranked = result.ranked_root_moves()
+        assert len(ranked) == 2
+        assert all(isinstance(entry, RankedRootMove) for entry in ranked)
+
+        entry_a = next(r for r in ranked if r.move == move_a)
+        assert entry_a.leaf_count == 2
+        assert entry_a.best_value == pytest.approx(1.0)
+        assert entry_a.mean_value == pytest.approx(0.75)
+        assert entry_a.win_probability == pytest.approx(0.875)
+        assert entry_a.has_terminal_win is True
+
+        entry_b = next(r for r in ranked if r.move == move_b)
+        assert entry_b.leaf_count == 1
+        assert entry_b.best_value == pytest.approx(-0.2)
+        assert entry_b.mean_value == pytest.approx(-0.2)
+        assert entry_b.win_probability == pytest.approx(0.4)
+        assert entry_b.has_terminal_win is False
+
+        # move_a strictly dominates on best_value, so it ranks first.
+        assert ranked[0].move == move_a
+        assert ranked[1].move == move_b
+
+    def test_perspective_sign_for_p1_root(self):
+        """ranked_root_moves negates P0-perspective values when root_player == 1.
+
+        Mutation guard: if the root-perspective negation were dropped (using
+        leaf.value as-is instead of flipping it for a P1 root), this test
+        would see best_value == -1.0 instead of +1.0 and fail.
+        """
+        move = Move(player=1, shape=0, position=0)
+        # P0-perspective -1.0 means player 1 (the root mover) actually won.
+        leaf = BeamLeaf(moves=(move,), value=-1.0, depth=1, is_terminal=True)
+
+        result = BeamSearchResult(
+            best_leaf=None,
+            terminal_leaves=[leaf],
+            reached_terminal=True,
+            max_depth_reached=1,
+            stats={},
+            root_player=1,
+            frontier_leaves=[],
+        )
+
+        ranked = result.ranked_root_moves()
+        assert len(ranked) == 1
+        entry = ranked[0]
+        assert entry.best_value == pytest.approx(1.0)
+        assert entry.mean_value == pytest.approx(1.0)
+        assert entry.win_probability == pytest.approx(1.0)
+        assert entry.has_terminal_win is True
+
+    def test_top_k_truncation(self):
+        """top_k truncates the ranked list without changing relative order."""
+        moves = [Move(player=0, shape=i, position=i) for i in range(4)]
+        leaves = [
+            BeamLeaf(moves=(moves[i],), value=i / 3.0, depth=1, is_terminal=False)
+            for i in range(4)
+        ]
+        result = BeamSearchResult(
+            best_leaf=None,
+            terminal_leaves=[],
+            reached_terminal=False,
+            max_depth_reached=1,
+            stats={},
+            root_player=0,
+            frontier_leaves=leaves,
+        )
+
+        ranked_all = result.ranked_root_moves()
+        assert len(ranked_all) == 4
+
+        ranked_top2 = result.ranked_root_moves(top_k=2)
+        assert ranked_top2 == ranked_all[:2]
+
+    def test_sorted_descending_by_best_value(self):
+        """Entries are sorted by best_value (then mean_value, then leaf_count)."""
+        move_high = Move(player=0, shape=0, position=0)
+        move_mid = Move(player=0, shape=1, position=1)
+        move_low = Move(player=0, shape=2, position=2)
+
+        leaves = [
+            BeamLeaf(moves=(move_low,), value=-0.5, depth=1, is_terminal=False),
+            BeamLeaf(moves=(move_high,), value=0.9, depth=1, is_terminal=False),
+            BeamLeaf(moves=(move_mid,), value=0.1, depth=1, is_terminal=False),
+        ]
+        result = BeamSearchResult(
+            best_leaf=None,
+            terminal_leaves=[],
+            reached_terminal=False,
+            max_depth_reached=1,
+            stats={},
+            root_player=0,
+            frontier_leaves=leaves,
+        )
+
+        ranked = result.ranked_root_moves()
+        assert [r.move for r in ranked] == [move_high, move_mid, move_low]
+        values = [r.best_value for r in ranked]
+        assert values == sorted(values, reverse=True)
+
+    def test_win_probability_within_bounds(self):
+        """win_probability always lands in [0, 1], even at value extremes."""
+        for value in (-1.0, 0.0, 1.0):
+            move = Move(player=0, shape=0, position=0)
+            leaf = BeamLeaf(
+                moves=(move,), value=value, depth=1, is_terminal=abs(value) == 1.0
+            )
+            result = BeamSearchResult(
+                best_leaf=None,
+                terminal_leaves=[leaf] if leaf.is_terminal else [],
+                reached_terminal=leaf.is_terminal,
+                max_depth_reached=1,
+                stats={},
+                root_player=0,
+                frontier_leaves=[] if leaf.is_terminal else [leaf],
+            )
+            entry = result.ranked_root_moves()[0]
+            assert 0.0 <= entry.win_probability <= 1.0
+
+    def test_empty_when_no_leaves(self):
+        """ranked_root_moves returns an empty list when nothing was collected."""
+        result = BeamSearchResult(
+            best_leaf=None,
+            terminal_leaves=[],
+            reached_terminal=True,
+            max_depth_reached=0,
+            stats={},
+            root_player=0,
+            frontier_leaves=[],
+        )
+        assert result.ranked_root_moves() == []
+
+    def test_integration_with_real_search(self):
+        """ranked_root_moves works end-to-end on a real search result."""
+        config = BeamSearchConfig(
+            beam_width=4, max_depth=2, rollouts_per_candidate=2, random_seed=7
+        )
+        engine = BeamSearchEngine(config)
+        result = engine.search(State.from_qfen(EMPTY_QFEN))
+
+        ranked = result.ranked_root_moves(top_k=3)
+        assert 0 < len(ranked) <= 3
+        for entry in ranked:
+            assert 0.0 <= entry.win_probability <= 1.0
+            assert entry.leaf_count > 0

--- a/tests/test_beam_search.py
+++ b/tests/test_beam_search.py
@@ -1022,8 +1022,8 @@ class TestRolloutSchedule:
 
     def test_exact_rollout_count_pins_depth_indexing(self):
         """beam_schedule=[3,51] + rollout_schedule=[1,5] performs exactly
-        3x1 + 51x5 = 258 playouts; an off-by-one depth indexing would give
-        3x5 + 51x1 = 66 and must fail here."""
+        3x1 + 51x5 = 258 playouts; an off-by-one depth indexing (e.g.
+        min(depth, len-1)) would give 3x5 + 51x5 = 270 and must fail here."""
         config = BeamSearchConfig(
             beam_schedule=[3, 51],
             max_depth=2,


### PR DESCRIPTION
## Summary

Adds a **parametrizable beam search** (`quantik_core.beam_search`) that complements the existing UCT `MCTSEngine`: it descends level-by-level to **true terminal leaves** (up to the full 16-ply Quantik game) while keeping memory bounded at **O(beam_width × depth)** by reusing the 18-byte `State.pack()` encoding and the 64-byte `CompactGameTree` nodes.

Design spec: `docs/superpowers/specs/2026-07-07-beam-search-design.md` · Docs: `docs/BEAM_SEARCH.md` · Demo: `examples/beam_search_demo.py`

## How it works

Per depth level: expand all frontier children → record terminals (`NODE_FLAG_TERMINAL` / `WINNING_P0/P1`, ±1.0 values, blocked-player-loses rule) → dedup by symmetry-aware `canonical_key()` (21×–10⁵× reduction per `GAME_TREE_ANALYSIS.md`) → score with a pluggable evaluator (default: seeded random rollouts to terminal) ranked **from the mover's perspective** (adversarial) → keep top `beam_width`; **only survivors are inserted** into the tree. Results rank from the root player's perspective and return replayable principal variations.

`BeamSearchConfig`: `beam_width`, `max_depth` (default 16 = full game), `rollouts_per_candidate`, `random_seed` (private RNG, no global seeding), `evaluator`, `initial_tree_capacity`. The engine can share a `CompactGameTree` with `MCTSEngine` (P0-to-move root caveat documented).

## Scope

- New: `src/quantik_core/beam_search.py`, `tests/test_beam_search.py` (25 tests), `examples/beam_search_demo.py`, `docs/BEAM_SEARCH.md`, design/plan docs
- Updated: `README.md`, `docs/EXAMPLES.md`, `CHANGELOG.md`
- **No changes** to `mcts.py`, `compact_tree.py`, `__init__.py`; no new dependencies

## Verification

- `./dev-check.sh` green: **436 passed**, total coverage **90.82%** (new module 100%), mypy + flake8 clean, wheel/sdist build + twine check pass
- Demo runs cleanly end-to-end (~11s)
- Independent review (opus agent) traced adversarial sign logic, terminal handling, memory claims, dedup/transposition interaction; its one blocking finding — the pruning sign was not pinned by any test (proven via mutation) — was fixed with a mutation-killing regression test (`test_pruning_uses_mover_relative_score`), re-verified by re-running the mutant

🤖 Generated with [Claude Code](https://claude.com/claude-code)