### PR TITLE
fix: address five follow-ups from beam search PR review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ All notable changes to `quantik-core` are documented here.
 ### Fixed
 
 - Fixed `examples/beam_search_demo.py`'s move formatting to reflect the actual mover (QFEN convention: uppercase = player 0, lowercase = player 1) instead of always rendering shapes uppercase.
+- Fixed `examples/mcts_demo.py`'s move formatting with the same player-aware convention (it had the identical uppercase-only bug).
+- Fixed `CompactGameTree.create_root_node` to derive `player_turn` from the root state's own piece-count parity instead of hardcoding player 0, so a tree can be correctly rooted at any mid-game (player-1-to-move) state.
+- Fixed `MCTSConfig.use_transposition_table`, which was declared but never consulted: `MCTSEngine._expand` now forwards it to `CompactGameTree.add_child_node`, and passing `False` skips the transposition merge so revisited canonical states always allocate a fresh node.
+- Fixed `auto-lint.sh` failing on a fresh environment by adding the missing `autopep8` dependency to the `dev` extra.
+- Corrected the MCTS throughput claims in `README.md` and `docs/MCTS.md` (previously an unverified 20,000+ iterations/second) to the measured ~150-210 iterations/second for the current pure-Python engine from the empty board.
 
 ## 1.0.0 - 2026-06-22
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ if entry:
 - **Canonicalization**: <1µs per position with precomputed lookup tables
 - **Memory Usage**: 16 bytes per game state + 1MB for transformation LUTs
 - **Serialization**: 18-byte binary format, human-readable QFEN, or self-describing CBOR
-- **MCTS**: 20,000+ iterations/second on modern hardware
+- **MCTS**: ~150-210 iterations/second from the empty board (pure-Python UCT; dominated by per-iteration playout cost, not tree overhead)
 - **Puzzle Generation**: 55,000+ positions/second with dropout optimization
 - **Opening Book**: SQLite backend with canonical deduplication for space efficiency
 

--- a/docs/MCTS.md
+++ b/docs/MCTS.md
@@ -51,7 +51,7 @@ print(f"Memory usage: {stats['memory_usage']} bytes")
 | `max_iterations` | int | 10,000 | Maximum number of MCTS iterations |
 | `max_depth` | int | 16 | Maximum simulation depth |
 | `random_seed` | int\|None | None | Seed for reproducible results |
-| `use_transposition_table` | bool | True | Use existing tree nodes for transpositions |
+| `use_transposition_table` | bool | True | When `False`, expansion always allocates a fresh node instead of merging into an existing node that shares the same canonical state at the same depth |
 
 ### Exploration Weight Tuning
 
@@ -110,11 +110,13 @@ for child_id in children:
 
 ### Iteration Speed
 
-Typical performance on modern hardware:
+Measured on the current pure-Python engine (empty board, `random_seed=42`):
 
-- **Empty board**: 20,000-25,000 iterations/second
-- **Midgame**: 15,000-20,000 iterations/second
-- **Endgame**: 25,000-30,000 iterations/second
+- **Empty board**: ~150-210 iterations/second (2k-5k iteration runs); throughput
+  is dominated by per-iteration random-playout cost, not tree/UCB overhead.
+- Larger runs trend toward the lower end of that range as the tree deepens
+  and playouts lengthen (see `docs/research/2026-07-07-beam-search-vs-mcts.md`
+  §5.4 for iteration counts up to 25k).
 
 ### Memory Usage
 

--- a/docs/MCTS.md
+++ b/docs/MCTS.md
@@ -112,11 +112,12 @@ for child_id in children:
 
 Measured on the current pure-Python engine (empty board, `random_seed=42`):
 
-- **Empty board**: ~150-210 iterations/second (2k-5k iteration runs); throughput
-  is dominated by per-iteration random-playout cost, not tree/UCB overhead.
-- Larger runs trend toward the lower end of that range as the tree deepens
-  and playouts lengthen (see `docs/research/2026-07-07-beam-search-vs-mcts.md`
-  §5.4 for iteration counts up to 25k).
+- **Empty board**: ~150-210 iterations/second (measured over 1k-5k iteration
+  runs; the rate varies run-to-run within this band). Throughput is dominated
+  by per-iteration random-playout cost, not tree/UCB overhead, so it can drift
+  lower on longer runs as the tree deepens and playouts lengthen (see
+  `docs/research/2026-07-07-beam-search-vs-mcts.md` §5.4 for iteration counts
+  up to 25k).
 
 ### Memory Usage
 

--- a/examples/mcts_demo.py
+++ b/examples/mcts_demo.py
@@ -31,11 +31,17 @@ class SearchResult:
 
 
 def format_move(move: Move) -> str:
-    """Format move for display."""
-    shape_name = chr(ord("A") + move.shape)
+    """Format move for display, player-aware.
+
+    QFEN convention: uppercase shape letters are player 0, lowercase are
+    player 1 (see `State.to_qfen`), so the letter case here follows suit.
+    """
+    shape_letter = chr(ord("A") + move.shape)
+    if move.player == 1:
+        shape_letter = shape_letter.lower()
     row = move.position // 4
     col = move.position % 4
-    return f"{shape_name} at ({row}, {col}) [pos {move.position}]"
+    return f"{shape_letter} at ({row}, {col}) [pos {move.position}]"
 
 
 def print_board(state: State):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "types-psutil>=7,<8",
     "build>=1,<2",
     "twine>=6,<7",
+    "autopep8>=2,<3",
 ]
 cbor = [
     "cbor2>=6,<7",

--- a/src/quantik_core/mcts.py
+++ b/src/quantik_core/mcts.py
@@ -234,7 +234,11 @@ class MCTSEngine:
 
             if new_state.canonical_key() not in existing_states:
                 # Add this child
-                child_id = self.tree.add_child_node(node_id, new_state)
+                child_id = self.tree.add_child_node(
+                    node_id,
+                    new_state,
+                    use_transposition_table=self.config.use_transposition_table,
+                )
 
                 # Mark parent as expanded if all moves tried
                 if len(existing_children) + 1 == len(all_moves):

--- a/src/quantik_core/memory/compact_tree.py
+++ b/src/quantik_core/memory/compact_tree.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Tuple
 from dataclasses import dataclass
 import numpy as np
 from quantik_core import State
+from quantik_core.game_utils import count_pieces_by_shape
 
 
 @dataclass
@@ -280,15 +281,26 @@ class CompactGameTree:
         self.root_id: Optional[int] = None
 
     def create_root_node(self, initial_state: State) -> int:
-        """Create the root node from initial game state."""
+        """Create the root node from initial game state.
+
+        player_turn is derived from the state's own piece counts rather
+        than assumed, so the tree can be rooted at any mid-game state
+        (not only the empty board) without corrupting MCTS/beam search
+        turn-relative logic. Uses total-piece parity rather than the
+        strict turn-balance validator so synthetic/terminal states
+        (e.g. constructed directly for tests) don't raise.
+        """
         canonical_state_data = initial_state.pack()
+        player0_counts, player1_counts = count_pieces_by_shape(initial_state.bb)
+        total_pieces = sum(player0_counts) + sum(player1_counts)
+        player_turn = total_pieces % 2
 
         node_id = self.storage.allocate_node_id()
         node = CompactGameTreeNode(
             canonical_state_data=canonical_state_data,
             parent_id=np.uint32(0),  # Root has no parent
             depth=np.uint16(0),
-            player_turn=np.uint8(0),  # Player 0 starts
+            player_turn=np.uint8(player_turn),
             flags=np.uint8(NODE_FLAG_EXPANDED),
             num_children=np.uint16(0),
             first_child_id=np.uint32(0),
@@ -307,20 +319,30 @@ class CompactGameTree:
         return node_id
 
     def add_child_node(
-        self, parent_id: int, child_state: State, multiplicity: int = 1
+        self,
+        parent_id: int,
+        child_state: State,
+        multiplicity: int = 1,
+        use_transposition_table: bool = True,
     ) -> int:
         """Add a child node to the tree with proper transposition table behavior.
 
         If the same canonical state already exists at the target depth,
-        merge multiplicities (transposition table behavior).
+        merge multiplicities (transposition table behavior). Passing
+        use_transposition_table=False skips that lookup entirely, so
+        revisiting the same canonical state always allocates a fresh node.
         """
         parent = self.storage.load_node(parent_id)
         canonical_state_data = child_state.pack()
         target_depth = parent.depth + 1
 
         # Check if this canonical state already exists at the target depth
-        existing_id = self.storage.find_node_by_canonical_state(
-            canonical_state_data, int(target_depth)
+        existing_id = (
+            self.storage.find_node_by_canonical_state(
+                canonical_state_data, int(target_depth)
+            )
+            if use_transposition_table
+            else None
         )
         if existing_id is not None:
             # Transposition found! Update multiplicity of existing node

--- a/tests/test_compact_tree.py
+++ b/tests/test_compact_tree.py
@@ -290,6 +290,22 @@ class TestCompactGameTree:
         assert root_node.parent_id == 0
         assert root_node.flags == NODE_FLAG_EXPANDED
 
+    def test_root_node_creation_derives_player_turn_from_piece_counts(self):
+        """A root state where player 0 has moved once must record player_turn=1.
+
+        create_root_node must not hardcode player_turn=0: a shared tree can be
+        rooted at any mid-game state, and the turn must be derived from the
+        state's own piece counts (P0 total - P1 total) rather than assumed.
+        """
+        tree = CompactGameTree()
+        # P0 placed shape A at position 0; P1 has not moved yet -> P1 to move.
+        p1_to_move_state = State.from_qfen("A.../..../..../....")
+
+        root_id = tree.create_root_node(p1_to_move_state)
+
+        root_node = tree.get_node(root_id)
+        assert root_node.player_turn == 1
+
     def test_child_node_addition(self):
         """Test adding child nodes."""
         tree = CompactGameTree()
@@ -346,6 +362,36 @@ class TestCompactGameTree:
         # Root should still show correct child count
         root_node = tree.get_node(root_id)
         assert root_node.num_children == 1  # Only one unique child
+
+    def test_duplicate_canonical_state_with_transposition_disabled(self):
+        """use_transposition_table=False must skip the merge entirely.
+
+        This is the knob MCTSConfig.use_transposition_table is meant to
+        control end-to-end: with it off, revisiting the same canonical
+        state at the same depth must allocate a distinct node instead of
+        folding into the existing one.
+        """
+        tree = CompactGameTree()
+        initial_state = State.empty()
+        root_id = tree.create_root_node(initial_state)
+        child_state = State.empty()
+
+        child_id1 = tree.add_child_node(
+            root_id, child_state, multiplicity=1, use_transposition_table=False
+        )
+        child_id2 = tree.add_child_node(
+            root_id, child_state, multiplicity=3, use_transposition_table=False
+        )
+
+        assert child_id1 != child_id2
+
+        node1 = tree.get_node(child_id1)
+        node2 = tree.get_node(child_id2)
+        assert node1.multiplicity == 1
+        assert node2.multiplicity == 3
+
+        root_node = tree.get_node(root_id)
+        assert root_node.num_children == 2  # Both children kept distinct
 
     def test_same_canonical_state_different_depths(self):
         """Test that same canonical state at different depths are stored separately."""

--- a/tests/test_examples_demos.py
+++ b/tests/test_examples_demos.py
@@ -1,0 +1,87 @@
+"""Tests for the runnable example scripts under examples/.
+
+These import the demo modules (both are guarded by `if __name__ ==
+"__main__":`, so import has no side effects) and pin the pure
+formatting helpers they expose, so display bugs like ignoring
+`move.player` don't silently regress.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from quantik_core import Move
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
+
+
+def _load_demo_module(filename: str):
+    module_name = f"_examples_{filename.removesuffix('.py')}"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, EXAMPLES_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mcts_demo():
+    return _load_demo_module("mcts_demo.py")
+
+
+@pytest.fixture(scope="module")
+def beam_search_demo():
+    return _load_demo_module("beam_search_demo.py")
+
+
+class TestMCTSDemoFormatMove:
+    """Pins the player-0/player-1 QFEN case convention for mcts_demo.py."""
+
+    def test_player_0_move_is_uppercase(self, mcts_demo):
+        move = Move(player=0, shape=0, position=1)
+
+        formatted = mcts_demo.format_move(move)
+
+        assert formatted.startswith("A ")
+        assert "a " not in formatted
+
+    def test_player_1_move_is_lowercase(self, mcts_demo):
+        move = Move(player=1, shape=1, position=11)
+
+        formatted = mcts_demo.format_move(move)
+
+        # Mutation guard: prior to the fix this always rendered "B",
+        # ignoring move.player entirely.
+        assert formatted.startswith("b ")
+        assert "B " not in formatted
+
+    def test_includes_row_col_and_position(self, mcts_demo):
+        move = Move(player=0, shape=2, position=11)
+
+        formatted = mcts_demo.format_move(move)
+
+        assert "(2, 3)" in formatted
+        assert "[pos 11]" in formatted
+
+
+class TestBeamSearchDemoFormatMove:
+    """Same convention, pinned for the sibling demo (regression guard)."""
+
+    def test_player_0_move_is_uppercase(self, beam_search_demo):
+        move = Move(player=0, shape=0, position=1)
+
+        formatted = beam_search_demo.format_move(move)
+
+        assert "P0 A " in formatted
+
+    def test_player_1_move_is_lowercase(self, beam_search_demo):
+        move = Move(player=1, shape=1, position=11)
+
+        formatted = beam_search_demo.format_move(move)
+
+        assert "P1 b " in formatted

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -407,6 +407,44 @@ class TestMCTSEngine:
         assert node.flags & NODE_FLAG_WINNING_P0
         assert float(node.terminal_value) == pytest.approx(1.0)
 
+    def test_expand_stalemate_at_p1_rooted_tree_attributes_p0_win(self):
+        """Rooting directly at a P1-to-move state must attribute the win correctly.
+
+        Integration guard for the create_root_node player_turn derivation:
+        the tree is rooted at a state where player 0 has already moved once
+        (so player 1 is to move), and player 1 is then blocked. The blocked
+        player loses, so player 0 must be recorded as the winner.
+
+        This exercises the fix's downstream consequence, not just the
+        isolated derivation: if create_root_node reverted to hardcoding
+        player_turn=0, the root would be treated as player-0-to-move and
+        the stalemate would be mis-attributed as a player-1 win, flipping
+        both the winning flag and the terminal value. The sibling
+        test_expand_stalemate_player1_loses cannot catch that regression
+        because it reaches player_turn==1 via a child of the root rather
+        than the root itself.
+        """
+        config = MCTSConfig(random_seed=42)
+        engine = MCTSEngine(config)
+
+        # Player 0 has placed one piece -> player 1 is to move at the root.
+        state = State.from_qfen("A.../..../..../....")
+        root_id = engine.tree.create_root_node(state)
+        assert int(engine.tree.get_node(root_id).player_turn) == 1
+
+        with (
+            patch("quantik_core.mcts.check_game_winner", return_value=WinStatus.NO_WIN),
+            patch("quantik_core.mcts.generate_legal_moves", return_value=(1, {})),
+        ):
+            result = engine._expand(root_id)
+
+        assert result is None
+        node = engine.tree.get_node(root_id)
+        assert node.flags & NODE_FLAG_TERMINAL
+        assert node.flags & NODE_FLAG_WINNING_P0
+        assert not (node.flags & NODE_FLAG_WINNING_P1)
+        assert float(node.terminal_value) == pytest.approx(1.0)
+
     def test_simulate_stalemate_player0(self):
         """Test _simulate returns correct value when player 0 has no moves."""
         config = MCTSConfig(max_depth=16, random_seed=42)

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -185,6 +185,41 @@ class TestMCTSEngine:
         assert child.depth == 1
         assert child.parent_id == root_id
 
+    def test_expand_wires_use_transposition_table_enabled(self):
+        """_expand must forward config.use_transposition_table to the tree.
+
+        MCTSConfig.use_transposition_table was previously declared but never
+        consulted; this pins that _expand actually threads it through to
+        CompactGameTree.add_child_node rather than silently always merging.
+        """
+        config = MCTSConfig(random_seed=42, use_transposition_table=True)
+        engine = MCTSEngine(config)
+        state = State.from_qfen("..../..../..../....")
+        root_id = engine.tree.create_root_node(state)
+
+        with patch.object(
+            engine.tree, "add_child_node", wraps=engine.tree.add_child_node
+        ) as spy:
+            engine._expand(root_id)
+
+        spy.assert_called_once()
+        assert spy.call_args.kwargs["use_transposition_table"] is True
+
+    def test_expand_wires_use_transposition_table_disabled(self):
+        """Mutation guard: flipping the config value must flip the call arg."""
+        config = MCTSConfig(random_seed=42, use_transposition_table=False)
+        engine = MCTSEngine(config)
+        state = State.from_qfen("..../..../..../....")
+        root_id = engine.tree.create_root_node(state)
+
+        with patch.object(
+            engine.tree, "add_child_node", wraps=engine.tree.add_child_node
+        ) as spy:
+            engine._expand(root_id)
+
+        spy.assert_called_once()
+        assert spy.call_args.kwargs["use_transposition_table"] is False
+
     def test_simulation(self):
         """Test random simulation."""
         config = MCTSConfig(max_depth=8, random_seed=42)


### PR DESCRIPTION
## Summary

Cleans up the five documented follow-ups left out of scope in #15:

- `CompactGameTree.create_root_node` hardcoded `player_turn=0` — now derives it from the root state's piece-count parity, so a shared tree can be correctly rooted at any mid-game (P1-to-move) state instead of silently corrupting turn-relative MCTS/beam logic.
- `MCTSConfig.use_transposition_table` was declared but never consulted — `MCTSEngine._expand` now forwards it to `CompactGameTree.add_child_node` (which gained a matching parameter); disabling it skips the transposition merge so revisited canonical states always get a fresh node.
- `examples/mcts_demo.py`'s `format_move` had the same uppercase-only bug already fixed in `beam_search_demo.py` (f49922a) — now player-aware per the QFEN case convention.
- `auto-lint.sh` called `autopep8`, which wasn't in the `dev` extra — added it, verified a clean env run works end-to-end.
- README/`docs/MCTS.md` claimed 20,000+ iterations/second for MCTS; re-measured on the current pure-Python engine from the empty board and it's ~150-210 iters/s. Docs now state the measured number.

## Test plan

- [x] New/updated unit tests are TDD'd (red confirmed before each fix): `tests/test_compact_tree.py` (root player_turn derivation + transposition-disabled behavior), `tests/test_mcts.py` (transposition wiring, mutation-style spy on the call kwarg), `tests/test_examples_demos.py` (new — pins both demos' `format_move` player-case convention).
- [x] Full suite: `pytest tests/ -q` → 479 passed.
- [x] `mypy src/` → no issues.
- [x] `flake8` → clean.
- [x] `./dev-check.sh` → full gate (tests + coverage 91.22% + black + flake8 + mypy + build + twine check) passes end-to-end.
- [x] `./auto-lint.sh` → runs clean now that `autopep8` is installable from the `dev` extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8MwB84fm8RhK7zkUKBnUw