### PR TITLE
feat(tuning): exact-solver opening-book filler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,10 @@ qfen_validation_results.txt
 
 # Tuning dataset (regenerable via tuning/build_dataset.py)
 tuning/dataset.npz
+
+# Opening book databases (regenerable via tuning/fill_opening_book.py).
+# WAL-mode SQLite (OpeningBookConfig.enable_wal=True) also leaves -shm/-wal
+# sidecar files alongside the main .db.
+*.db
+*.db-shm
+*.db-wal

--- a/docs/OPENING_BOOK.md
+++ b/docs/OPENING_BOOK.md
@@ -298,6 +298,40 @@ def build_opening_book(db, max_depth=5):
     return len(positions)
 ```
 
+## Filling with Exact Solver Ground Truth
+
+The self-play exploration above records *statistical* estimates (`evaluation`
+computed by walking the raw tree, `best_moves` taken from move-generation
+order rather than actual strength). `tuning/fill_opening_book.py` instead
+writes **exact** entries: it samples positions that are tractable to solve
+outright with `quantik_core.minimax.MinimaxEngine` (8–12 plies in, where a
+full solve is fast — see `docs/MINIMAX.md`'s "three depths" section) and
+records the solver's true game-theoretic value, winner, and best move. Since
+the book is keyed by `canonical_key()` and is engine-agnostic, these entries
+upgrade what MCTS and beam search read for those positions from an estimate
+to ground truth.
+
+```python
+from quantik_core.opening_book import OpeningBookConfig, OpeningBookDatabase
+from tuning.fill_opening_book import fill
+
+with OpeningBookDatabase(OpeningBookConfig(database_path="quantik_opening_book.db")) as db:
+    written = fill(db, n=300, seed=20260710)
+    print(f"wrote {written} exact entries")
+```
+
+Or from the command line:
+
+```bash
+python -m tuning.fill_opening_book   # writes quantik_opening_book.db
+```
+
+The `evaluation` convention here is the **side-to-move's** perspective
+(`+1.0` win / `-1.0` loss — Quantik has no draws), not the fixed P0
+perspective used by the self-play example above; check `evaluation`
+alongside `win_count_p0`/`win_count_p1`, which are always in absolute
+P0/P1 terms, if you need to compare the two.
+
 ## Statistics and Analytics
 
 ### Database Statistics

--- a/docs/OPENING_BOOK.md
+++ b/docs/OPENING_BOOK.md
@@ -332,6 +332,19 @@ perspective used by the self-play example above; check `evaluation`
 alongside `win_count_p0`/`win_count_p1`, which are always in absolute
 P0/P1 terms, if you need to compare the two.
 
+**Note on the no-legal-moves case:** this filler encodes a no-legal-moves
+position as a **win for the opponent** (`is_terminal=WIN_P0`/`WIN_P1`,
+`draw_count=0`), matching `Board.get_game_result()` (the authoritative
+game-rules implementation, which is explicit that "if a player has no
+legal moves, the other player wins") and `MinimaxEngine`'s own `_negamax`
+convention. The "Building from Game Tree" self-play example above and
+`examples/generate_opening_book.py` both instead encode this as
+`TerminalStatus.STALEMATE`/a draw (`draw_count=1`) — Quantik has no
+draws, so that appears to be a pre-existing bug in those examples rather
+than a legitimate alternate convention. If you mix entries from both
+sources in the same database, `is_terminal`/`draw_count` will not be
+self-consistent for no-legal-moves positions.
+
 ## Statistics and Analytics
 
 ### Database Statistics

--- a/docs/superpowers/plans/2026-07-10-cross-engine-0-INDEX.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-0-INDEX.md
@@ -8,7 +8,7 @@ other — though the suggested order below front-loads the cheapest wins.
 | # | Plan | Scope | Coverage gate? | Rough size | Status |
 |---|------|-------|----------------|-----------|--------|
 | 1 | `...cross-engine-1-midgame-benchmark.md` | Example + smoke test only (`examples/cross_engine_benchmark.py`) | No (examples not measured) | Small | ✅ Done (branch `feat/cross-engine-midgame-benchmark`) |
-| 2 | `...cross-engine-2-opening-book-filler.md` | Tool + tests (`tuning/fill_opening_book.py`) | No | Small–medium | Not started |
+| 2 | `...cross-engine-2-opening-book-filler.md` | Tool + tests (`tuning/fill_opening_book.py`) | No | Small–medium | ✅ Done (branch `feat/cross-engine-opening-book-filler`) |
 | 3 | `...cross-engine-3-eval-guided-mcts.md` | **Library change** (`src/quantik_core/mcts.py`) | **Yes — ./dev-check.sh, ≥90%** | Medium | Not started |
 | 4 | `...cross-engine-4-hybrid-player.md` | **New library module** (`src/quantik_core/hybrid.py`) | **Yes — ./dev-check.sh, ≥90%** | Medium | Not started |
 

--- a/docs/superpowers/plans/2026-07-10-cross-engine-2-opening-book-filler.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-2-opening-book-filler.md
@@ -36,7 +36,7 @@
 
 **Convention (document in the module docstring):** the book `evaluation` is stored from the **side-to-move's** perspective: `+1.0` if the side to move wins with perfect play, `-1.0` if it loses. `win_count_p0/p1` record the exact winner as a single ground-truth "game".
 
-- [ ] **Step 1: Write failing tests**:
+- [x] **Step 1: Write failing tests**:
 
 ```python
 import numpy as np  # noqa: F401  (parity with repo style; remove if unused)
@@ -75,9 +75,9 @@ def test_fill_writes_and_is_idempotent(tmp_path):
         fill(db, n=15, seed=1)
 ```
 
-- [ ] **Step 2: Run, verify fail** — `.venv/bin/pytest tests/test_opening_book_filler.py -x --no-cov`. Ensure `tuning/` is importable (a `tuning/__init__.py` already exists from the minimax feature).
+- [x] **Step 2: Run, verify fail** — `.venv/bin/pytest tests/test_opening_book_filler.py -x --no-cov`. Ensure `tuning/` is importable (a `tuning/__init__.py` already exists from the minimax feature).
 
-- [ ] **Step 3: Implement `tuning/fill_opening_book.py`.** Full content:
+- [x] **Step 3: Implement `tuning/fill_opening_book.py`.** Full content:
 
 ```python
 """Fill the shared opening book with EXACT minimax-solved entries.
@@ -157,11 +157,11 @@ if __name__ == "__main__":
     main()
 ```
 
-- [ ] **Step 4: Run tests, verify pass** — `.venv/bin/pytest tests/test_opening_book_filler.py -v --no-cov`.
+- [x] **Step 4: Run tests, verify pass** — `.venv/bin/pytest tests/test_opening_book_filler.py -v --no-cov`.
 
-- [ ] **Step 5: Smoke-run** — `.venv/bin/python tuning/fill_opening_book.py` with a small `n` (edit call or run `python -c "from tuning.fill_opening_book import main; main(n=30)"`). Confirm it writes a DB and prints a count. Do NOT commit the `.db` file — add `*.db` to `.gitignore` if not already ignored (`grep -q '\.db' .gitignore || echo '*.db' >> .gitignore`).
+- [x] **Step 5: Smoke-run** — `.venv/bin/python tuning/fill_opening_book.py` with a small `n` (edit call or run `python -c "from tuning.fill_opening_book import main; main(n=30)"`). Confirm it writes a DB and prints a count. Do NOT commit the `.db` file — add `*.db` to `.gitignore` if not already ignored (`grep -q '\.db' .gitignore || echo '*.db' >> .gitignore`).
 
-- [ ] **Step 6: Lint + commit** — `./auto-lint.sh`; `git add tuning/fill_opening_book.py tests/test_opening_book_filler.py .gitignore`; commit `feat(tuning): exact-solver opening-book filler`.
+- [x] **Step 6: Lint + commit** — `./auto-lint.sh`; `git add tuning/fill_opening_book.py tests/test_opening_book_filler.py .gitignore`; commit `feat(tuning): exact-solver opening-book filler`.
 
 ---
 
@@ -170,3 +170,31 @@ if __name__ == "__main__":
 - `evaluation` perspective documented (side-to-move) and consistent with `win_count_*`.
 - No `.db` artifact committed.
 - Optional extension (note in the module, do not implement unless asked): store the FULL optimal-move set instead of just `result.best_move`, by solving each child (more expensive).
+
+## Post-implementation notes
+
+Both plan test anchors reused the SAME `"AbC./..../..../...."` position
+already found to be intractable in follow-up 1: `exact_entry()` calls
+`MinimaxEngine.solve()` on the **root** itself (not a child), and
+`_search_root` deliberately does not prune across root siblings, so a
+near-empty root requires exhaustively evaluating ~40 non-winning branches
+from the intractable early game (timed out after 30s, never completed).
+Replaced with a deep (12-piece) P0-to-move anchor with a single forced
+win-in-1 (`"ad.b/.cDb/CaBC/D.A."`, solves in 0.58s); the second anchor
+(a pre-existing 8-piece forced-loss-in-4 position from
+`tests/test_minimax.py`) was already fine.
+
+Proactively applied the script-mode import fallback pattern from
+`fit_weights.py` (a PR #17 review finding) to `fill_opening_book.py`
+before it could recur as its own finding, and added `*.db`/`*.db-shm`/
+`*.db-wal` to `.gitignore` (the opening book's default WAL mode leaves
+sidecar files alongside the main `.db`).
+
+Verified both invocation modes end-to-end: `python -m tuning.fill_opening_book`
+and `python tuning/fill_opening_book.py` (script mode, exercising the
+fallback import) both wrote 300 entries in ~119s.
+
+Documented the tool in `docs/OPENING_BOOK.md` under a new "Filling with
+Exact Solver Ground Truth" section, distinguishing its ground-truth
+`evaluation` convention (side-to-move perspective) from the pre-existing
+self-play example's fixed-P0 convention.

--- a/docs/superpowers/plans/2026-07-10-cross-engine-2-opening-book-filler.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-2-opening-book-filler.md
@@ -198,3 +198,35 @@ Documented the tool in `docs/OPENING_BOOK.md` under a new "Filling with
 Exact Solver Ground Truth" section, distinguishing its ground-truth
 `evaluation` convention (side-to-move perspective) from the pre-existing
 self-play example's fixed-P0 convention.
+
+A GitHub Copilot review of the resulting PR (#19) found four more issues
+across four rounds:
+- `exact_entry()` called `.solve()` unconditionally, without handling a
+  terminal `bb` itself (a completed winning line, or no legal moves) --
+  `search()` raises on the latter and mis-scores the former. Fixed by
+  scoring both cases directly (the side to move has already lost),
+  matching `_negamax`'s convention. Added two regression tests, verified
+  both fail against the pre-fix code.
+- Untyped `exact_entry()` params/return and a redundant dict comprehension
+  in the test -- both cleaned up.
+- `fill()` allocated a fresh `MinimaxEngine` per position instead of
+  reusing one (same pattern as `optimal_moves()` in PR #18) -- fixed by
+  adding an optional `engine` param to `exact_entry()`. Also corrected
+  `fill()`'s docstring: `sample_states()` can return fewer than `n`.
+- **A genuine repo-wide convention conflict**, not a bug in this PR:
+  `exact_entry()` encodes a no-legal-moves position as a win for the
+  opponent (`draw_count=0`), while `examples/opening_book_demo.py` and
+  `examples/generate_opening_book.py` both encode the same case as
+  `TerminalStatus.STALEMATE`/a draw. Verified against the authoritative
+  source, `Board.get_game_result()` in `src/quantik_core/board.py`:
+  "If a player has no legal moves, the other player wins" -- and
+  `WinStatus` has no draw member at all. Kept `exact_entry()`'s correct
+  encoding and documented the discrepancy prominently (in the function
+  docstring and `docs/OPENING_BOOK.md`) rather than silently matching
+  what appears to be a pre-existing bug in those two examples; fixing
+  them is out of scope for this PR.
+
+A GitHub Copilot coding-agent execution request (posted as a PR comment)
+ran `main(n=3000, seed=20260710)` and reported back: 3000 entries written
+in 1568.4s (~26 min, before the engine-reuse fix above), `quantik_opening_book.db`
+at 584K.

--- a/docs/superpowers/plans/2026-07-10-cross-engine-2-opening-book-filler.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-2-opening-book-filler.md
@@ -230,3 +230,34 @@ A GitHub Copilot coding-agent execution request (posted as a PR comment)
 ran `main(n=3000, seed=20260710)` and reported back: 3000 entries written
 in 1568.4s (~26 min, before the engine-reuse fix above), `quantik_opening_book.db`
 at 584K.
+
+Six more review rounds followed (10 total). Round 5 found real fixes worth
+noting:
+- A `black --check` CI failure that a local `./auto-lint.sh` run had
+  (apparently stalely) reported clean -- since re-verified explicitly
+  with `black --check .` before every subsequent commit in this PR and
+  the two that followed it.
+- **The most severe finding of the review**: `exact_entry()` treated any
+  empty `generate_legal_moves_list(bb)` as a legitimate no-legal-moves
+  terminal, but that function also returns `[]` for a genuinely
+  **invalid** bitboard (piece overlap, turn-balance violation, illegal
+  placement) -- there was no way to tell the two apart. Confirmed
+  concretely: the pre-fix code, given an overlapping-piece board with a
+  piece count that looked superficially balanced (2 vs 1, so the old
+  `get_current_player_from_counts()`-only check didn't catch it),
+  silently returned `win_count_p0=1` -- fabricating a decided game result
+  from invalid input. Fixed by calling `validate_game_state(bb,
+  raise_on_error=True)` up front, which also supplies the authoritative
+  side-to-move (now threaded into `generate_legal_moves_list`'s
+  `player_id` too). Added a regression test using this exact scenario.
+
+Rounds 6-10 were minor: an `assert`-under-`python -O` idiom fix (assert
+is stripped in optimized runs, so replaced with an explicit `RuntimeError`
+guard), two docstring line-wrap cosmetic fixes, a docstring wording
+clarification (`best_moves` is a list, not a single move), and a test-
+completeness suggestion (asserting `win_count_*`/`is_terminal` in the
+no-legal-moves regression test, not just `evaluation`) -- all applied
+since they were cheap, even though the last few were closer to
+diminishing returns than earlier rounds. The review loop was capped at
+10 rounds by deliberate choice, not because round 10 ran out of findings
+on its own.

--- a/tests/test_opening_book_filler.py
+++ b/tests/test_opening_book_filler.py
@@ -1,6 +1,10 @@
 from quantik_core import State
 from tuning.fill_opening_book import exact_entry, fill
-from quantik_core.opening_book import OpeningBookConfig, OpeningBookDatabase
+from quantik_core.opening_book import (
+    OpeningBookConfig,
+    OpeningBookDatabase,
+    TerminalStatus,
+)
 
 # A deep (12-piece) P0-to-move anchor with a single forced win-in-1 (B at
 # pos 13), NOT the plan's original "AbC./..../..../...." (3 pieces placed):
@@ -26,6 +30,29 @@ def test_exact_entry_loss_for_side_to_move():
     e = exact_entry(State.from_qfen(".D.a/D..c/..d./.BBd").bb)
     assert e["evaluation"] == -1.0
     assert e["win_count_p1"] == 1 and e["win_count_p0"] == 0
+
+
+def test_exact_entry_handles_completed_winning_line_without_solving():
+    # Regression: MinimaxEngine.solve/search assume a non-terminal root.
+    # This board's row 0 already completed a winning line (by the
+    # PREVIOUS mover); calling solve() on it either mis-scores it as an
+    # interior node or raises. P0 (the side to move here) has already
+    # lost -- exact_entry must recognize this directly.
+    bb = State.from_qfen("AbCd/..../..../....").bb
+    e = exact_entry(bb)
+    assert e["evaluation"] == -1.0
+    assert e["win_count_p1"] == 1 and e["win_count_p0"] == 0
+    assert e["best_moves"] == []
+    assert e["is_terminal"] == TerminalStatus.WIN_P1
+
+
+def test_exact_entry_handles_no_legal_moves_without_solving():
+    # Regression, the other terminal condition: no winning line, but the
+    # side to move has zero legal moves (search() raises on this).
+    bb = State.from_qfen(".DbC/c.ab/cD.a/AA.C").bb
+    e = exact_entry(bb)
+    assert e["evaluation"] == -1.0
+    assert e["best_moves"] == []
 
 
 def test_fill_writes_and_is_idempotent(tmp_path):

--- a/tests/test_opening_book_filler.py
+++ b/tests/test_opening_book_filler.py
@@ -1,4 +1,7 @@
+import pytest
+
 from quantik_core import State
+from quantik_core.commons import ValidationError
 from tuning.fill_opening_book import exact_entry, fill
 from quantik_core.opening_book import (
     OpeningBookConfig,
@@ -53,6 +56,20 @@ def test_exact_entry_handles_no_legal_moves_without_solving():
     e = exact_entry(bb)
     assert e["evaluation"] == -1.0
     assert e["best_moves"] == []
+
+
+def test_exact_entry_raises_on_invalid_bitboard():
+    # Regression: generate_legal_moves_list() returns [] for BOTH a
+    # genuine no-legal-moves terminal AND an invalid bitboard -- that
+    # check alone can't tell them apart. Two P0 shapes overlapping on
+    # cell 0, with one P1 piece elsewhere so the piece-count TURN BALANCE
+    # alone looks superficially valid (2 vs 1) and wouldn't have raised
+    # via the old get_current_player_from_counts() check either -- only
+    # full validation (piece overlap) catches this. An invalid bb must
+    # raise, not silently be written to the book as a bogus terminal win.
+    overlapping_bb = (0b1, 0b1, 0, 0, 0b10, 0, 0, 0)
+    with pytest.raises(ValidationError):
+        exact_entry(overlapping_bb)
 
 
 def test_fill_writes_and_is_idempotent(tmp_path):

--- a/tests/test_opening_book_filler.py
+++ b/tests/test_opening_book_filler.py
@@ -51,11 +51,13 @@ def test_exact_entry_handles_completed_winning_line_without_solving():
 
 def test_exact_entry_handles_no_legal_moves_without_solving():
     # Regression, the other terminal condition: no winning line, but the
-    # side to move has zero legal moves (search() raises on this).
+    # side to move (P0) has zero legal moves (search() raises on this).
     bb = State.from_qfen(".DbC/c.ab/cD.a/AA.C").bb
     e = exact_entry(bb)
     assert e["evaluation"] == -1.0
     assert e["best_moves"] == []
+    assert e["win_count_p0"] == 0 and e["win_count_p1"] == 1
+    assert e["is_terminal"] == TerminalStatus.WIN_P1
 
 
 def test_exact_entry_raises_on_invalid_bitboard():

--- a/tests/test_opening_book_filler.py
+++ b/tests/test_opening_book_filler.py
@@ -1,0 +1,43 @@
+from quantik_core import State
+from tuning.fill_opening_book import exact_entry, fill
+from quantik_core.opening_book import OpeningBookConfig, OpeningBookDatabase
+
+# A deep (12-piece) P0-to-move anchor with a single forced win-in-1 (B at
+# pos 13), NOT the plan's original "AbC./..../..../...." (3 pieces placed):
+# exact_entry() solves the ROOT itself at max_depth=16, and MinimaxEngine's
+# _search_root deliberately does not prune across root siblings (see
+# minimax.py), so a near-empty root requires exhaustively solving ~40
+# non-winning branches from an intractable early-game position -- measured
+# to exceed 30s (never completed) on the plan's original anchor, vs. 0.58s
+# here.
+_WIN_ANCHOR = "ad.b/.cDb/CaBC/D.A."
+
+
+def test_exact_entry_win_for_side_to_move():
+    e = exact_entry(State.from_qfen(_WIN_ANCHOR).bb)
+    assert e["evaluation"] == 1.0
+    assert e["win_count_p0"] == 1 and e["win_count_p1"] == 0
+    assert (1, 13) in [(m.shape, m.position) for m in e["best_moves"]]  # B at pos 13
+
+
+def test_exact_entry_loss_for_side_to_move():
+    # A position where the side to move (P0) is lost (8 pieces placed --
+    # reused from tests/test_minimax.py's forced-loss-in-4 anchor).
+    e = exact_entry(State.from_qfen(".D.a/D..c/..d./.BBd").bb)
+    assert e["evaluation"] == -1.0
+    assert e["win_count_p1"] == 1 and e["win_count_p0"] == 0
+
+
+def test_fill_writes_and_is_idempotent(tmp_path):
+    db_path = str(tmp_path / "book.db")
+    cfg = OpeningBookConfig(database_path=db_path)
+    with OpeningBookDatabase(cfg) as db:
+        n1 = fill(db, n=15, seed=1)
+        assert n1 > 0
+        sample = State.from_qfen(_WIN_ANCHOR)
+        db.add_position(sample, **{k: v for k, v in exact_entry(sample.bb).items()})
+        entry = db.get_position(sample)
+        assert entry is not None and entry.evaluation == 1.0
+    # Reopen and re-fill: must not error (upsert).
+    with OpeningBookDatabase(cfg) as db:
+        fill(db, n=15, seed=1)

--- a/tests/test_opening_book_filler.py
+++ b/tests/test_opening_book_filler.py
@@ -62,7 +62,7 @@ def test_fill_writes_and_is_idempotent(tmp_path):
         n1 = fill(db, n=15, seed=1)
         assert n1 > 0
         sample = State.from_qfen(_WIN_ANCHOR)
-        db.add_position(sample, **{k: v for k, v in exact_entry(sample.bb).items()})
+        db.add_position(sample, **exact_entry(sample.bb))
         entry = db.get_position(sample)
         assert entry is not None and entry.evaluation == 1.0
     # Reopen and re-fill: must not error (upsert).

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -17,11 +17,7 @@ from typing import Dict, List, Optional, Union
 
 from quantik_core import Move, State
 from quantik_core.commons import Bitboard
-from quantik_core.game_utils import (
-    count_total_pieces,
-    get_current_player_from_counts,
-    has_winning_line,
-)
+from quantik_core.game_utils import count_total_pieces, has_winning_line
 from quantik_core.minimax import MinimaxConfig, MinimaxEngine
 from quantik_core.move import generate_legal_moves_list
 from quantik_core.opening_book import (
@@ -29,6 +25,7 @@ from quantik_core.opening_book import (
     OpeningBookDatabase,
     TerminalStatus,
 )
+from quantik_core.state_validator import validate_game_state
 
 try:
     from tuning.build_dataset import sample_states
@@ -75,10 +72,20 @@ def exact_entry(
     examples appear to carry a pre-existing bug; fixing them is out of
     scope for this change, but a reader comparing conventions across the
     opening-book-writing code in this repo should not assume they agree.
+
+    Raises `ValidationError` for an invalid `bb` (piece-count/overlap/
+    turn-balance/placement violations) rather than treating it as a
+    terminal loss: `generate_legal_moves_list` returns an empty list for
+    BOTH a genuine no-legal-moves terminal AND an invalid bitboard, so
+    that check alone can't tell them apart -- validating up front lets
+    invalid input fail loudly instead of silently writing a bogus
+    terminal-win entry into the database.
     """
+    stm, _ = validate_game_state(bb, raise_on_error=True)
     p0, p1 = count_total_pieces(bb)
-    stm = get_current_player_from_counts(p0, p1)
-    already_decided = has_winning_line(bb) or not generate_legal_moves_list(bb)
+    already_decided = has_winning_line(bb) or not generate_legal_moves_list(
+        bb, player_id=stm
+    )
     if already_decided:
         stm_wins = False
         best_moves: List[Move] = []

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -53,16 +53,16 @@ def exact_entry(
     `MinimaxEngine.solve`/`search` assume a non-terminal root: a
     no-legal-moves position raises, and a position with an already-completed
     winning line (but empty cells remaining, so `search` wouldn't raise) is
-    silently mis-scored -- treated as an interior node instead of an already
-    -decided one. `sample_states()` filters these out, but `exact_entry` is
-    a public, reusable mapping function, so a terminal `bb` (either
-    condition) is handled directly here instead of being solved: the side
-    to move has already lost, matching the convention `_negamax` uses
-    throughout `minimax.py`.
+    silently mis-scored -- treated as an interior node instead of an
+    already-decided one. `sample_states()` filters these out, but
+    `exact_entry` is a public, reusable mapping function, so a terminal
+    `bb` (either condition) is handled directly here instead of being
+    solved: the side to move has already lost, matching the convention
+    `_negamax` uses throughout `minimax.py`.
 
     A no-legal-moves position is scored as a WIN for the opponent here
-    (`is_terminal=WIN_P0`/`WIN_P1`, `draw_count=0`), NOT `TerminalStatus
-    .STALEMATE`/a draw. This intentionally diverges from
+    (`is_terminal=WIN_P0`/`WIN_P1`, `draw_count=0`), NOT
+    `TerminalStatus.STALEMATE`/a draw. This intentionally diverges from
     `examples/opening_book_demo.py` and `examples/generate_opening_book.py`,
     which both encode no-legal-moves as a draw -- but `board.py`'s own
     `Board.get_game_result()` (the authoritative game-rules implementation)

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -42,7 +42,8 @@ def exact_entry(
     """Solve `bb` exactly and return kwargs for `add_position` (minus `state`).
 
     `evaluation` is +1.0 if the side to move wins with perfect play, else
-    -1.0 (Quantik has no draws). `best_moves` is the solver's best move.
+    -1.0 (Quantik has no draws). `best_moves` is a single-element list
+    holding the solver's best move (empty for an already-terminal `bb`).
 
     `engine` lets a caller solving many positions (e.g. `fill()`'s loop)
     reuse one `MinimaxEngine` instead of paying a fresh allocation per

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -13,7 +13,7 @@ python tuning/fill_opening_book.py -> writes quantik_opening_book.db
 
 from __future__ import annotations
 
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from quantik_core import Move, State
 from quantik_core.commons import Bitboard
@@ -39,11 +39,19 @@ except ImportError:
     from build_dataset import sample_states  # type: ignore[import-not-found]
 
 
-def exact_entry(bb: Bitboard) -> Dict[str, Union[float, int, List[Move]]]:
+def exact_entry(
+    bb: Bitboard, engine: Optional[MinimaxEngine] = None
+) -> Dict[str, Union[float, int, List[Move]]]:
     """Solve `bb` exactly and return kwargs for `add_position` (minus `state`).
 
     `evaluation` is +1.0 if the side to move wins with perfect play, else
     -1.0 (Quantik has no draws). `best_moves` is the solver's best move.
+
+    `engine` lets a caller solving many positions (e.g. `fill()`'s loop)
+    reuse one `MinimaxEngine` instead of paying a fresh allocation per
+    call -- `solve()` resets all its per-call state (TT, node count, PV),
+    so reuse across independent positions is safe. When omitted (the
+    default for standalone/test use), a fresh engine is constructed.
 
     `MinimaxEngine.solve`/`search` assume a non-terminal root: a
     no-legal-moves position raises, and a position with an already-completed
@@ -62,7 +70,8 @@ def exact_entry(bb: Bitboard) -> Dict[str, Union[float, int, List[Move]]]:
         stm_wins = False
         best_moves: List[Move] = []
     else:
-        result = MinimaxEngine(MinimaxConfig(max_depth=16)).solve(State(bb))
+        solver = engine if engine is not None else MinimaxEngine(MinimaxConfig(max_depth=16))
+        result = solver.solve(State(bb))
         stm_wins = result.score > 0
         best_moves = [result.best_move]
     winner = stm if stm_wins else 1 - stm
@@ -85,12 +94,16 @@ def exact_entry(bb: Bitboard) -> Dict[str, Union[float, int, List[Move]]]:
 
 
 def fill(db: OpeningBookDatabase, n: int = 300, seed: int = 20260710) -> int:
-    """Sample `n` tractable positions, solve each, and upsert into `db`.
+    """Sample up to `n` tractable positions, solve each, and upsert into `db`.
 
-    Returns the number of positions written."""
+    `sample_states()` stops after a bounded number of attempts, so it can
+    return fewer than `n` distinct positions; this returns however many
+    were actually written, which may be less than `n`.
+    """
     written = 0
+    engine = MinimaxEngine(MinimaxConfig(max_depth=16))
     for bb in sample_states(n, seed):
-        db.add_position(State(bb), **exact_entry(bb))
+        db.add_position(State(bb), **exact_entry(bb, engine=engine))
         written += 1
     return written
 

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -13,9 +13,10 @@ python tuning/fill_opening_book.py -> writes quantik_opening_book.db
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from quantik_core import Move, State
+from quantik_core.commons import Bitboard
 from quantik_core.game_utils import (
     count_total_pieces,
     get_current_player_from_counts,
@@ -38,7 +39,7 @@ except ImportError:
     from build_dataset import sample_states  # type: ignore[import-not-found]
 
 
-def exact_entry(bb) -> Dict:
+def exact_entry(bb: Bitboard) -> Dict[str, Union[float, int, List[Move]]]:
     """Solve `bb` exactly and return kwargs for `add_position` (minus `state`).
 
     `evaluation` is +1.0 if the side to move wins with perfect play, else

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -16,8 +16,13 @@ from __future__ import annotations
 from typing import Dict, List
 
 from quantik_core import Move, State
-from quantik_core.game_utils import count_total_pieces, get_current_player_from_counts
+from quantik_core.game_utils import (
+    count_total_pieces,
+    get_current_player_from_counts,
+    has_winning_line,
+)
 from quantik_core.minimax import MinimaxConfig, MinimaxEngine
+from quantik_core.move import generate_legal_moves_list
 from quantik_core.opening_book import (
     OpeningBookConfig,
     OpeningBookDatabase,
@@ -38,13 +43,33 @@ def exact_entry(bb) -> Dict:
 
     `evaluation` is +1.0 if the side to move wins with perfect play, else
     -1.0 (Quantik has no draws). `best_moves` is the solver's best move.
+
+    `MinimaxEngine.solve`/`search` assume a non-terminal root: a
+    no-legal-moves position raises, and a position with an already-completed
+    winning line (but empty cells remaining, so `search` wouldn't raise) is
+    silently mis-scored -- treated as an interior node instead of an already
+    -decided one. `sample_states()` filters these out, but `exact_entry` is
+    a public, reusable mapping function, so a terminal `bb` (either
+    condition) is handled directly here instead of being solved: the side
+    to move has already lost, matching the convention `_negamax` uses
+    throughout `minimax.py`.
     """
-    result = MinimaxEngine(MinimaxConfig(max_depth=16)).solve(State(bb))
     p0, p1 = count_total_pieces(bb)
     stm = get_current_player_from_counts(p0, p1)
-    stm_wins = result.score > 0
+    already_decided = has_winning_line(bb) or not generate_legal_moves_list(bb)
+    if already_decided:
+        stm_wins = False
+        best_moves: List[Move] = []
+    else:
+        result = MinimaxEngine(MinimaxConfig(max_depth=16)).solve(State(bb))
+        stm_wins = result.score > 0
+        best_moves = [result.best_move]
     winner = stm if stm_wins else 1 - stm
-    best_moves: List[Move] = [result.best_move]
+    is_terminal = (
+        (TerminalStatus.WIN_P0 if winner == 0 else TerminalStatus.WIN_P1)
+        if already_decided
+        else TerminalStatus.INTERIOR
+    )
     return {
         "evaluation": 1.0 if stm_wins else -1.0,
         "visit_count": 1,
@@ -53,7 +78,7 @@ def exact_entry(bb) -> Dict:
         "draw_count": 0,
         "best_moves": best_moves,
         "depth": p0 + p1,
-        "is_terminal": TerminalStatus.INTERIOR,
+        "is_terminal": is_terminal,
         "symmetry_count": State(bb).symmetry_count(),
     }
 

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -1,0 +1,84 @@
+"""Fill the shared opening book with EXACT minimax-solved entries.
+
+The opening book (`quantik_core.opening_book.OpeningBookDatabase`) is keyed
+by `canonical_key()` and is engine-agnostic, so entries written here are
+consumed by any engine. This tool samples positions that are tractable to
+solve exactly (a few plies from the end) and records ground truth:
+`evaluation` (+1 win / -1 loss, side-to-move perspective), the exact winner
+as win counts, and the solver's best move.
+
+Run: python -m tuning.fill_opening_book (preferred) or
+python tuning/fill_opening_book.py -> writes quantik_opening_book.db
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from quantik_core import Move, State
+from quantik_core.game_utils import count_total_pieces, get_current_player_from_counts
+from quantik_core.minimax import MinimaxConfig, MinimaxEngine
+from quantik_core.opening_book import (
+    OpeningBookConfig,
+    OpeningBookDatabase,
+    TerminalStatus,
+)
+
+try:
+    from tuning.build_dataset import sample_states
+except ImportError:
+    # Script mode (`python tuning/fill_opening_book.py`): sys.path[0] is
+    # tuning/ itself, so the package-qualified import above fails there
+    # even though `python -m tuning.fill_opening_book` works.
+    from build_dataset import sample_states  # type: ignore[import-not-found]
+
+
+def exact_entry(bb) -> Dict:
+    """Solve `bb` exactly and return kwargs for `add_position` (minus `state`).
+
+    `evaluation` is +1.0 if the side to move wins with perfect play, else
+    -1.0 (Quantik has no draws). `best_moves` is the solver's best move.
+    """
+    result = MinimaxEngine(MinimaxConfig(max_depth=16)).solve(State(bb))
+    p0, p1 = count_total_pieces(bb)
+    stm = get_current_player_from_counts(p0, p1)
+    stm_wins = result.score > 0
+    winner = stm if stm_wins else 1 - stm
+    best_moves: List[Move] = [result.best_move]
+    return {
+        "evaluation": 1.0 if stm_wins else -1.0,
+        "visit_count": 1,
+        "win_count_p0": 1 if winner == 0 else 0,
+        "win_count_p1": 1 if winner == 1 else 0,
+        "draw_count": 0,
+        "best_moves": best_moves,
+        "depth": p0 + p1,
+        "is_terminal": TerminalStatus.INTERIOR,
+        "symmetry_count": State(bb).symmetry_count(),
+    }
+
+
+def fill(db: OpeningBookDatabase, n: int = 300, seed: int = 20260710) -> int:
+    """Sample `n` tractable positions, solve each, and upsert into `db`.
+
+    Returns the number of positions written."""
+    written = 0
+    for bb in sample_states(n, seed):
+        db.add_position(State(bb), **exact_entry(bb))
+        written += 1
+    return written
+
+
+def main(
+    n: int = 300, seed: int = 20260710, db_path: str = "quantik_opening_book.db"
+) -> None:
+    import time
+
+    start = time.time()
+    with OpeningBookDatabase(OpeningBookConfig(database_path=db_path)) as db:
+        written = fill(db, n=n, seed=seed)
+    print(f"wrote {written} exact entries in {time.time() - start:.1f}s -> {db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -62,6 +62,19 @@ def exact_entry(
     condition) is handled directly here instead of being solved: the side
     to move has already lost, matching the convention `_negamax` uses
     throughout `minimax.py`.
+
+    A no-legal-moves position is scored as a WIN for the opponent here
+    (`is_terminal=WIN_P0`/`WIN_P1`, `draw_count=0`), NOT `TerminalStatus
+    .STALEMATE`/a draw. This intentionally diverges from
+    `examples/opening_book_demo.py` and `examples/generate_opening_book.py`,
+    which both encode no-legal-moves as a draw -- but `board.py`'s own
+    `Board.get_game_result()` (the authoritative game-rules implementation)
+    is explicit that "If a player has no legal moves, the other player
+    wins", and Quantik has no draws at all (confirmed: `WinStatus` has no
+    draw member, only `NO_WIN`/`PLAYER_0_WINS`/`PLAYER_1_WINS`). Those two
+    examples appear to carry a pre-existing bug; fixing them is out of
+    scope for this change, but a reader comparing conventions across the
+    opening-book-writing code in this repo should not assume they agree.
     """
     p0, p1 = count_total_pieces(bb)
     stm = get_current_player_from_counts(p0, p1)

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -84,9 +84,12 @@ def exact_entry(
     stm, _ = validate_game_state(bb, raise_on_error=True)
     # validate_game_state is typed Optional[PlayerId] because it can return
     # (None, error) -- but raise_on_error=True means we only reach here on
-    # ValidationResult.OK, which always pairs with a concrete player. This
-    # assert makes that invariant explicit for readers and type checkers.
-    assert stm is not None
+    # ValidationResult.OK, which always pairs with a concrete player. An
+    # `assert` would be stripped under `python -O`, silently letting a
+    # None stm through; raise explicitly instead so this invariant holds
+    # even in optimized runs.
+    if stm is None:
+        raise RuntimeError("validate_game_state returned OK with stm=None")
     p0, p1 = count_total_pieces(bb)
     already_decided = has_winning_line(bb) or not generate_legal_moves_list(
         bb, player_id=stm

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -82,6 +82,11 @@ def exact_entry(
     terminal-win entry into the database.
     """
     stm, _ = validate_game_state(bb, raise_on_error=True)
+    # validate_game_state is typed Optional[PlayerId] because it can return
+    # (None, error) -- but raise_on_error=True means we only reach here on
+    # ValidationResult.OK, which always pairs with a concrete player. This
+    # assert makes that invariant explicit for readers and type checkers.
+    assert stm is not None
     p0, p1 = count_total_pieces(bb)
     already_decided = has_winning_line(bb) or not generate_legal_moves_list(
         bb, player_id=stm

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -83,7 +83,9 @@ def exact_entry(
         stm_wins = False
         best_moves: List[Move] = []
     else:
-        solver = engine if engine is not None else MinimaxEngine(MinimaxConfig(max_depth=16))
+        solver = (
+            engine if engine is not None else MinimaxEngine(MinimaxConfig(max_depth=16))
+        )
         result = solver.solve(State(bb))
         stm_wins = result.score > 0
         best_moves = [result.best_move]


### PR DESCRIPTION
## Summary
Implements cross-engine follow-up 2 from `docs/superpowers/plans/2026-07-10-cross-engine-2-opening-book-filler.md` (index: `2026-07-10-cross-engine-0-INDEX.md`).

- `tuning/fill_opening_book.py`: solves tractable positions (8-12 plies in) exactly with `MinimaxEngine` and writes ground-truth entries (`evaluation`, winner, best move) into the shared, engine-agnostic `OpeningBookDatabase`.

## Review: 10 rounds (capped by deliberate choice)
The most severe finding (round 5): `exact_entry()` treated any empty `generate_legal_moves_list(bb)` as a legitimate no-legal-moves terminal, but that function also returns `[]` for a genuinely **invalid** bitboard. Confirmed concretely — the pre-fix code, given an overlapping-piece board with a superficially-balanced piece count, silently returned `win_count_p0=1`, fabricating a decided result from invalid input. Fixed via `validate_game_state(bb, raise_on_error=True)` up front.

Other real fixes: terminal-root handling in `.solve()` calls (raises/mis-scores on an already-decided `bb`), engine reuse across `fill()`'s loop, a documented (not silently matched) convention conflict with two pre-existing examples that encode no-legal-moves as a draw when Quantik has none, and a `black --check` CI failure caught after a stale local check. Rounds 6-10 were minor (Python idiom, docstring wording/wrapping, test completeness) — applied since cheap, but the loop was capped at 10 by choice, not because findings ran out. Full details in the plan file's "Post-implementation notes".

## Verified / measured
- Both invocation modes end-to-end (300 entries, ~119s each).
- GitHub Copilot's coding agent executed `main(n=3000, seed=20260710)` on request and reported back: 3000 entries in 1568.4s (~26 min, pre-engine-reuse-fix), 584K database.

## Docs
`docs/OPENING_BOOK.md`: new "Filling with Exact Solver Ground Truth" section, including the no-legal-moves convention caveat.

## Test plan
- [x] 7 tests in `test_opening_book_filler.py`, incl. 3 regressions verified to fail against pre-fix code
- [x] Full suite: 521 passed
- [x] `black --check .` and `flake8 --select=E9,F63,F7,F82` both explicitly clean
- [x] Ran both invocation modes to completion; Copilot's agent independently ran n=3000

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>