### PR TITLE
feat(hybrid): opening->endgame composite player

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -104,3 +104,18 @@ choice matches:
 ```bash
 python examples/cross_engine_benchmark.py
 ```
+
+## Hybrid Player
+
+`quantik_core.hybrid.HybridPlayer` samples with MCTS or beam search while
+the tree is intractable, then hands off to the exact minimax solver once
+few enough cells remain — see `docs/HYBRID.md`.
+
+```python
+from quantik_core import State
+from quantik_core.hybrid import HybridPlayer, HybridConfig
+
+move = HybridPlayer(HybridConfig()).select_move(
+    State.from_qfen("A.b./..../..../....")
+)
+```

--- a/docs/HYBRID.md
+++ b/docs/HYBRID.md
@@ -1,0 +1,89 @@
+# Hybrid Opening→Endgame Player
+
+`quantik_core.hybrid.HybridPlayer` combines an adaptive sampling engine
+(MCTS or beam search) for the open game with the **exact** minimax solver
+for the endgame — pairing each engine with the regime where it is
+strongest.
+
+## Why a handoff
+
+A full solve from the empty board is intractable in pure Python (see
+`docs/MINIMAX.md`'s "three depths" section: `canonical_key()` scans all 192
+symmetries per call, so the open game runs at only a few hundred nodes/s).
+But Quantik's branching shrinks sharply as pieces are placed — a position
+with few empty cells has a small remaining tree that `MinimaxEngine.solve`
+resolves exactly and fast. `HybridPlayer` samples (MCTS or beam) while the
+tree is still wide, then switches to the exact solver once few enough
+empty cells remain, sidestepping the open-game intractability wall
+entirely instead of trying to search through it.
+
+## Quick start
+
+```python
+from quantik_core import State
+from quantik_core.hybrid import HybridPlayer, HybridConfig
+
+move = HybridPlayer(HybridConfig()).select_move(
+    State.from_qfen("A.b./..../..../....")
+)
+```
+
+`search()` returns the fuller `HybridResult` (which engine was used, and
+whether the move is exact) instead of just the move:
+
+```python
+result = HybridPlayer(HybridConfig()).search(state)
+print(result.engine_used, result.exact, result.best_move)
+```
+
+## Configuration (`HybridConfig`)
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `handoff_empty_cells` | int | 8 | At or below this many empty cells, use the exact solver; above it, use `opening_engine`. |
+| `opening_engine` | str | `"mcts"` | `"mcts"` or `"beam"` — which engine drives play above the handoff threshold. |
+| `mcts_config` | `MCTSConfig` | defaults | Used when `opening_engine="mcts"`. |
+| `beam_config` | `BeamSearchConfig` | defaults | Used when `opening_engine="beam"`. |
+| `minimax_config` | `MinimaxConfig` | `max_depth=16` | Used for the endgame handoff; `max_depth=16` guarantees an exact solve (see `docs/MINIMAX.md`). |
+
+### Tuning `handoff_empty_cells`
+
+The default of **8** (i.e. handoff once 8+ pieces are placed) was chosen
+because exact solves from that depth complete quickly — this repo's
+measurements across several 8-empty-cell positions range from ~0.25s to
+~1.3s. Raising the threshold hands off earlier (more exact play, since
+minimax never misjudges a position the way a sampling engine's heuristic
+can) but risks slower per-move latency as you approach the open game's
+intractability wall; lowering it defers to the sampling engine longer
+(faster moves, but no longer provably optimal near the boundary). The
+handoff itself is a hard cutover by empty-cell count, not a smooth
+blend — at or below the threshold, the exact solver decides every move.
+
+### Choosing `opening_engine`
+
+- **`"beam"`** (`BeamSearchEngine`) always reaches true terminal states
+  within its search horizon and is deterministic given a seed. See
+  `docs/BEAM_SEARCH.md`.
+- **`"mcts"`** (`MCTSEngine`) samples stochastically via UCB1. **Known
+  limitation:** `CompactGameTree.create_root_node` currently marks the
+  root node as fully expanded at creation instead of only once every
+  legal move has a child, which can leave MCTS's root with a single
+  explored child regardless of `max_iterations` — see `docs/MCTS.md`'s
+  "Known limitation" note. When that happens, the opening move MCTS
+  contributes is decided by move-generation order, not search quality.
+  `opening_engine="beam"` does not share this limitation.
+
+## API
+
+```python
+from quantik_core.hybrid import HybridPlayer, HybridConfig, HybridResult
+```
+
+- `HybridConfig` — see the table above.
+- `HybridResult`: `best_move: Move`, `engine_used: "minimax" | "mcts" | "beam"`, `exact: bool`.
+- `HybridPlayer(config)`:
+  - `.select_move(state) -> Move`
+  - `.search(state) -> HybridResult`
+
+Module-only, matching `quantik_core.mcts` / `quantik_core.beam_search` —
+import from `quantik_core.hybrid`, not the top-level `quantik_core` package.

--- a/docs/HYBRID.md
+++ b/docs/HYBRID.md
@@ -61,9 +61,13 @@ blend — at or below the threshold, the exact solver decides every move.
 
 ### Choosing `opening_engine`
 
-- **`"beam"`** (`BeamSearchEngine`) always reaches true terminal states
-  within its search horizon and is deterministic given a seed. See
-  `docs/BEAM_SEARCH.md`.
+- **`"beam"`** (`BeamSearchEngine`) is deterministic given a seed, and any
+  candidate that *survives* beam pruning is always followed all the way to
+  a true terminal state (unlike MCTS's rollouts, which can stop at
+  `max_depth` without resolving). This is not a guarantee of finding the
+  objectively best line, though: `beam_width` pruning can discard a
+  promising branch before it's explored deeply enough to reveal where it
+  leads. See `docs/BEAM_SEARCH.md`.
 - **`"mcts"`** (`MCTSEngine`) samples stochastically via UCB1. **Known
   limitation:** `CompactGameTree.create_root_node` currently marks the
   root node as fully expanded at creation instead of only once every

--- a/docs/HYBRID.md
+++ b/docs/HYBRID.md
@@ -44,7 +44,7 @@ print(result.engine_used, result.exact, result.best_move)
 | `opening_engine` | str | `"mcts"` | `"mcts"` or `"beam"` — which engine drives play above the handoff threshold. |
 | `mcts_config` | `MCTSConfig` | defaults | Used when `opening_engine="mcts"`. |
 | `beam_config` | `BeamSearchConfig` | defaults | Used when `opening_engine="beam"`. |
-| `minimax_config` | `MinimaxConfig` | `max_depth=16` | Used for the endgame handoff; `max_depth=16` guarantees an exact solve (see `docs/MINIMAX.md`). |
+| `minimax_config` | `MinimaxConfig` | `max_depth=16` | Used for the endgame handoff via `MinimaxEngine.solve()`. **`max_depth` and `time_limit_s` are ignored**: `solve()` unconditionally overrides both to guarantee an exact result (see `docs/MINIMAX.md`). `eval_config` is also never consulted there, since `solve()` never reaches the heuristic depth-cutoff. Only `use_alpha_beta`/`use_transposition_table`/`dedup_children`/`random_seed` actually affect the endgame handoff. |
 
 ### Tuning `handoff_empty_cells`
 

--- a/docs/research/2026-07-10-alpha-beta-eval-vs-mcts.md
+++ b/docs/research/2026-07-10-alpha-beta-eval-vs-mcts.md
@@ -670,10 +670,12 @@ piece of work, listed roughly by increasing scope):
    input. Fixed by validating up front (`validate_game_state(bb,
    raise_on_error=True)`) rather than inferring terminality from an empty
    move list.
-3. **Hybrid opening→endgame player.** Use adaptive sampling (UCT or beam) while
-   the tree is intractable, then hand off to the **exact** minimax solve once
-   few enough cells remain — pairing each engine with the regime where it is
-   strongest and sidestepping the open-game intractability wall entirely.
+3. **Hybrid opening→endgame player.** ✅ Done — `quantik_core.hybrid
+   .HybridPlayer`. Samples with MCTS or beam search while the tree is
+   intractable, then hands off to the **exact** minimax solve once few
+   enough cells remain (default: 8 empty cells, where solves measured
+   ~0.25–1.3s). `opening_engine="beam"` is unaffected by item 4's MCTS
+   root-expansion bug; `opening_engine="mcts"` inherits it.
 4. **Eval-guided MCTS rollouts.** ✅ Done — `MCTSConfig.rollout_eval_config`/
    `rollout_epsilon`, opt-in and purely additive (`None` reproduces the
    original pure-random rollouts exactly). Measured cost: 3,000 iterations

--- a/docs/superpowers/plans/2026-07-10-cross-engine-0-INDEX.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-0-INDEX.md
@@ -10,7 +10,7 @@ other — though the suggested order below front-loads the cheapest wins.
 | 1 | `...cross-engine-1-midgame-benchmark.md` | Example + smoke test only (`examples/cross_engine_benchmark.py`) | No (examples not measured) | Small | ✅ Done (branch `feat/cross-engine-midgame-benchmark`) |
 | 2 | `...cross-engine-2-opening-book-filler.md` | Tool + tests (`tuning/fill_opening_book.py`) | No | Small–medium | ✅ Done (branch `feat/cross-engine-opening-book-filler`) |
 | 3 | `...cross-engine-3-eval-guided-mcts.md` | **Library change** (`src/quantik_core/mcts.py`) | **Yes — ./dev-check.sh, ≥90%** | Medium | ✅ Done (branch `feat/cross-engine-eval-guided-mcts`) — found a significant pre-existing MCTS bug along the way, see plan's "Post-implementation notes" |
-| 4 | `...cross-engine-4-hybrid-player.md` | **New library module** (`src/quantik_core/hybrid.py`) | **Yes — ./dev-check.sh, ≥90%** | Medium | Not started |
+| 4 | `...cross-engine-4-hybrid-player.md` | **New library module** (`src/quantik_core/hybrid.py`) | **Yes — ./dev-check.sh, ≥90%** | Medium | ✅ Done (branch `feat/cross-engine-hybrid-player`) |
 
 ## Shared conventions (all four)
 - Work in an isolated worktree/branch; open a PR per plan (or bundle 1+2 and 3+4 if you prefer fewer PRs — they don't conflict).

--- a/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
@@ -241,3 +241,25 @@ discovered while implementing Follow-up 3 (PR #20): `CompactGameTree
 .create_root_node` marks the root as fully expanded at creation, so MCTS's
 root can get stuck with a single explored child regardless of
 `max_iterations`. `opening_engine="beam"` does not share this limitation.
+
+Two more review rounds followed. Round 2: an undocumented API-clarity gap
+(`minimax_config.max_depth`/`.time_limit_s`/`.eval_config` are silently
+ignored by `MinimaxEngine.solve()`, now documented in both places) and a
+cosmetic docstring line-wrap. Round 3 found the most severe issue in this
+PR: `HybridPlayer.search()` never validated that the input state was
+non-terminal before dispatching. `BeamSearchEngine.search()` already
+raises `ValueError` for a terminal root, but `MinimaxEngine.solve()` and
+`MCTSEngine.search()` do not -- both silently returned a meaningless move
+on an already-decided position (confirmed concretely: a completed-winning
+-line board with empty cells remaining elsewhere returned `HybridResult
+(..., engine_used="minimax", exact=True)` instead of raising, on both the
+minimax and MCTS paths). Fixed by validating up front in `search()` itself
+(`has_winning_line` or no legal moves → raise), so all three engines now
+behave consistently regardless of which one a call dispatches to. Two
+regression tests (one per previously-silent path) confirmed to fail
+against the pre-fix code. Also fixed: an inconsistent docstring claim
+("well under a second" vs. the documented 0.25-1.3s measured range), and
+an overclaim in `docs/HYBRID.md` about beam search's terminal-reaching
+guarantee (only *surviving* candidates are followed to a true terminal;
+`beam_width` pruning can discard a promising line before it's explored).
+Overall coverage after all three rounds: 92.02%.

--- a/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
@@ -34,7 +34,7 @@
 - `@dataclass HybridResult`: `best_move: Move`, `engine_used: str` (`"minimax"` / `"mcts"` / `"beam"`), `exact: bool`.
 - `class HybridPlayer`: `__init__(self, config: HybridConfig)`; `select_move(self, state: State) -> Move`; `search(self, state: State) -> HybridResult`.
 
-- [ ] **Step 1: Write failing tests** (`tests/test_hybrid.py`):
+- [x] **Step 1: Write failing tests** (`tests/test_hybrid.py`):
 
 ```python
 import pytest
@@ -89,9 +89,9 @@ def test_invalid_engine_raises():
             State.from_qfen("A.b./..../..../...."))
 ```
 
-- [ ] **Step 2: Run, verify fail** — `.venv/bin/pytest tests/test_hybrid.py -x --no-cov`. (If `AbC./d.a./B..c/....` is not a valid 8-piece P0-to-move position or already has a winning line, adjust the QFEN so it is a legal non-terminal 8-piece position with P0 to move; verify with `State.from_qfen(q, validate=True)` and `has_winning_line`.)
+- [x] **Step 2: Run, verify fail** — `.venv/bin/pytest tests/test_hybrid.py -x --no-cov`. (If `AbC./d.a./B..c/....` is not a valid 8-piece P0-to-move position or already has a winning line, adjust the QFEN so it is a legal non-terminal 8-piece position with P0 to move; verify with `State.from_qfen(q, validate=True)` and `has_winning_line`.)
 
-- [ ] **Step 3: Implement `src/quantik_core/hybrid.py`.** Full content:
+- [x] **Step 3: Implement `src/quantik_core/hybrid.py`.** Full content:
 
 ```python
 """Hybrid opening->endgame player for Quantik.
@@ -172,25 +172,25 @@ class HybridPlayer:
         raise ValueError(f"Unknown opening_engine: {engine!r}")
 ```
 
-- [ ] **Step 4: Run tests, verify pass** — `.venv/bin/pytest tests/test_hybrid.py -v --no-cov`.
+- [x] **Step 4: Run tests, verify pass** — `.venv/bin/pytest tests/test_hybrid.py -v --no-cov`.
 
-- [ ] **Step 5: Full gate** — `./auto-lint.sh` then `./dev-check.sh` (coverage ≥ 90%; the new module is small and fully exercised by the tests above).
+- [x] **Step 5: Full gate** — `./auto-lint.sh` then `./dev-check.sh` (coverage ≥ 90%; the new module is small and fully exercised by the tests above).
 
-- [ ] **Step 6: Commit** — `git add src/quantik_core/hybrid.py tests/test_hybrid.py`; commit `feat(hybrid): opening->endgame composite player`.
+- [x] **Step 6: Commit** — `git add src/quantik_core/hybrid.py tests/test_hybrid.py`; commit `feat(hybrid): opening->endgame composite player`.
 
 ---
 
 ## Task 2: Docs + example
 
 **Files:** Create `docs/HYBRID.md`; modify `docs/EXAMPLES.md`.
-- [ ] **Step 1:** `docs/HYBRID.md` — explain the handoff rationale (branching shrinks; exact solve becomes tractable), the `handoff_empty_cells` trade-off (higher = more exact play but slower moves near the boundary), and the `opening_engine` choice. Include a runnable snippet:
+- [x] **Step 1:** `docs/HYBRID.md` — explain the handoff rationale (branching shrinks; exact solve becomes tractable), the `handoff_empty_cells` trade-off (higher = more exact play but slower moves near the boundary), and the `opening_engine` choice. Include a runnable snippet:
   ```python
   from quantik_core import State
   from quantik_core.hybrid import HybridPlayer, HybridConfig
   move = HybridPlayer(HybridConfig()).select_move(State.from_qfen("A.b./..../..../...."))
   ```
-- [ ] **Step 2:** Add the same snippet to `docs/EXAMPLES.md` under a "Hybrid Player" heading; verify it runs.
-- [ ] **Step 3:** Commit — `docs: add HYBRID.md and example`.
+- [x] **Step 2:** Add the same snippet to `docs/EXAMPLES.md` under a "Hybrid Player" heading; verify it runs.
+- [x] **Step 3:** Commit — `docs: add HYBRID.md and example`.
 
 ---
 
@@ -199,3 +199,38 @@ class HybridPlayer:
 - Both opening engines return a guaranteed-legal move; beam guards the `best_leaf is None` case.
 - Invalid `opening_engine` raises `ValueError` (tested).
 - Optional extension (note only): consult a shared opening book (`OpeningBookDatabase.get_position`) before searching, returning its `best_moves[0]` on a hit — combine with Follow-up 2.
+
+## Post-implementation notes
+
+Verified every claimed API (`State.get_occupied_bb()`, `State.from_qfen
+(qfen, validate)`, `Move`'s home module, `MinimaxEngine.solve().best_move`,
+`MCTSEngine.search()`, `BeamSearchConfig`/`BeamSearchResult`/
+`ranked_root_moves()`) against the actual current source files before
+writing code — all matched exactly, unlike several earlier plans in this
+series.
+
+One defect found and fixed: the plan's own `test_endgame_uses_exact_solver
+_and_finds_mate` used `"AbC./d.a./B..c/...."` as an 8-piece P0-to-move
+anchor, but this QFEN fails `State.from_qfen(q, validate=True)` (the plan's
+own Step 2 anticipated this possibility and said to adjust it if so).
+Replaced with a genuinely valid, freshly-sampled 8-piece P0-to-move
+position (`"c.../.aBD/bcD./A..."`), which happens to also be a forced
+mate-in-1 (score 9999 = win − 1 ply), matching the test's name; solves in
+~1.3s.
+
+`hybrid.py`'s `best_leaf is None` fallback branch (line 84, the beam-search
+guard) is not exercised by any test — `BeamSearchResult.best_leaf` is only
+`None` when both `terminal_leaves` and the final frontier are empty, which
+doesn't appear reachable through normal validated-config beam search
+behavior (a non-terminal root with legal moves always produces at least
+one frontier candidate). Left uncovered as defensive code, consistent with
+an identical guard pattern in `examples/cross_engine_benchmark.py`
+(Follow-up 1) that is also untested there. Overall coverage is 92.00%,
+comfortably above the 90% gate.
+
+Documented (in both `docs/HYBRID.md` and the module's own docstring) that
+`opening_engine="mcts"` inherits the pre-existing MCTS root-expansion bug
+discovered while implementing Follow-up 3 (PR #20): `CompactGameTree
+.create_root_node` marks the root as fully expanded at creation, so MCTS's
+root can get stuck with a single explored child regardless of
+`max_iterations`. `opening_engine="beam"` does not share this limitation.

--- a/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
@@ -218,15 +218,22 @@ position (`"c.../.aBD/bcD./A..."`), which happens to also be a forced
 mate-in-1 (score 9999 = win − 1 ply), matching the test's name; solves in
 ~1.3s.
 
-`hybrid.py`'s `best_leaf is None` fallback branch (line 84, the beam-search
-guard) is not exercised by any test — `BeamSearchResult.best_leaf` is only
-`None` when both `terminal_leaves` and the final frontier are empty, which
-doesn't appear reachable through normal validated-config beam search
-behavior (a non-terminal root with legal moves always produces at least
-one frontier candidate). Left uncovered as defensive code, consistent with
-an identical guard pattern in `examples/cross_engine_benchmark.py`
-(Follow-up 1) that is also untested there. Overall coverage is 92.00%,
-comfortably above the 90% gate.
+A GitHub Copilot review of the resulting PR (#21) found a genuine crash
+risk in that same `best_leaf is None` fallback: if `ranked_root_moves()`
+also returned empty, `result.ranked_root_moves()[0].move` raised a bare
+`IndexError` with no context. Fixed to raise a clear `ValueError` instead,
+with a regression test that constructs an empty `BeamSearchResult`
+directly (`best_leaf=None`, no terminal/frontier leaves) via `unittest
+.mock.patch`, confirmed to fail with the original `IndexError` against
+the pre-fix code. That test also closes the coverage gap this branch
+previously had. Six more (mostly cosmetic-but-correct) findings in the
+same review round: `bin(x).count("1")` → `int.bit_count()` (matching the
+convention used throughout the rest of the codebase), and all four
+`from_qfen` calls in the test file switched to `validate=True` so an
+accidentally-illegal anchor fails loudly at parse time — plus the
+mate-in-1 test's name now matches an actual assertion (`has_winning_line`
+on the applied move), where it previously only checked the move was
+legal, not that it won. Overall coverage after all fixes: 92.01%.
 
 Documented (in both `docs/HYBRID.md` and the module's own docstring) that
 `opening_engine="mcts"` inherits the pre-existing MCTS root-expansion bug

--- a/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
@@ -262,4 +262,19 @@ against the pre-fix code. Also fixed: an inconsistent docstring claim
 an overclaim in `docs/HYBRID.md` about beam search's terminal-reaching
 guarantee (only *surviving* candidates are followed to a true terminal;
 `beam_width` pruning can discard a promising line before it's explored).
-Overall coverage after all three rounds: 92.02%.
+
+Round 4 found two more real issues, both quick follow-ons of earlier
+rounds' patterns:
+- `handoff_empty_cells` (a 0-16 empty-cell threshold on a 4x4 board) was
+  unvalidated. Added a range check in `HybridPlayer.__init__`, matching
+  the precedent set by PR #20's `rollout_epsilon` validation.
+- The round-3 terminal-state check had the exact same misclassification
+  bug already found and fixed in PR #19's `exact_entry()`:
+  `generate_legal_moves_list()` returns `[]` for both a genuine
+  no-legal-moves terminal AND an invalid bitboard, so an invalid state
+  was being raised as a misleading "terminal state" `ValueError` instead
+  of `ValidationError`. Fixed by calling `validate_game_state(state.bb,
+  raise_on_error=True)` before the terminal check, reusing the same
+  overlapping-piece regression scenario from PR #19's test.
+
+Overall coverage after all four rounds: 92.03%.

--- a/src/quantik_core/hybrid.py
+++ b/src/quantik_core/hybrid.py
@@ -1,0 +1,86 @@
+"""Hybrid opening->endgame player for Quantik.
+
+Uses an adaptive sampling engine (MCTS or beam search) while the game tree
+is intractable to search exactly, then hands off to the exact minimax
+solver once few enough cells remain. The handoff is by empty-cell count:
+Quantik's branching shrinks as pieces are placed, so a position with few
+empty cells has a small remaining tree that `MinimaxEngine.solve` resolves
+exactly and quickly.
+
+Known limitation when `opening_engine="mcts"`: `CompactGameTree
+.create_root_node` currently marks the root node as fully expanded at
+creation instead of only once every legal move has a child, which can
+leave MCTS's root with a single explored child regardless of
+`max_iterations` (see `docs/MCTS.md`'s "Known limitation" note). When that
+happens, the opening move MCTS returns is decided by move-generation
+order rather than search quality. `opening_engine="beam"` does not share
+this limitation -- `BeamSearchEngine` does not use `CompactGameTree`'s
+`NODE_FLAG_EXPANDED`/`_select` traversal at all.
+"""
+
+from dataclasses import dataclass, field
+
+from .core import State
+from .move import Move
+from .minimax import MinimaxConfig, MinimaxEngine
+from .mcts import MCTSConfig, MCTSEngine
+from .beam_search import BeamSearchConfig, BeamSearchEngine
+
+
+@dataclass
+class HybridConfig:
+    """Configuration for `HybridPlayer`.
+
+    `handoff_empty_cells`: at or below this many empty cells, use the exact
+    solver; above it, use `opening_engine`. Default 8 (>= 8 pieces placed),
+    where exact solves complete in well under a second.
+    """
+
+    handoff_empty_cells: int = 8
+    opening_engine: str = "mcts"  # "mcts" or "beam"
+    mcts_config: MCTSConfig = field(default_factory=MCTSConfig)
+    beam_config: BeamSearchConfig = field(default_factory=BeamSearchConfig)
+    minimax_config: MinimaxConfig = field(
+        default_factory=lambda: MinimaxConfig(max_depth=16)
+    )
+
+
+@dataclass
+class HybridResult:
+    """Which move was chosen, by which engine, and whether it is exact."""
+
+    best_move: Move
+    engine_used: str  # "minimax" | "mcts" | "beam"
+    exact: bool
+
+
+def _empty_cells(state: State) -> int:
+    return 16 - bin(state.get_occupied_bb()).count("1")
+
+
+class HybridPlayer:
+    """Composite player: sampling in the open game, exact solve in the endgame."""
+
+    def __init__(self, config: HybridConfig) -> None:
+        self.config = config
+
+    def select_move(self, state: State) -> Move:
+        return self.search(state).best_move
+
+    def search(self, state: State) -> HybridResult:
+        if _empty_cells(state) <= self.config.handoff_empty_cells:
+            move = MinimaxEngine(self.config.minimax_config).solve(state).best_move
+            return HybridResult(best_move=move, engine_used="minimax", exact=True)
+
+        engine = self.config.opening_engine
+        if engine == "mcts":
+            move, _ = MCTSEngine(self.config.mcts_config).search(state)
+            return HybridResult(best_move=move, engine_used="mcts", exact=False)
+        if engine == "beam":
+            result = BeamSearchEngine(self.config.beam_config).search(state)
+            if result.best_leaf is not None and result.best_leaf.moves:
+                move = result.best_leaf.moves[0]
+            else:
+                move = result.ranked_root_moves()[0].move
+            return HybridResult(best_move=move, engine_used="beam", exact=False)
+        raise ValueError(f"Unknown opening_engine: {engine!r}")

--- a/src/quantik_core/hybrid.py
+++ b/src/quantik_core/hybrid.py
@@ -21,7 +21,8 @@ at all.
 from dataclasses import dataclass, field
 
 from .core import State
-from .move import Move
+from .game_utils import has_winning_line
+from .move import Move, generate_legal_moves_list
 from .minimax import MinimaxConfig, MinimaxEngine
 from .mcts import MCTSConfig, MCTSEngine
 from .beam_search import BeamSearchConfig, BeamSearchEngine
@@ -33,7 +34,8 @@ class HybridConfig:
 
     `handoff_empty_cells`: at or below this many empty cells, use the exact
     solver; above it, use `opening_engine`. Default 8 (>= 8 pieces placed),
-    where exact solves complete in well under a second.
+    where measured exact solves range roughly 0.25-1.3s (hardware-dependent;
+    see `docs/HYBRID.md`).
 
     `minimax_config.max_depth` and `.time_limit_s` are ignored for the
     endgame handoff: `HybridPlayer.search` always calls `MinimaxEngine
@@ -80,6 +82,18 @@ class HybridPlayer:
         return self.search(state).best_move
 
     def search(self, state: State) -> HybridResult:
+        # BeamSearchEngine already raises ValueError for a terminal root,
+        # but MinimaxEngine.solve() and MCTSEngine.search() do not -- both
+        # silently return SOME move on an already-decided position (a
+        # completed winning line that still happens to leave empty cells,
+        # or no legal moves at all) instead of raising. Validate up front
+        # so all three engines behave consistently regardless of which one
+        # this call happens to dispatch to.
+        if has_winning_line(state.bb) or not generate_legal_moves_list(state.bb):
+            raise ValueError(
+                "Cannot search from a terminal state (a winning line is "
+                "already complete, or the side to move has no legal moves)."
+            )
         if _empty_cells(state) <= self.config.handoff_empty_cells:
             move = MinimaxEngine(self.config.minimax_config).solve(state).best_move
             return HybridResult(best_move=move, engine_used="minimax", exact=True)

--- a/src/quantik_core/hybrid.py
+++ b/src/quantik_core/hybrid.py
@@ -7,15 +7,15 @@ Quantik's branching shrinks as pieces are placed, so a position with few
 empty cells has a small remaining tree that `MinimaxEngine.solve` resolves
 exactly and quickly.
 
-Known limitation when `opening_engine="mcts"`: `CompactGameTree
-.create_root_node` currently marks the root node as fully expanded at
-creation instead of only once every legal move has a child, which can
-leave MCTS's root with a single explored child regardless of
-`max_iterations` (see `docs/MCTS.md`'s "Known limitation" note). When that
-happens, the opening move MCTS returns is decided by move-generation
-order rather than search quality. `opening_engine="beam"` does not share
-this limitation -- `BeamSearchEngine` does not use `CompactGameTree`'s
-`NODE_FLAG_EXPANDED`/`_select` traversal at all.
+Known limitation when `opening_engine="mcts"`: `CompactGameTree.create_root_node`
+currently marks the root node as fully expanded at creation instead of only
+once every legal move has a child, which can leave MCTS's root with a
+single explored child regardless of `max_iterations` (see `docs/MCTS.md`'s
+"Known limitation" note). When that happens, the opening move MCTS returns
+is decided by move-generation order rather than search quality.
+`opening_engine="beam"` does not share this limitation -- `BeamSearchEngine`
+does not use `CompactGameTree`'s `NODE_FLAG_EXPANDED`/`_select` traversal
+at all.
 """
 
 from dataclasses import dataclass, field
@@ -34,6 +34,18 @@ class HybridConfig:
     `handoff_empty_cells`: at or below this many empty cells, use the exact
     solver; above it, use `opening_engine`. Default 8 (>= 8 pieces placed),
     where exact solves complete in well under a second.
+
+    `minimax_config.max_depth` and `.time_limit_s` are ignored for the
+    endgame handoff: `HybridPlayer.search` always calls `MinimaxEngine
+    .solve()`, which unconditionally overrides both to `max_depth=16,
+    time_limit_s=None` (`MinimaxEngine.solve`'s own docstring: "Exact
+    solve"). `.eval_config` is likewise never consulted there, since every
+    Quantik game resolves within 16 plies and `solve()` therefore never
+    reaches the heuristic depth-cutoff that would invoke it. Only the
+    other `MinimaxConfig` fields (`use_alpha_beta`, `use_transposition_
+    table`, `dedup_children`, `random_seed`) affect the endgame handoff;
+    this is by design -- the whole point of the handoff is a *guaranteed
+    exact* result, matching `HybridResult.exact=True`.
     """
 
     handoff_empty_cells: int = 8

--- a/src/quantik_core/hybrid.py
+++ b/src/quantik_core/hybrid.py
@@ -55,7 +55,7 @@ class HybridResult:
 
 
 def _empty_cells(state: State) -> int:
-    return 16 - bin(state.get_occupied_bb()).count("1")
+    return 16 - state.get_occupied_bb().bit_count()
 
 
 class HybridPlayer:
@@ -81,6 +81,13 @@ class HybridPlayer:
             if result.best_leaf is not None and result.best_leaf.moves:
                 move = result.best_leaf.moves[0]
             else:
-                move = result.ranked_root_moves()[0].move
+                ranked = result.ranked_root_moves()
+                if not ranked:
+                    raise ValueError(
+                        "BeamSearchEngine returned no best_leaf and no "
+                        "ranked_root_moves() for a non-terminal state; "
+                        "cannot select a move."
+                    )
+                move = ranked[0].move
             return HybridResult(best_move=move, engine_used="beam", exact=False)
         raise ValueError(f"Unknown opening_engine: {engine!r}")

--- a/src/quantik_core/hybrid.py
+++ b/src/quantik_core/hybrid.py
@@ -26,6 +26,7 @@ from .move import Move, generate_legal_moves_list
 from .minimax import MinimaxConfig, MinimaxEngine
 from .mcts import MCTSConfig, MCTSEngine
 from .beam_search import BeamSearchConfig, BeamSearchEngine
+from .state_validator import validate_game_state
 
 
 @dataclass
@@ -76,12 +77,24 @@ class HybridPlayer:
     """Composite player: sampling in the open game, exact solve in the endgame."""
 
     def __init__(self, config: HybridConfig) -> None:
+        if not (0 <= config.handoff_empty_cells <= 16):
+            raise ValueError(
+                "handoff_empty_cells must be in [0, 16] (a 4x4 board has "
+                f"16 cells), got {config.handoff_empty_cells}"
+            )
         self.config = config
 
     def select_move(self, state: State) -> Move:
         return self.search(state).best_move
 
     def search(self, state: State) -> HybridResult:
+        # generate_legal_moves_list() returns [] for BOTH a genuine
+        # no-legal-moves terminal AND an invalid bitboard (piece overlap,
+        # turn-balance violation, ...) -- that check alone can't tell them
+        # apart, so validate first: an invalid state should raise
+        # ValidationError, not be misclassified as "terminal".
+        validate_game_state(state.bb, raise_on_error=True)
+
         # BeamSearchEngine already raises ValueError for a terminal root,
         # but MinimaxEngine.solve() and MCTSEngine.search() do not -- both
         # silently return SOME move on an already-decided position (a

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -1,29 +1,37 @@
 import pytest
-from quantik_core import State
+from quantik_core import State, apply_move
 from quantik_core.hybrid import HybridPlayer, HybridConfig
 from quantik_core.mcts import MCTSConfig
 from quantik_core.beam_search import BeamSearchConfig
+from quantik_core.game_utils import has_winning_line
 from quantik_core.move import generate_legal_moves_list
 
 # A valid 8-piece (4+4) P0-to-move, non-terminal position -- the plan's
 # original "AbC./d.a./B..c/...." was invalid (fails from_qfen(validate=True)).
 # This one solves in ~1.3s and happens to be a forced mate-in-1 for P0
-# (score 9999 = win - 1 ply), matching the test's name.
+# (score 9999 = win - 1 ply), matching the test's name -- asserted below by
+# applying the returned move and checking has_winning_line, not just assumed.
 _ENDGAME_QFEN = "c.../.aBD/bcD./A..."
+
+# All from_qfen calls below pass validate=True so an accidentally-illegal
+# anchor fails loudly (at parse time) rather than silently exercising
+# undefined engine behavior on an invalid position.
+_OPEN_GAME_QFEN = "A.b./..../..../...."
 
 
 def test_endgame_uses_exact_solver_and_finds_mate():
     # 8 pieces placed => 8 empty cells => at the handoff threshold => exact.
-    state = State.from_qfen(_ENDGAME_QFEN)
+    state = State.from_qfen(_ENDGAME_QFEN, validate=True)
     player = HybridPlayer(HybridConfig(handoff_empty_cells=8))
     result = player.search(state)
     assert result.exact and result.engine_used == "minimax"
     assert result.best_move in generate_legal_moves_list(state.bb)
+    assert has_winning_line(apply_move(state.bb, result.best_move))
 
 
 def test_open_game_uses_opening_engine():
     # 2 pieces placed => 14 empty cells => above threshold => opening engine.
-    state = State.from_qfen("A.b./..../..../....")
+    state = State.from_qfen(_OPEN_GAME_QFEN, validate=True)
     player = HybridPlayer(
         HybridConfig(
             handoff_empty_cells=8,
@@ -37,7 +45,7 @@ def test_open_game_uses_opening_engine():
 
 
 def test_beam_opening_engine_selected():
-    state = State.from_qfen("A.b./..../..../....")
+    state = State.from_qfen(_OPEN_GAME_QFEN, validate=True)
     player = HybridPlayer(
         HybridConfig(
             handoff_empty_cells=8,
@@ -50,8 +58,32 @@ def test_beam_opening_engine_selected():
     assert result.best_move in generate_legal_moves_list(state.bb)
 
 
+def test_beam_engine_raises_clearly_instead_of_indexerror_when_no_results():
+    # Regression: if BeamSearchEngine ever returns no best_leaf AND no
+    # ranked_root_moves() (both empty), the old code did
+    # `result.ranked_root_moves()[0].move`, an IndexError with no context.
+    # Simulate that with a directly-constructed empty BeamSearchResult.
+    from unittest.mock import patch
+    from quantik_core.beam_search import BeamSearchResult
+
+    empty_result = BeamSearchResult(
+        best_leaf=None,
+        terminal_leaves=[],
+        reached_terminal=False,
+        max_depth_reached=0,
+        stats={},
+    )
+    state = State.from_qfen(_OPEN_GAME_QFEN, validate=True)
+    player = HybridPlayer(HybridConfig(handoff_empty_cells=8, opening_engine="beam"))
+    with patch(
+        "quantik_core.hybrid.BeamSearchEngine.search", return_value=empty_result
+    ):
+        with pytest.raises(ValueError, match="no best_leaf"):
+            player.search(state)
+
+
 def test_select_move_matches_search():
-    state = State.from_qfen("A.b./..../..../....")
+    state = State.from_qfen(_OPEN_GAME_QFEN, validate=True)
     player = HybridPlayer(
         HybridConfig(mcts_config=MCTSConfig(max_iterations=50, random_seed=3))
     )
@@ -61,5 +93,5 @@ def test_select_move_matches_search():
 def test_invalid_engine_raises():
     with pytest.raises(ValueError):
         HybridPlayer(HybridConfig(opening_engine="nope")).search(
-            State.from_qfen("A.b./..../..../....")
+            State.from_qfen(_OPEN_GAME_QFEN, validate=True)
         )

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -95,3 +95,33 @@ def test_invalid_engine_raises():
         HybridPlayer(HybridConfig(opening_engine="nope")).search(
             State.from_qfen(_OPEN_GAME_QFEN, validate=True)
         )
+
+
+def test_search_raises_on_already_terminal_state_minimax_path():
+    # Regression: a position with a completed winning line but empty
+    # cells remaining elsewhere previously fell through to
+    # MinimaxEngine.solve() (which only checks "no legal moves", not
+    # "already won") and silently returned a meaningless move with
+    # exact=True. Confirmed concretely: pre-fix, this returned
+    # HybridResult(best_move=..., engine_used="minimax", exact=True)
+    # instead of raising.
+    state = State.from_qfen("AbCd/..../..../....", validate=True)
+    assert has_winning_line(state.bb) and generate_legal_moves_list(state.bb)
+    player = HybridPlayer(HybridConfig(handoff_empty_cells=16))  # force minimax path
+    with pytest.raises(ValueError, match="terminal"):
+        player.search(state)
+
+
+def test_search_raises_on_already_terminal_state_mcts_path():
+    # Same regression, opening-engine side: MCTSEngine.search() also
+    # didn't validate terminality and silently returned a move.
+    state = State.from_qfen("AbCd/..../..../....", validate=True)
+    player = HybridPlayer(
+        HybridConfig(
+            handoff_empty_cells=0,
+            opening_engine="mcts",
+            mcts_config=MCTSConfig(max_iterations=10, random_seed=0),
+        )
+    )
+    with pytest.raises(ValueError, match="terminal"):
+        player.search(state)

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -125,3 +125,24 @@ def test_search_raises_on_already_terminal_state_mcts_path():
     )
     with pytest.raises(ValueError, match="terminal"):
         player.search(state)
+
+
+def test_rejects_out_of_range_handoff_empty_cells():
+    for bad_value in (-1, 17):
+        with pytest.raises(ValueError, match="handoff_empty_cells"):
+            HybridPlayer(HybridConfig(handoff_empty_cells=bad_value))
+
+
+def test_search_raises_validation_error_on_invalid_bitboard_not_terminal():
+    # Regression: generate_legal_moves_list() returns [] for BOTH a
+    # genuine no-legal-moves terminal AND an invalid bitboard -- prior to
+    # this fix, an invalid state was misclassified as "terminal" with a
+    # misleading ValueError instead of ValidationError. Same overlapping
+    # -piece construction as tests/test_opening_book_filler.py's
+    # equivalent regression test (PR #19): turn balance alone (2 vs 1)
+    # looks superficially valid, so only full validation catches it.
+    from quantik_core.commons import ValidationError
+
+    overlapping_bb = (0b1, 0b1, 0, 0, 0b10, 0, 0, 0)
+    with pytest.raises(ValidationError):
+        HybridPlayer(HybridConfig()).search(State(overlapping_bb))

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -1,0 +1,65 @@
+import pytest
+from quantik_core import State
+from quantik_core.hybrid import HybridPlayer, HybridConfig
+from quantik_core.mcts import MCTSConfig
+from quantik_core.beam_search import BeamSearchConfig
+from quantik_core.move import generate_legal_moves_list
+
+# A valid 8-piece (4+4) P0-to-move, non-terminal position -- the plan's
+# original "AbC./d.a./B..c/...." was invalid (fails from_qfen(validate=True)).
+# This one solves in ~1.3s and happens to be a forced mate-in-1 for P0
+# (score 9999 = win - 1 ply), matching the test's name.
+_ENDGAME_QFEN = "c.../.aBD/bcD./A..."
+
+
+def test_endgame_uses_exact_solver_and_finds_mate():
+    # 8 pieces placed => 8 empty cells => at the handoff threshold => exact.
+    state = State.from_qfen(_ENDGAME_QFEN)
+    player = HybridPlayer(HybridConfig(handoff_empty_cells=8))
+    result = player.search(state)
+    assert result.exact and result.engine_used == "minimax"
+    assert result.best_move in generate_legal_moves_list(state.bb)
+
+
+def test_open_game_uses_opening_engine():
+    # 2 pieces placed => 14 empty cells => above threshold => opening engine.
+    state = State.from_qfen("A.b./..../..../....")
+    player = HybridPlayer(
+        HybridConfig(
+            handoff_empty_cells=8,
+            opening_engine="mcts",
+            mcts_config=MCTSConfig(max_iterations=100, random_seed=0),
+        )
+    )
+    result = player.search(state)
+    assert not result.exact and result.engine_used == "mcts"
+    assert result.best_move in generate_legal_moves_list(state.bb)
+
+
+def test_beam_opening_engine_selected():
+    state = State.from_qfen("A.b./..../..../....")
+    player = HybridPlayer(
+        HybridConfig(
+            handoff_empty_cells=8,
+            opening_engine="beam",
+            beam_config=BeamSearchConfig(beam_width=8, max_depth=4, random_seed=0),
+        )
+    )
+    result = player.search(state)
+    assert result.engine_used == "beam"
+    assert result.best_move in generate_legal_moves_list(state.bb)
+
+
+def test_select_move_matches_search():
+    state = State.from_qfen("A.b./..../..../....")
+    player = HybridPlayer(
+        HybridConfig(mcts_config=MCTSConfig(max_iterations=50, random_seed=3))
+    )
+    assert player.select_move(state) == player.search(state).best_move
+
+
+def test_invalid_engine_raises():
+    with pytest.raises(ValueError):
+        HybridPlayer(HybridConfig(opening_engine="nope")).search(
+            State.from_qfen("A.b./..../..../....")
+        )


### PR DESCRIPTION
## Summary
Implements cross-engine follow-up 4 (the final one) from `docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md` (index: `2026-07-10-cross-engine-0-INDEX.md`).

- New module `quantik_core.hybrid` (`HybridConfig`, `HybridResult`, `HybridPlayer`): samples with MCTS or beam search while the tree is intractable, then hands off to the exact minimax solver once few enough empty cells remain (default: 8, where solves measured ~0.25–1.3s).
- Module-only, matching `mcts.py`/`beam_search.py`'s own top-level export pattern (not re-exported from `quantik_core`'s `__init__.py`).

## Verified before writing code
Every claimed API (`State.get_occupied_bb()`, `State.from_qfen`'s `validate` kwarg, `Move`'s home module, `MinimaxEngine.solve().best_move`, `MCTSEngine.search()`, `BeamSearchConfig`/`BeamSearchResult`/`ranked_root_moves()`) checked against the actual current source before implementing — all matched exactly.

One defect found: the plan's own 8-piece test anchor QFEN (`"AbC./d.a./B..c/...."`) is itself invalid — fails `State.from_qfen(q, validate=True)` (the plan's own Step 2 anticipated this might happen). Replaced with a freshly-sampled valid 8-piece P0-to-move position that happens to also be a forced mate-in-1.

## Known limitation (documented, not fixed — inherited from PR #20)
`opening_engine="mcts"` inherits the pre-existing MCTS root-expansion bug discovered while implementing PR #20 (`CompactGameTree.create_root_node` marks the root fully-expanded at creation, so MCTS's root can get stuck with a single explored child regardless of `max_iterations`). `opening_engine="beam"` is unaffected — `BeamSearchEngine` doesn't use `CompactGameTree`'s `NODE_FLAG_EXPANDED`/`_select` traversal at all. Documented in both `docs/HYBRID.md` and the module's own docstring so this isn't silently hidden from readers.

## Coverage note
`hybrid.py`'s `best_leaf is None` fallback branch (a beam-search guard) is uncovered — `BeamSearchResult.best_leaf` is only `None` when both `terminal_leaves` and the final frontier are empty, which doesn't appear reachable through normal validated-config beam search behavior. Left as defensive code, consistent with an identical untested guard in `examples/cross_engine_benchmark.py` (Follow-up 1). Overall coverage is comfortably above the gate regardless.

## Docs
`docs/HYBRID.md` (new reference doc) + `docs/EXAMPLES.md` snippet, both verified to actually run.

## Test plan
- [x] 5 new tests in `test_hybrid.py`, all passing
- [x] Full suite: 535 passed
- [x] Full `./dev-check.sh` gate: 92.00% coverage (`hybrid.py` 97%), black/flake8/**mypy**/build/twine all clean

This is the last of the four cross-engine follow-up plans (PR #17 → #18 → #19 → #20 → this one).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>