### PR TITLE
fix(mcts): root can now explore multiple children, UCB perspective corrected

### DIFF
--- a/docs/HYBRID.md
+++ b/docs/HYBRID.md
@@ -68,14 +68,7 @@ blend — at or below the threshold, the exact solver decides every move.
   objectively best line, though: `beam_width` pruning can discard a
   promising branch before it's explored deeply enough to reveal where it
   leads. See `docs/BEAM_SEARCH.md`.
-- **`"mcts"`** (`MCTSEngine`) samples stochastically via UCB1. **Known
-  limitation:** `CompactGameTree.create_root_node` currently marks the
-  root node as fully expanded at creation instead of only once every
-  legal move has a child, which can leave MCTS's root with a single
-  explored child regardless of `max_iterations` — see `docs/MCTS.md`'s
-  "Known limitation" note. When that happens, the opening move MCTS
-  contributes is decided by move-generation order, not search quality.
-  `opening_engine="beam"` does not share this limitation.
+- **`"mcts"`** (`MCTSEngine`) samples stochastically via UCB1.
 
 ## API
 

--- a/docs/MCTS.md
+++ b/docs/MCTS.md
@@ -90,8 +90,9 @@ purely additive.
 expensive per iteration than a single `random.choice`. Measured: 3,000
 iterations from the empty board took 10.6s with random rollouts vs. 53.8s
 with `rollout_eval_config=EvalConfig.load()` (`rollout_epsilon=0.2`) — a
-~5.1x slowdown (re-measured after the root-expansion/UCB fixes in
-`fix/mcts-root-expansion`; the root now actually explores multiple
+~5.1x slowdown (re-measured after fixing two root-exploration/UCB
+perspective bugs in `CompactGameTree.create_root_node` and
+`MCTSEngine._calculate_ucb`; the root now actually explores multiple
 children instead of getting stuck on one, so both configurations do more
 real work per run than the pre-fix numbers this section previously
 quoted). Use fewer `max_iterations`, or budget for proportionally slower

--- a/docs/MCTS.md
+++ b/docs/MCTS.md
@@ -86,23 +86,16 @@ under `evaluate()` is chosen. `rollout_eval_config=None` (the default)
 reproduces the original pure-random rollouts exactly — this option is
 purely additive.
 
-**Known limitation:** `CompactGameTree.create_root_node` currently marks
-the root node as fully expanded at creation instead of only once every
-legal move has a child, which can leave the root with a single explored
-child regardless of `max_iterations`. When that happens, the move
-`search()` returns is decided by move-generation order rather than by
-search quality — eval-guided rollouts may then only affect the reported
-`win_prob` for that one branch, not which move is actually returned. This
-is a pre-existing issue in the tree-expansion logic, not specific to
-rollout selection; see the research note's "Future work" section for the
-full writeup.
-
 **Cost:** evaluating every candidate move at every playout step is far more
 expensive per iteration than a single `random.choice`. Measured: 3,000
-iterations from the empty board took 9.8s with random rollouts vs. 41.8s
+iterations from the empty board took 10.6s with random rollouts vs. 53.8s
 with `rollout_eval_config=EvalConfig.load()` (`rollout_epsilon=0.2`) — a
-~4.3x slowdown. Use fewer `max_iterations`, or budget for proportionally
-slower searches, when this is enabled.
+~5.1x slowdown (re-measured after the root-expansion/UCB fixes in
+`fix/mcts-root-expansion`; the root now actually explores multiple
+children instead of getting stuck on one, so both configurations do more
+real work per run than the pre-fix numbers this section previously
+quoted). Use fewer `max_iterations`, or budget for proportionally slower
+searches, when this is enabled.
 
 ### Exploration Weight Tuning
 

--- a/docs/research/2026-07-10-alpha-beta-eval-vs-mcts.md
+++ b/docs/research/2026-07-10-alpha-beta-eval-vs-mcts.md
@@ -422,6 +422,20 @@ a fitted leaf heuristic reliably outplays both an undirected random mover
 and a moderately-budgeted stochastic search — the two engines are not
 merely different in character, one dominates the other at these settings.
 
+> **2026-07-11 caveat — superseded by the MCTS fix below.** The
+> `vs UCT, 1,500 iterations` row above, and every other MCTS number in this
+> document (§7's tables, item 1's move-agreement=0.500, the "vs MCTS-1500"
+> matchups), was measured against a version of `MCTSEngine` where the root
+> node could only ever explore a single child (see "A pre-existing MCTS bug"
+> below, now fixed on `fix/mcts-root-expansion`). Re-measured post-fix on
+> `examples/minimax_benchmark.py`: `minimax as P1` against UCT-1,500 flipped
+> to **0/8** (minimax as P0 stayed 8/8; `vs random` unaffected both sides).
+> `examples/cross_engine_benchmark.py`'s move-agreement for MCTS rose from
+> 0.500 to 0.725. This document's historical numbers are left as-is (they
+> accurately describe what was measured, when) rather than rewritten
+> throughout — treat every MCTS figure above this note as describing the
+> pre-fix engine, not current behavior.
+
 ### 7.2 Search performance: alpha-beta and TT prune ratios
 
 Fixed depth-4 search from a mid-game anchor position
@@ -674,16 +688,33 @@ piece of work, listed roughly by increasing scope):
    .HybridPlayer`. Samples with MCTS or beam search while the tree is
    intractable, then hands off to the **exact** minimax solve once few
    enough cells remain (default: 8 empty cells, where solves measured
-   ~0.25–1.3s). `opening_engine="beam"` is unaffected by item 4's MCTS
-   root-expansion bug; `opening_engine="mcts"` inherits it.
+   ~0.25–1.3s). `opening_engine="beam"` was always unaffected by the MCTS
+   root-expansion bug below; `opening_engine="mcts"` inherited it until
+   the fix on `fix/mcts-root-expansion` (see below).
 4. **Eval-guided MCTS rollouts.** ✅ Done — `MCTSConfig.rollout_eval_config`/
    `rollout_epsilon`, opt-in and purely additive (`None` reproduces the
-   original pure-random rollouts exactly). Measured cost: 3,000 iterations
-   from the empty board, 9.8s random vs. 41.8s eval-guided (~4.3x). See the
-   next item — this feature's practical value turned out to be much smaller
-   than intended, for a reason discovered while implementing it.
+   original pure-random rollouts exactly). Measured cost (re-measured
+   post-fix, see below): 3,000 iterations from the empty board, 10.6s
+   random vs. 53.8s eval-guided (~5.1x). See the next item — this
+   feature's practical value was much smaller than intended at the time
+   it was implemented, for a reason discovered while implementing it and
+   since resolved.
 
-### A pre-existing MCTS bug discovered while implementing item 4
+### A pre-existing MCTS bug discovered while implementing item 4 — resolved 2026-07-11
+
+**Status: fixed**, on branch `fix/mcts-root-expansion`, together with a
+second, independently-discovered bug in `_calculate_ucb` (it computed the
+win-rate term from the *child's* `player_turn` instead of the *parent's*
+mover — backwards from the perspective of whichever player was actually
+choosing among the children). Both had to be fixed together: fixing only
+the root-expansion bug below left `search()` still returning a
+non-winning move on a hand-verified mate-in-one position, because the
+now-correctly-explored win-rate comparisons were themselves inverted.
+Post-fix, MCTS reliably finds forced wins it previously missed (10/10
+seeds on the regression position), and the root explores multiple
+children rather than getting stuck on one (`test_root_explores_multiple_
+children_not_stuck_at_one` in `tests/test_mcts.py`). The description below
+is left as originally written, describing the bug as found.
 
 `CompactGameTree.create_root_node` (`src/quantik_core/memory/
 compact_tree.py:304`) creates the root node with `NODE_FLAG_EXPANDED`
@@ -706,12 +737,13 @@ checking for the objectively best move. It plausibly explains MCTS's
 consistently weak showing in every cross-engine benchmark so far
 (item 1's move-agreement=0.500, the "vs MCTS-1500" matchups above) — MCTS
 may never have explored more than one root move in any of them. **Not
-fixed here** (out of scope for the eval-guided-rollouts plan, shared with
-`beam_search.py`'s tree — though that engine doesn't reference
-`NODE_FLAG_EXPANDED`/`_select` and appears unaffected — and fixing it would
-change existing MCTS search results, which every other engine's benchmarks
-in this document were measured against). Worth a dedicated, carefully
--scoped follow-up.
+fixed at the time this section was written** (out of scope for the
+eval-guided-rollouts plan, shared with `beam_search.py`'s tree — though
+that engine doesn't reference `NODE_FLAG_EXPANDED`/`_select` and appears
+unaffected — and fixing it would change existing MCTS search results,
+which every other engine's benchmarks in this document were measured
+against). Fixed as the dedicated follow-up this section called for — see
+the "resolved 2026-07-11" note above.
 
 ## References
 

--- a/docs/research/2026-07-10-alpha-beta-eval-vs-mcts.md
+++ b/docs/research/2026-07-10-alpha-beta-eval-vs-mcts.md
@@ -427,7 +427,7 @@ merely different in character, one dominates the other at these settings.
 > document (§7's tables, item 1's move-agreement=0.500, the "vs MCTS-1500"
 > matchups), was measured against a version of `MCTSEngine` where the root
 > node could only ever explore a single child (see "A pre-existing MCTS bug"
-> below, now fixed on `fix/mcts-root-expansion`). Re-measured post-fix on
+> below, now fixed in PR #22). Re-measured post-fix on
 > `examples/minimax_benchmark.py`: `minimax as P1` against UCT-1,500 flipped
 > to **0/8** (minimax as P0 stayed 8/8; `vs random` unaffected both sides).
 > `examples/cross_engine_benchmark.py`'s move-agreement for MCTS rose from
@@ -690,7 +690,7 @@ piece of work, listed roughly by increasing scope):
    enough cells remain (default: 8 empty cells, where solves measured
    ~0.25–1.3s). `opening_engine="beam"` was always unaffected by the MCTS
    root-expansion bug below; `opening_engine="mcts"` inherited it until
-   the fix on `fix/mcts-root-expansion` (see below).
+   the fix in PR #22 (see below).
 4. **Eval-guided MCTS rollouts.** ✅ Done — `MCTSConfig.rollout_eval_config`/
    `rollout_epsilon`, opt-in and purely additive (`None` reproduces the
    original pure-random rollouts exactly). Measured cost (re-measured
@@ -702,8 +702,8 @@ piece of work, listed roughly by increasing scope):
 
 ### A pre-existing MCTS bug discovered while implementing item 4 — resolved 2026-07-11
 
-**Status: fixed**, on branch `fix/mcts-root-expansion`, together with a
-second, independently-discovered bug in `_calculate_ucb` (it computed the
+**Status: fixed**, in PR #22, together with a second,
+independently-discovered bug in `_calculate_ucb` (it computed the
 win-rate term from the *child's* `player_turn` instead of the *parent's*
 mover — backwards from the perspective of whichever player was actually
 choosing among the children). Both had to be fixed together: fixing only

--- a/docs/superpowers/plans/2026-07-10-cross-engine-3-eval-guided-mcts.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-3-eval-guided-mcts.md
@@ -267,3 +267,31 @@ section -- likely explains MCTS's consistently weak showing in every
 cross-engine benchmark so far this session (PR #17's "vs MCTS-1500"
 matchups, PR #18's move-agreement=0.500 result): MCTS may have never
 actually been exploring more than one root move in any of them.
+
+### Resolved on branch `fix/mcts-root-expansion`
+
+Both this bug and a second, independent one were fixed as a dedicated
+follow-up (not this plan's PR, per the scope decision above):
+
+1. `create_root_node` now creates the root with `flags=0` instead of
+   `NODE_FLAG_EXPANDED`, so `_select` correctly keeps returning the root
+   for expansion until every legal move has a child, matching `_expand`'s
+   own bookkeeping.
+2. A second bug in `_calculate_ucb` was found while validating fix (1):
+   it computed the win-rate term from the *child's* `player_turn` instead
+   of the *parent's* mover, so UCB was systematically preferring
+   whichever branch the opponent won through most -- backwards from the
+   perspective of the player actually choosing among children. Both had
+   to be fixed together; fixing only (1) still produced a non-winning
+   `search()` result on the plan's own mate-in-one test (`win_prob=0.276`
+   on a losing move) because the win-rate comparisons it now had access
+   to were themselves inverted.
+
+Post-fix, `test_eval_guided_search_runs_end_to_end` was restored to
+assert the actual mate-in-one move (`shape=3, position=3`) rather than
+the loose `isinstance`/probability-threshold check described above.
+`root only ever has one child` is no longer true: root now explores
+`>1` children on any position with a real search budget (see
+`test_root_explores_multiple_children_not_stuck_at_one` in
+`tests/test_mcts.py`). See `docs/research/2026-07-10-alpha-beta-eval-vs-mcts.md`'s
+"Future work" section for the corresponding resolution note.

--- a/docs/superpowers/plans/2026-07-10-cross-engine-3-eval-guided-mcts.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-3-eval-guided-mcts.md
@@ -268,7 +268,7 @@ cross-engine benchmark so far this session (PR #17's "vs MCTS-1500"
 matchups, PR #18's move-agreement=0.500 result): MCTS may have never
 actually been exploring more than one root move in any of them.
 
-### Resolved on branch `fix/mcts-root-expansion`
+### Resolved in PR #22
 
 Both this bug and a second, independent one were fixed as a dedicated
 follow-up (not this plan's PR, per the scope decision above):

--- a/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
@@ -278,3 +278,17 @@ rounds' patterns:
   overlapping-piece regression scenario from PR #19's test.
 
 Overall coverage after all four rounds: 92.03%.
+
+### Resolved on branch `fix/mcts-root-expansion`
+
+The MCTS root-expansion limitation documented above (`opening_engine=
+"mcts"` getting stuck with a single explored child) is fixed:
+`create_root_node` no longer marks the root pre-expanded, and a second,
+independently-discovered bug in `_calculate_ucb` (win-rate computed from
+the child's `player_turn` instead of the parent's mover) was fixed
+alongside it -- both were needed for `opening_engine="mcts"` to actually
+pick moves by search quality rather than move-generation order. The
+"Known limitation" language has been removed from `docs/HYBRID.md` and
+`src/quantik_core/hybrid.py`'s module docstring accordingly. See
+`docs/superpowers/plans/2026-07-10-cross-engine-3-eval-guided-mcts.md`'s
+own resolution note for the fix details.

--- a/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
+++ b/docs/superpowers/plans/2026-07-10-cross-engine-4-hybrid-player.md
@@ -279,7 +279,7 @@ rounds' patterns:
 
 Overall coverage after all four rounds: 92.03%.
 
-### Resolved on branch `fix/mcts-root-expansion`
+### Resolved in PR #22
 
 The MCTS root-expansion limitation documented above (`opening_engine=
 "mcts"` getting stuck with a single explored child) is fixed:

--- a/src/quantik_core/hybrid.py
+++ b/src/quantik_core/hybrid.py
@@ -6,16 +6,6 @@ solver once few enough cells remain. The handoff is by empty-cell count:
 Quantik's branching shrinks as pieces are placed, so a position with few
 empty cells has a small remaining tree that `MinimaxEngine.solve` resolves
 exactly and quickly.
-
-Known limitation when `opening_engine="mcts"`: `CompactGameTree.create_root_node`
-currently marks the root node as fully expanded at creation instead of only
-once every legal move has a child, which can leave MCTS's root with a
-single explored child regardless of `max_iterations` (see `docs/MCTS.md`'s
-"Known limitation" note). When that happens, the opening move MCTS returns
-is decided by move-generation order rather than search quality.
-`opening_engine="beam"` does not share this limitation -- `BeamSearchEngine`
-does not use `CompactGameTree`'s `NODE_FLAG_EXPANDED`/`_select` traversal
-at all.
 """
 
 from dataclasses import dataclass, field

--- a/src/quantik_core/mcts.py
+++ b/src/quantik_core/mcts.py
@@ -149,6 +149,14 @@ class MCTSEngine:
 
         UCB1 = win_rate + c * sqrt(ln(parent_visits) / child_visits)
 
+        The win rate must be from the perspective of `parent`'s mover --
+        the player *choosing* among `parent`'s children -- not the
+        child's own player_turn (the opponent, since add_child_node
+        always alternates player_turn). Using the child's player_turn
+        here selected children by how often the OPPONENT won through
+        them, systematically preferring moves that were worse for
+        whoever was actually choosing.
+
         Args:
             parent_id: Parent node ID
             child_id: Child node ID
@@ -163,21 +171,16 @@ class MCTSEngine:
         if child.visit_count == 0:
             return float("inf")
 
+        mover = int(parent.player_turn)
+
         # If parent unvisited, return child win rate only
         if parent.visit_count == 0:
-            player = int(child.player_turn)
-            if player == 0:
-                wins = child.win_count_p0
-            else:
-                wins = child.win_count_p1
+            wins = child.win_count_p0 if mover == 0 else child.win_count_p1
             return float(wins / child.visit_count)
 
-        # Calculate win rate from perspective of current player
-        player = int(child.player_turn)
-        if player == 0:
-            wins = child.win_count_p0
-        else:
-            wins = child.win_count_p1
+        # Win rate from the perspective of the player choosing (parent's
+        # mover), not the child's own player_turn.
+        wins = child.win_count_p0 if mover == 0 else child.win_count_p1
 
         win_rate = wins / child.visit_count
 

--- a/src/quantik_core/memory/compact_tree.py
+++ b/src/quantik_core/memory/compact_tree.py
@@ -290,9 +290,9 @@ class CompactGameTree:
         strict turn-balance validator so synthetic/terminal states
         (e.g. constructed directly for tests) don't raise.
 
-        `flags` starts at 0 (neither terminal nor expanded): `NODE_FLAG_
-        EXPANDED` is meant to be set only once every legal move has a
-        corresponding child (see `MCTSEngine._expand`'s own bookkeeping,
+        `flags` starts at 0 (neither terminal nor expanded):
+        `NODE_FLAG_EXPANDED` is meant to be set only once every legal move
+        has a corresponding child (see `MCTSEngine._expand`'s own bookkeeping,
         `if len(existing_children) + 1 == len(all_moves): ... EXPANDED`).
         A root created already-expanded made `MCTSEngine._select` treat
         the root as fully explored as soon as it had a SINGLE child,

--- a/src/quantik_core/memory/compact_tree.py
+++ b/src/quantik_core/memory/compact_tree.py
@@ -289,6 +289,18 @@ class CompactGameTree:
         turn-relative logic. Uses total-piece parity rather than the
         strict turn-balance validator so synthetic/terminal states
         (e.g. constructed directly for tests) don't raise.
+
+        `flags` starts at 0 (neither terminal nor expanded): `NODE_FLAG_
+        EXPANDED` is meant to be set only once every legal move has a
+        corresponding child (see `MCTSEngine._expand`'s own bookkeeping,
+        `if len(existing_children) + 1 == len(all_moves): ... EXPANDED`).
+        A root created already-expanded made `MCTSEngine._select` treat
+        the root as fully explored as soon as it had a SINGLE child,
+        stopping it from ever adding a second one -- MCTS's root got
+        exactly one explored child for the entire search, regardless of
+        `max_iterations`, with the returned move decided by move-
+        generation order rather than search quality. `BeamSearchEngine`
+        does not consult this flag, so it was unaffected.
         """
         canonical_state_data = initial_state.pack()
         player0_counts, player1_counts = count_pieces_by_shape(initial_state.bb)
@@ -301,7 +313,7 @@ class CompactGameTree:
             parent_id=np.uint32(0),  # Root has no parent
             depth=np.uint16(0),
             player_turn=np.uint8(player_turn),
-            flags=np.uint8(NODE_FLAG_EXPANDED),
+            flags=np.uint8(0),
             num_children=np.uint16(0),
             first_child_id=np.uint32(0),
             multiplicity=np.uint32(1),

--- a/tests/test_compact_tree.py
+++ b/tests/test_compact_tree.py
@@ -288,7 +288,14 @@ class TestCompactGameTree:
         assert root_node.depth == 0
         assert root_node.player_turn == 0
         assert root_node.parent_id == 0
-        assert root_node.flags == NODE_FLAG_EXPANDED
+        # Regression: the root must NOT start already-expanded.
+        # NODE_FLAG_EXPANDED is meant to be set only once every legal move
+        # has a corresponding child (see MCTSEngine._expand's bookkeeping).
+        # A root born already-expanded made MCTSEngine._select treat it as
+        # fully explored as soon as it had a single child, so MCTS's root
+        # got exactly one explored child for the entire search regardless
+        # of max_iterations -- fixed in create_root_node.
+        assert root_node.flags == 0
 
     def test_root_node_creation_derives_player_turn_from_piece_counts(self):
         """A root state where player 0 has moved once must record player_turn=1.

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -78,14 +78,24 @@ class TestMCTSEngine:
         config = MCTSConfig(max_iterations=500, random_seed=42)
         engine = MCTSEngine(config)
 
-        # P0: A at (0,0), B at (0,1); P1: c at (0,2), d at (1,0)
-        # Row 0 has shapes A, B, C — P0 can win by placing D at (0,3)
+        # P0: A at (0,0), B at (0,1); P1: c at (0,2), d at (1,0). Two
+        # immediate wins exist here: D at (0,3) completes row 0 (A,B,C,D),
+        # and C at (1,1) completes the top-left quadrant (A,B,d,C) --
+        # verified against MinimaxEngine.solve() and has_winning_line.
         state = State.from_qfen("ABc./d.../..../....")
         move, win_prob = engine.search(state)
 
-        # Should find a winning move (reasonable win probability)
+        # Should find a winning move with high confidence. Regression:
+        # before fixing (1) CompactGameTree.create_root_node marking the
+        # root already-expanded and (2) _calculate_ucb using the child's
+        # own player_turn instead of the parent's mover to pick the win
+        # count, this returned win_prob=0.276 for a NON-winning move.
+        from quantik_core import apply_move
+        from quantik_core.game_utils import has_winning_line
+
         assert isinstance(move, Move)
-        assert win_prob > 0.3  # Should have decent confidence
+        assert has_winning_line(apply_move(state.bb, move))
+        assert win_prob > 0.9
 
     def test_reproducibility_with_seed(self):
         """Test that same seed produces same results."""
@@ -148,6 +158,48 @@ class TestMCTSEngine:
         assert ucb > 0
         assert ucb < float("inf")
 
+    def test_ucb_uses_parent_movers_perspective_not_childs(self):
+        """Regression: UCB must select by win rate for the PARENT's mover.
+
+        add_child_node always sets child.player_turn = 1 - parent.player_
+        turn, so using the child's own player_turn to pick which win_count
+        field to read selects by how often the OPPONENT won through that
+        child -- the exact opposite of what UCB1 should optimize for the
+        player actually choosing among these children. Concretely: a
+        child where the root's own mover (P0) won 9/10 simulated games
+        must score HIGHER than a child where P0 only won 1/10, not lower.
+        """
+        engine = MCTSEngine(MCTSConfig(random_seed=1))
+        root_id = engine.tree.create_root_node(State.from_qfen("..../..../..../...."))
+        root = engine.tree.get_node(root_id)
+        assert int(root.player_turn) == 0  # P0 to move at the root
+
+        good_for_root_id = engine.tree.add_child_node(
+            root_id, State.from_qfen("A.../..../..../....")
+        )
+        bad_for_root_id = engine.tree.add_child_node(
+            root_id, State.from_qfen(".A../..../..../....")
+        )
+
+        good = engine.tree.get_node(good_for_root_id)
+        good.visit_count = np.uint32(10)
+        good.win_count_p0 = np.uint32(9)  # good for P0 (the root's mover)
+        good.win_count_p1 = np.uint32(1)
+        engine.tree.storage.store_node(good_for_root_id, good)
+
+        bad = engine.tree.get_node(bad_for_root_id)
+        bad.visit_count = np.uint32(10)
+        bad.win_count_p0 = np.uint32(1)  # bad for P0
+        bad.win_count_p1 = np.uint32(9)
+        engine.tree.storage.store_node(bad_for_root_id, bad)
+
+        root.visit_count = np.uint32(20)
+        engine.tree.storage.store_node(root_id, root)
+
+        ucb_good = engine._calculate_ucb(root_id, good_for_root_id)
+        ucb_bad = engine._calculate_ucb(root_id, bad_for_root_id)
+        assert ucb_good > ucb_bad
+
     def test_ucb_unvisited_child(self):
         """Test UCB returns infinity for unvisited children."""
         config = MCTSConfig(random_seed=42)
@@ -185,6 +237,27 @@ class TestMCTSEngine:
         child = engine.tree.get_node(child_id)
         assert child.depth == 1
         assert child.parent_id == root_id
+
+    def test_root_explores_multiple_children_not_stuck_at_one(self):
+        """Regression: the root must gain more than one child over several
+        search iterations.
+
+        Before fixing CompactGameTree.create_root_node (it marked the root
+        NODE_FLAG_EXPANDED at creation instead of only once every legal
+        move had a child), MCTSEngine._select treated the root as fully
+        explored as soon as it had a single child, so the root got exactly
+        one explored child for the entire search regardless of
+        max_iterations. A wide-branching position run for enough
+        iterations to clearly exceed one-child-only behavior must now show
+        multiple root children.
+        """
+        state = State.from_qfen("..../..../..../....")
+        engine = MCTSEngine(MCTSConfig(max_iterations=200, random_seed=1))
+        engine.search(state)
+
+        assert engine.root_id is not None
+        root_children = engine.tree.get_children(engine.root_id)
+        assert len(root_children) > 1
 
     def test_expand_wires_use_transposition_table_enabled(self):
         """_expand must forward config.use_transposition_table to the tree.
@@ -621,22 +694,22 @@ class TestEvalGuidedRollouts:
     def test_eval_guided_search_runs_end_to_end(self):
         # Integration smoke test: eval-guided rollouts must complete a real
         # search() and return a legal move with a sane win probability.
-        # NOT asserting the specific move returned equals the objectively
-        # best one (see docs/superpowers/plans/2026-07-10-cross-engine-3-
-        # eval-guided-mcts.md "Post-implementation notes": a pre-existing,
-        # out-of-scope bug in CompactGameTree.create_root_node makes the
-        # root node born already NODE_FLAG_EXPANDED, so MCTS's root ever
-        # gets exactly one child regardless of rollout policy or iteration
-        # budget -- the discrete move search() returns is determined by
-        # generate_legal_moves()'s iteration order, not by search quality.
-        # This affects the pre-existing default/random-rollout path too,
-        # matching the loose style of the suite's other search()-level
-        # tests (e.g. test_search_near_win_position above).
+        # This position (near-empty, 42 legal moves at the root -- P1 to
+        # move, with a mate-in-one at shape=3/pos=3) previously required a
+        # downgraded, non-move-specific assertion here (see git history):
+        # CompactGameTree.create_root_node marked the root already-
+        # expanded, so MCTS's root got exactly one explored child
+        # regardless of iteration budget, and _calculate_ucb separately
+        # used the child's own player_turn instead of the parent's mover
+        # to pick the win-rate perspective, inverting exploitation
+        # entirely. With both fixed, MCTS reliably finds the actual
+        # mate-in-one here -- restored to the plan's originally-intended
+        # assertion.
         from quantik_core.evaluation import EvalConfig
         from quantik_core.move import generate_legal_moves_list
 
         cfg = MCTSConfig(
-            max_iterations=200,
+            max_iterations=400,
             random_seed=1,
             rollout_eval_config=EvalConfig.load(),
             rollout_epsilon=0.2,
@@ -644,6 +717,7 @@ class TestEvalGuidedRollouts:
         state = State.from_qfen("AbC./..../..../....")
         best_move, win_prob = MCTSEngine(cfg).search(state)
         assert best_move in generate_legal_moves_list(state.bb)
+        assert best_move.shape == 3 and best_move.position == 3
         assert 0.0 <= win_prob <= 1.0
 
     def test_default_mcts_unchanged(self):

--- a/tests/test_mcts.py
+++ b/tests/test_mcts.py
@@ -161,8 +161,8 @@ class TestMCTSEngine:
     def test_ucb_uses_parent_movers_perspective_not_childs(self):
         """Regression: UCB must select by win rate for the PARENT's mover.
 
-        add_child_node always sets child.player_turn = 1 - parent.player_
-        turn, so using the child's own player_turn to pick which win_count
+        add_child_node always sets child.player_turn = 1 - parent.player_turn,
+        so using the child's own player_turn to pick which win_count
         field to read selects by how often the OPPONENT won through that
         child -- the exact opposite of what UCB1 should optimize for the
         player actually choosing among these children. Concretely: a


### PR DESCRIPTION
## Summary
- `CompactGameTree.create_root_node` created the root already marked `NODE_FLAG_EXPANDED`, so `_select()` treated it as fully explored after a single child — root got exactly one explored child for the entire search regardless of `max_iterations`, with the returned move decided by move-generation order rather than search quality.
- `MCTSEngine._calculate_ucb` computed the win-rate term from the *child's* `player_turn` instead of the *parent's* mover — backwards from the perspective of whoever was actually choosing among the children.
- Both bugs had to be fixed together: fixing only the first still produced a non-winning move on a hand-verified mate-in-one regression position, because the win-rate comparisons it then had access to were themselves inverted.
- Follow-up from the completed cross-engine cooperation work (PRs #18-21); tracked as "not fixed here, out of scope" in `docs/superpowers/plans/2026-07-10-cross-engine-3-eval-guided-mcts.md` and as a "Future work" item in `docs/research/2026-07-10-alpha-beta-eval-vs-mcts.md`.

## Measured impact
- `examples/cross_engine_benchmark.py`: MCTS move-agreement rose from 0.500 to 0.725.
- `examples/minimax_benchmark.py`: `vs MCTS1500(minimax P1)` flipped from 8/8 to 0/8 (minimax as P0, and vs random both sides, unaffected).
- `docs/MCTS.md`'s eval-guided-rollouts cost re-measured post-fix (10.6s random vs 53.8s eval-guided, ~5.1x, up from a previously-quoted ~4.3x — both configurations now do more real search work per run).

## Test plan
- [x] Added `test_root_explores_multiple_children_not_stuck_at_one` and `test_ucb_uses_parent_movers_perspective_not_childs` regressions in `tests/test_mcts.py`, both confirmed to fail against the pre-fix code.
- [x] Strengthened `test_search_near_win_position` to assert the actual winning move (was a loose `win_prob > 0.3` check).
- [x] Restored `test_eval_guided_search_runs_end_to_end`'s originally-intended mate-in-one assertion.
- [x] Updated `test_root_node_creation` in `tests/test_compact_tree.py` for the new `flags=0` root.
- [x] Full `./dev-check.sh` gate: 542 tests passed, black clean, flake8 clean, mypy clean, 92% coverage, build + twine check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHnCU3jTYCKNSrNPjTXiWR