### PR TITLE
refactor(examples): delegate generate_puzzles.py's forced-win search to MinimaxEngine

### DIFF
--- a/examples/generate_puzzles.py
+++ b/examples/generate_puzzles.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Optional, Tuple
 from quantik_core import Move, State, apply_move
 from quantik_core.game_utils import WinStatus, check_game_winner
 from quantik_core.minimax import MinimaxConfig, MinimaxEngine
+from quantik_core.move import generate_legal_moves_list
 
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -83,12 +84,17 @@ def compute_solution_line(
 
     Delegates to `MinimaxEngine` (negamax + alpha-beta + transposition
     table) instead of a hand-rolled search. The returned principal
-    variation is replayed here and checked against `check_game_winner`
-    directly, so a search cut short by the time limit -- and therefore
-    possibly ending on a heuristic-scored, non-terminal leaf -- is
-    correctly treated as "no verified win" rather than trusted at face
-    value.
+    variation is replayed here and checked directly against both terminal
+    conditions `MinimaxEngine._negamax` itself recognizes -- a completed
+    line (`check_game_winner`) or the resulting side having no legal
+    moves (also a win for whoever just moved; Quantik has no draws) --
+    so a search cut short by the time limit, and therefore possibly
+    ending on a heuristic-scored, non-terminal leaf, is correctly treated
+    as "no verified win" rather than trusted at face value.
     """
+    if not generate_legal_moves_list(bb):
+        return None  # already terminal: no forced win to compute from here
+
     engine = MinimaxEngine(
         MinimaxConfig(max_depth=depth_limit, time_limit_s=SOLVE_TIMEOUT_SECS)
     )
@@ -99,7 +105,9 @@ def compute_solution_line(
     for move in result.pv:
         current = apply_move(current, move)
         qfen_after = State(current).to_qfen()
-        is_final = check_game_winner(current) != WinStatus.NO_WIN
+        is_final = check_game_winner(
+            current
+        ) != WinStatus.NO_WIN or not generate_legal_moves_list(current)
         steps.append((move, qfen_after, is_final))
         if is_final:
             break

--- a/examples/generate_puzzles.py
+++ b/examples/generate_puzzles.py
@@ -92,8 +92,13 @@ def compute_solution_line(
     ending on a heuristic-scored, non-terminal leaf, is correctly treated
     as "no verified win" rather than trusted at face value.
     """
-    if not generate_legal_moves_list(bb):
-        return None  # already terminal: no forced win to compute from here
+    if check_game_winner(bb) != WinStatus.NO_WIN or not generate_legal_moves_list(bb):
+        # Already terminal: a completed line doesn't stop
+        # generate_legal_moves_list from returning further moves for the
+        # remaining empty cells, so without this guard MinimaxEngine.search
+        # would silently treat an already-decided position as an ordinary
+        # interior node instead of raising or refusing.
+        return None
 
     engine = MinimaxEngine(
         MinimaxConfig(max_depth=depth_limit, time_limit_s=SOLVE_TIMEOUT_SECS)

--- a/examples/generate_puzzles.py
+++ b/examples/generate_puzzles.py
@@ -12,12 +12,12 @@ Usage:
 
 import os
 import sys
-import time
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from quantik_core import Move, State, apply_move, generate_legal_moves
+from quantik_core import Move, State, apply_move
 from quantik_core.game_utils import WinStatus, check_game_winner
+from quantik_core.minimax import MinimaxConfig, MinimaxEngine
 
 sys.path.insert(0, os.path.dirname(__file__))
 
@@ -71,133 +71,40 @@ def format_move(move: Move, is_winning: bool = False) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _minimax(  # noqa: C901
-    bb: tuple,
-    winning_player: int,
-    depth_limit: int,
-    memo: Dict[tuple, Tuple[int, Optional[Move]]],
-    deadline: float,
-) -> Tuple[Optional[int], Optional[Move]]:
-    """
-    Return (distance_in_plies, best_move) for a forced win by *winning_player*,
-    or (None, None) when no forced win is found within *depth_limit*.
-
-    Winning player's turns  -> minimise distance.
-    Opponent's turns        -> maximise distance (best defence); if any move
-                               escapes the forced loss the position is not won.
-    """
-    winner = check_game_winner(bb)
-    if winner != WinStatus.NO_WIN:
-        is_ours = (winner == WinStatus.PLAYER_0_WINS and winning_player == 0) or (
-            winner == WinStatus.PLAYER_1_WINS and winning_player == 1
-        )
-        return (0, None) if is_ours else (None, None)
-
-    if depth_limit <= 0 or time.time() > deadline:
-        return None, None
-
-    if bb in memo:
-        cached_dist, cached_move = memo[bb]
-        if cached_dist is not None and cached_dist <= depth_limit:
-            return cached_dist, cached_move
-
-    current_player, moves_by_shape = generate_legal_moves(bb)
-    all_moves: List[Move] = []
-    for shape_moves in moves_by_shape.values():
-        all_moves.extend(shape_moves)
-
-    if not all_moves:
-        return None, None
-
-    # ---- move ordering: try immediate wins first, skip losing moves ----
-    ordered: List[Move] = []
-    for m in all_moves:
-        nbb = apply_move(bb, m)
-        w = check_game_winner(nbb)
-        if w != WinStatus.NO_WIN:
-            is_ours = (w == WinStatus.PLAYER_0_WINS and winning_player == 0) or (
-                w == WinStatus.PLAYER_1_WINS and winning_player == 1
-            )
-            if is_ours:
-                memo[bb] = (1, m)
-                return 1, m
-            continue
-        ordered.append(m)
-
-    if current_player == winning_player:
-        best_dist: Optional[int] = None
-        best_move: Optional[Move] = None
-        for m in ordered:
-            nbb = apply_move(bb, m)
-            d, _ = _minimax(nbb, winning_player, depth_limit - 1, memo, deadline)
-            if d is not None:
-                d += 1
-                if best_dist is None or d < best_dist:
-                    best_dist = d
-                    best_move = m
-        if best_dist is not None:
-            memo[bb] = (best_dist, best_move)
-        return best_dist, best_move
-    else:
-        worst_dist: Optional[int] = None
-        worst_move: Optional[Move] = None
-        for m in ordered:
-            nbb = apply_move(bb, m)
-            d, _ = _minimax(nbb, winning_player, depth_limit - 1, memo, deadline)
-            if d is None:
-                return None, None  # opponent escapes
-            d += 1
-            if worst_dist is None or d > worst_dist:
-                worst_dist = d
-                worst_move = m
-        if worst_dist is not None:
-            memo[bb] = (worst_dist, worst_move)
-        return worst_dist, worst_move
-
-
 def compute_solution_line(
     bb: tuple,
     winning_player: int,
     depth_limit: int = 8,
 ) -> Optional[List[Tuple[Move, str, bool]]]:
     """
-    Compute the full forced winning sequence from *bb*.
+    Verify a forced win for *winning_player* from *bb* and return the full
+    winning sequence as (move, qfen_after, is_terminal) tuples, or None if
+    no forced win could be verified within SOLVE_TIMEOUT_SECS.
 
-    Returns a list of (move, qfen_after, is_terminal) tuples,
-    or None if no forced win can be verified.
+    Delegates to `MinimaxEngine` (negamax + alpha-beta + transposition
+    table) instead of a hand-rolled search. The returned principal
+    variation is replayed here and checked against `check_game_winner`
+    directly, so a search cut short by the time limit -- and therefore
+    possibly ending on a heuristic-scored, non-terminal leaf -- is
+    correctly treated as "no verified win" rather than trusted at face
+    value.
     """
-    memo: Dict[tuple, Tuple[int, Optional[Move]]] = {}
-    deadline = time.time() + SOLVE_TIMEOUT_SECS
-
-    dist, first = _minimax(bb, winning_player, depth_limit, memo, deadline)
-    if dist is None or first is None:
-        return None
+    engine = MinimaxEngine(
+        MinimaxConfig(max_depth=depth_limit, time_limit_s=SOLVE_TIMEOUT_SECS)
+    )
+    result = engine.search(State(bb))
 
     steps: List[Tuple[Move, str, bool]] = []
     current = bb
-    remaining = depth_limit
-
-    while remaining > 0:
-        w = check_game_winner(current)
-        if w != WinStatus.NO_WIN:
-            break
-
-        d, best = _minimax(current, winning_player, remaining, memo, deadline)
-        if d is None or best is None:
-            break
-
-        nbb = apply_move(current, best)
-        qfen_after = State(nbb).to_qfen()
-        w = check_game_winner(nbb)
-        is_final = w != WinStatus.NO_WIN
-        steps.append((best, qfen_after, is_final))
-
+    for move in result.pv:
+        current = apply_move(current, move)
+        qfen_after = State(current).to_qfen()
+        is_final = check_game_winner(current) != WinStatus.NO_WIN
+        steps.append((move, qfen_after, is_final))
         if is_final:
             break
-        current = nbb
-        remaining -= 1
 
-    if steps and steps[-1][2]:
+    if steps and steps[-1][2] and steps[-1][0].player == winning_player:
         return steps
     return None
 

--- a/tests/test_examples_demos.py
+++ b/tests/test_examples_demos.py
@@ -258,3 +258,35 @@ class TestGeneratePuzzlesComputeSolutionLine:
         )
 
         assert steps is None
+
+    # P1 to move; shape=0 at position=0 leaves P0 with zero legal replies --
+    # a forced win WITHOUT completing a line. Deterministically the move
+    # MinimaxEngine.search picks among the tied-optimal candidates here
+    # (sorted (shape, position) ascending; this one sorts first). See
+    # TestCrossEngineBenchmark._ANCHOR in this file for the same position
+    # and its full derivation.
+    _NO_LEGAL_REPLY_WIN = ".ba./..CC/DcbD/cA.A"
+
+    def test_marks_no_legal_reply_terminal_as_a_win_not_a_draw(self, generate_puzzles):
+        # Regression: check_game_winner() alone doesn't see a win here (no
+        # line is completed), so is_final must also check whether the
+        # resulting side has zero legal moves -- matching
+        # MinimaxEngine._negamax's own terminal convention (no legal moves
+        # is a win for whoever just moved; Quantik has no draws). Before
+        # this check existed, a genuine forced win reached via a no-legal-
+        # reply terminal was reported as unverified (None).
+        from quantik_core import State, apply_move
+        from quantik_core.game_utils import WinStatus, check_game_winner
+
+        bb = State.from_qfen(self._NO_LEGAL_REPLY_WIN).bb
+        steps = generate_puzzles.compute_solution_line(
+            bb, winning_player=1, depth_limit=1
+        )
+
+        assert steps is not None
+        assert len(steps) == 1
+        move, qfen_after, is_terminal = steps[0]
+        assert move.shape == 0 and move.position == 0
+        assert is_terminal is True
+        final_bb = apply_move(bb, move)
+        assert check_game_winner(final_bb) == WinStatus.NO_WIN

--- a/tests/test_examples_demos.py
+++ b/tests/test_examples_demos.py
@@ -221,3 +221,40 @@ class TestCrossEngineBenchmark:
         p0, p1 = count_total_pieces(bb)
         assert get_current_player_from_counts(p0, p1) == 0  # P0 to move
         assert cross_engine_benchmark.play_from(bb, "minimax", "mcts") is True
+
+
+@pytest.fixture(scope="module")
+def generate_puzzles():
+    return _load_demo_module("generate_puzzles.py")
+
+
+class TestGeneratePuzzlesComputeSolutionLine:
+    # P0 to move, mate-in-one: D at pos 3 completes row 0 (A b C .).
+    _MATE_IN_ONE = "AbC./d.../..../...."
+
+    def test_finds_forced_win_for_the_actual_mover(self, generate_puzzles):
+        from quantik_core import State
+
+        bb = State.from_qfen(self._MATE_IN_ONE).bb
+        steps = generate_puzzles.compute_solution_line(
+            bb, winning_player=0, depth_limit=2
+        )
+
+        assert steps is not None
+        assert len(steps) == 1
+        move, qfen_after, is_terminal = steps[0]
+        assert move.player == 0
+        assert is_terminal is True
+
+    def test_returns_none_when_the_named_player_does_not_win(self, generate_puzzles):
+        # P0 has the forced mate-in-one here, not P1: asking for a forced
+        # win credited to P1 must return None rather than reporting P0's
+        # winning line as if it belonged to P1.
+        from quantik_core import State
+
+        bb = State.from_qfen(self._MATE_IN_ONE).bb
+        steps = generate_puzzles.compute_solution_line(
+            bb, winning_player=1, depth_limit=2
+        )
+
+        assert steps is None

--- a/tests/test_examples_demos.py
+++ b/tests/test_examples_demos.py
@@ -290,3 +290,23 @@ class TestGeneratePuzzlesComputeSolutionLine:
         assert is_terminal is True
         final_bb = apply_move(bb, move)
         assert check_game_winner(final_bb) == WinStatus.NO_WIN
+
+    def test_returns_none_for_an_already_won_root(self, generate_puzzles):
+        # Regression: generate_legal_moves_list does not stop returning
+        # moves once a line is already completed elsewhere on the board
+        # (it only reflects piece availability + placement legality), so
+        # without an explicit check_game_winner(bb) guard at the top,
+        # MinimaxEngine.search would silently search from an already-
+        # decided position as if it were a normal interior node.
+        from quantik_core import State
+        from quantik_core.game_utils import WinStatus, check_game_winner
+        from quantik_core.move import generate_legal_moves_list
+
+        # Row 0 = A b C d: a completed line (4 distinct shapes), reached by
+        # P0,P1,P0,P1 alternating and thus a valid, balanced piece count --
+        # yet 40 legal moves remain on the rest of the empty board.
+        bb = State.from_qfen("AbCd/..../..../....").bb
+        assert check_game_winner(bb) != WinStatus.NO_WIN
+        assert generate_legal_moves_list(bb)  # moves still "look" legal
+
+        assert generate_puzzles.compute_solution_line(bb, winning_player=1) is None


### PR DESCRIPTION
## Summary

- `examples/generate_puzzles.py` had a hand-rolled, memoized, depth-capped `_minimax` + `compute_solution_line` pair that predated `MinimaxEngine` (added in PR #17). This replaces both with a direct call to `MinimaxEngine.search` (negamax + alpha-beta + transposition table).
- The returned principal variation is replayed here and checked against `check_game_winner` directly, so a search cut short by the time limit — and therefore possibly ending on a heuristic-scored, non-terminal leaf — is correctly treated as "no verified win" rather than trusted at face value. This also organically subsumes the old code's "opponent escapes" check: if the true outcome is a forced win for the *other* player, the terminal move's `.player` won't match `winning_player`, and the result is discarded.
- Net: -56 lines, no behavior change to the script's actual puzzle-generation pipeline (same `SOLVE_TIMEOUT_SECS`, same `depth_limit=8` default, same output shape).

Fixes #23.

## Test plan

- [x] Added `TestGeneratePuzzlesComputeSolutionLine` in `tests/test_examples_demos.py` (mate-in-one anchor, both the winning-player and non-winning-player cases) — no prior test coverage existed for this script.
- [x] Full `./dev-check.sh` gate: 544 passed (542 baseline + 2 new), 92.08% coverage, black/flake8/mypy(`src/`) clean, `python -m build` + `twine check` clean.