### PR TITLE
fix(examples): encode no-legal-moves as a win for the opponent, not a draw

### DIFF
--- a/docs/OPENING_BOOK.md
+++ b/docs/OPENING_BOOK.md
@@ -337,13 +337,14 @@ position as a **win for the opponent** (`is_terminal=WIN_P0`/`WIN_P1`,
 `draw_count=0`), matching `Board.get_game_result()` (the authoritative
 game-rules implementation, which is explicit that "if a player has no
 legal moves, the other player wins") and `MinimaxEngine`'s own `_negamax`
-convention. The "Building from Game Tree" self-play example above and
-`examples/generate_opening_book.py` both instead encode this as
-`TerminalStatus.STALEMATE`/a draw (`draw_count=1`) — Quantik has no
-draws, so that appears to be a pre-existing bug in those examples rather
-than a legitimate alternate convention. If you mix entries from both
-sources in the same database, `is_terminal`/`draw_count` will not be
-self-consistent for no-legal-moves positions.
+convention. The "Building from Game Tree" self-play example above
+(`examples/opening_book_demo.py::explore_positions`) and
+`examples/generate_opening_book.py::_expand_chunk` previously encoded
+this as `TerminalStatus.STALEMATE`/a draw (`draw_count=1`) — Quantik has
+no draws, so that was a genuine bug rather than a legitimate alternate
+convention; both were fixed to match this filler's convention. All three
+opening-book-writing code paths in this repo now agree on the
+no-legal-moves case.
 
 ## Statistics and Analytics
 

--- a/examples/generate_opening_book.py
+++ b/examples/generate_opening_book.py
@@ -209,8 +209,9 @@ def _expand_chunk(
         sym_count = state.symmetry_count()
 
         all_moves: list = []
+        current_player = 0
         if winner == WinStatus.NO_WIN:
-            _, moves_by_shape = generate_legal_moves(bb)
+            current_player, moves_by_shape = generate_legal_moves(bb)
             for shape_moves in moves_by_shape.values():
                 all_moves.extend(shape_moves)
 
@@ -221,8 +222,16 @@ def _expand_chunk(
             ev, w0, w1, dr = -1.0, 0, 1, 0
             terminal = 2  # WIN_P1
         elif not all_moves:
-            ev, w0, w1, dr = 0.0, 0, 0, 1
-            terminal = 3  # STALEMATE
+            # No legal moves for current_player: Quantik has no draws, so
+            # the OTHER player wins here -- matching Board.get_game_result()
+            # and MinimaxEngine._negamax's convention, not a stalemate/draw.
+            winner_player = 1 - current_player
+            if winner_player == 0:
+                ev, w0, w1, dr = 1.0, 1, 0, 0
+                terminal = 1  # WIN_P0
+            else:
+                ev, w0, w1, dr = -1.0, 0, 1, 0
+                terminal = 2  # WIN_P1
         else:
             ev, w0, w1, dr = 0.0, 0, 0, 0
             terminal = 0  # INTERIOR

--- a/examples/opening_book_demo.py
+++ b/examples/opening_book_demo.py
@@ -77,16 +77,19 @@ def explore_positions(bb: tuple, depth: int, max_depth: int, positions: dict) ->
         all_moves.extend(shape_moves)
 
     if not all_moves:
-        # Stalemate
+        # No legal moves for current_player: Quantik has no draws, so the
+        # OTHER player wins here -- matching Board.get_game_result() and
+        # MinimaxEngine._negamax's convention, not a stalemate/draw.
+        winner_player = 1 - current_player
         positions[(canonical_key, depth)] = {
             "state": state,
             "depth": depth,
             "visit_count": 1,
-            "win_count_p0": 0,
-            "win_count_p1": 0,
-            "draw_count": 1,
+            "win_count_p0": 1 if winner_player == 0 else 0,
+            "win_count_p1": 1 if winner_player == 1 else 0,
+            "draw_count": 0,
             "best_moves": [],
-            "evaluation": 0.0,
+            "evaluation": 1.0 if winner_player == 0 else -1.0,
         }
         return
 

--- a/tests/test_examples_demos.py
+++ b/tests/test_examples_demos.py
@@ -221,3 +221,65 @@ class TestCrossEngineBenchmark:
         p0, p1 = count_total_pieces(bb)
         assert get_current_player_from_counts(p0, p1) == 0  # P0 to move
         assert cross_engine_benchmark.play_from(bb, "minimax", "mcts") is True
+
+
+@pytest.fixture(scope="module")
+def opening_book_demo():
+    return _load_demo_module("opening_book_demo.py")
+
+
+@pytest.fixture(scope="module")
+def generate_opening_book():
+    return _load_demo_module("generate_opening_book.py")
+
+
+class TestOpeningBookNoLegalMovesIsAWinNotADraw:
+    """Regression: Quantik has no draws. A position with no legal moves
+    and no completed line must be scored as a win for whichever player is
+    NOT to move (Board.get_game_result()'s own convention), not as a
+    stalemate/draw -- see docs/OPENING_BOOK.md's "no-legal-moves case"
+    callout and tuning/fill_opening_book.py's exact_entry, which already
+    follows this convention.
+    """
+
+    # No legal moves, no completed line (found by random self-play search):
+    # P0 to move (6 pieces each), every empty cell blocks every remaining
+    # shape for P0 via row/col/box constraints. P1 -- who is NOT to move --
+    # must be credited with the win.
+    _NO_LEGAL_MOVES_NO_WIN = "ca.c/DDbb/BC.a/B.C."
+
+    def test_explore_positions_credits_the_non_mover(self, opening_book_demo):
+        from quantik_core import State
+        from quantik_core.game_utils import check_game_winner, WinStatus
+
+        bb = State.from_qfen(self._NO_LEGAL_MOVES_NO_WIN).bb
+        assert check_game_winner(bb) == WinStatus.NO_WIN  # no completed line
+
+        positions: dict = {}
+        opening_book_demo.explore_positions(
+            bb, depth=0, max_depth=0, positions=positions
+        )
+
+        canonical_key = State(bb).canonical_key()
+        data = positions[(canonical_key, 0)]
+        assert data["draw_count"] == 0
+        assert data["win_count_p0"] == 0
+        assert data["win_count_p1"] == 1
+        assert data["evaluation"] == -1.0
+
+    def test_expand_chunk_credits_the_non_mover(self, generate_opening_book):
+        from quantik_core import State
+
+        bb = State.from_qfen(self._NO_LEGAL_MOVES_NO_WIN).bb
+
+        results = generate_opening_book._expand_chunk(
+            [bb], depth=12, dropout_rate=0.0, dropout_from_depth=999, seed=0
+        )
+
+        assert len(results) == 1
+        result = results[0]
+        assert result["draws"] == 0
+        assert result["w0"] == 0
+        assert result["w1"] == 1
+        assert result["eval"] == -1.0
+        assert result["is_terminal"] == 2  # WIN_P1

--- a/tuning/fill_opening_book.py
+++ b/tuning/fill_opening_book.py
@@ -62,17 +62,16 @@ def exact_entry(
     `_negamax` uses throughout `minimax.py`.
 
     A no-legal-moves position is scored as a WIN for the opponent here
-    (`is_terminal=WIN_P0`/`WIN_P1`, `draw_count=0`), NOT
-    `TerminalStatus.STALEMATE`/a draw. This intentionally diverges from
-    `examples/opening_book_demo.py` and `examples/generate_opening_book.py`,
-    which both encode no-legal-moves as a draw -- but `board.py`'s own
-    `Board.get_game_result()` (the authoritative game-rules implementation)
-    is explicit that "If a player has no legal moves, the other player
-    wins", and Quantik has no draws at all (confirmed: `WinStatus` has no
-    draw member, only `NO_WIN`/`PLAYER_0_WINS`/`PLAYER_1_WINS`). Those two
-    examples appear to carry a pre-existing bug; fixing them is out of
-    scope for this change, but a reader comparing conventions across the
-    opening-book-writing code in this repo should not assume they agree.
+    (`is_terminal=WIN_P0`/`WIN_P1`, `draw_count=0`), matching `board.py`'s
+    own `Board.get_game_result()` (the authoritative game-rules
+    implementation, which is explicit that "If a player has no legal
+    moves, the other player wins") -- Quantik has no draws at all
+    (confirmed: `WinStatus` has no draw member, only
+    `NO_WIN`/`PLAYER_0_WINS`/`PLAYER_1_WINS`). `examples/opening_book_demo.py`
+    and `examples/generate_opening_book.py` previously encoded
+    no-legal-moves as `TerminalStatus.STALEMATE`/a draw instead; both were
+    fixed to match this convention, so all opening-book-writing code paths
+    in this repo now agree.
 
     Raises `ValidationError` for an invalid `bb` (piece-count/overlap/
     turn-balance/placement violations) rather than treating it as a


### PR DESCRIPTION
## Summary

- `examples/opening_book_demo.py::explore_positions` and `examples/generate_opening_book.py::_expand_chunk` both encoded a no-legal-moves position as a draw/`STALEMATE` (`draw_count=1`).
- Quantik has no draws: `Board.get_game_result()` is explicit that "if a player has no legal moves, the other player wins", and `MinimaxEngine._negamax` follows the same convention. `tuning/fill_opening_book.py`'s `exact_entry` already encoded this correctly (win for the opponent, `draw_count=0`) — these two scripts disagreed with it, which meant mixing their output into the same opening-book database left `is_terminal`/`draw_count` self-inconsistent for no-legal-moves positions. This was already flagged (not fixed) in `docs/OPENING_BOOK.md`'s "Note on the no-legal-moves case" callout.
- Both fixed to credit the non-mover as the winner. `docs/OPENING_BOOK.md` and `tuning/fill_opening_book.py`'s docstring updated to say all three opening-book-writing code paths now agree.

Fixes #25.

## Test plan

- [x] Added `TestOpeningBookNoLegalMovesIsAWinNotADraw` in `tests/test_examples_demos.py`, covering both `explore_positions` and `_expand_chunk`, using a real no-legal-moves/no-completed-line position found via random self-play search (`ca.c/DDbb/BC.a/B.C.`).
- [x] Verified both new tests fail against the pre-fix code (temporarily reverted via `git stash`, confirmed `2 failed`, then restored the fix) before relying on them as regression guards.
- [x] Full `./dev-check.sh` gate: 544 passed, 92.08% coverage, black/flake8/mypy(`src/`) clean, `python -m build` + `twine check` clean.