### PR TITLE
docs: add release agent instructions

### DIFF
--- a/.claude/skills/make-release/SKILL.md
+++ b/.claude/skills/make-release/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: make-release
+description: Use when preparing, validating, documenting, or publishing a quantik-core release. Covers branch setup, version and metadata updates, changelog/docs checks, local quality gates, artifact validation, PR review, tagging, and PyPI/GitHub release handoff.
+---
+
+# Make Release
+
+Use this skill for release work in `quantik-core-py`, especially requests like "make a release", "prepare 1.0.0", "validate release artifacts", "cut a tag", or "publish to PyPI".
+
+## Release Posture
+
+Treat releases as packaging and API stabilization work, not opportunistic refactors. Keep edits scoped to release correctness: public API contracts, version metadata, changelog, docs, quality gates, artifacts, and publish automation.
+
+Before changing files, read the latest release plan if one exists under `docs/superpowers/plans/*release*.md`. If the plan has task checkboxes, keep progress updated there so another agent can resume.
+
+## Workflow
+
+1. Start from a clean, synchronized `main` unless the user explicitly names another branch.
+2. Preserve any existing user work before switching branches. Do not overwrite dirty or untracked files.
+3. Create a release branch, normally `release/vX.Y.Z`.
+4. Update package metadata and supported Python classifiers consistently across `pyproject.toml`, `src/quantik_core/__init__.py`, docs, and changelog.
+5. Review the public API surface and import cost. Stable exports belong in `quantik_core.__init__`; experimental or heavy modules should stay explicit subpackage imports.
+6. Update release documentation: `CHANGELOG.md`, `README.md`, architecture/API stability docs, examples, and any workflow notes affected by the release.
+7. Verify artifacts before publishing: build sdist/wheel, inspect metadata, and run `twine check` when available.
+8. Open a PR for review unless the user explicitly asks for a local-only release preparation.
+9. After approval and green checks, tag from the merge commit and publish through the configured trusted release path.
+
+## Required Local Gates
+
+Use the repository virtual environment:
+
+```bash
+.venv/bin/python -m pytest tests/ -q --cov=quantik_core --cov-report=term-missing
+.venv/bin/python -m black --check .
+.venv/bin/python -m flake8 . --count --statistics
+.venv/bin/python -m mypy src/quantik_core/
+./auto-lint.sh
+./dev-check.sh
+```
+
+If dependencies are missing, report the exact blocker and do not claim release readiness. Network-dependent installs or publishing require explicit permission.
+
+## PR and Handoff
+
+A release PR should include:
+
+- release version and target tag
+- notable API or packaging changes
+- docs/changelog updates
+- local gate results
+- artifact validation status
+- any publish blockers or manual steps
+
+Do not publish, tag, or delete release branches unless the user has explicitly asked for that step.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+
+After receiving a clear definition of goal, use a superior model (`opus`, `fable`) as a consultant and coordinator, while coding tasks implementation can be delegated to `sonnet`/`haiku`. 
+
+Use an agent team where you have a team lead, teammates (sub-agents) who share the same tasklist and can communicate over a messaging system (mailbox).
+
+Be mindful about token consumption and which model needs to be used.
+
+### Guardrails around code quality
+
+Local development using .venv
+```
+# Check if .venv folder exists
+if [ ! -d ".venv" ]; then
+    # Create virtual environment
+    python -m venv .venv
+
+    # Install development dependencies
+    .venv/bin/python -m pip install -e ".[dev,cbor]"
+fi
+
+PYTHON=".venv/bin/python"
+```
+
+Pre-commit checks:
+1. Auto-fix lint: `./auto-lint.sh`
+2. Full CI checks: `./dev-check.sh`
+
+## Agentic Release Work
+
+For release tasks, use the Claude skill at `.claude/skills/make-release/SKILL.md`. Keep release work scoped, preserve user changes before branch operations, use `.venv`, run `./auto-lint.sh` before commits, and run `./dev-check.sh` before pushes or release handoff.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,142 @@
+<!-- rtk-instructions v2 -->
+# RTK (Rust Token Killer) - Token-Optimized Commands
+
+## Golden Rule
+
+**Always prefix commands with `rtk`**. If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
+
+**Important**: Even in command chains with `&&`, use `rtk`:
+```bash
+# ❌ Wrong
+git add . && git commit -m "msg" && git push
+
+# ✅ Correct
+rtk git add . && rtk git commit -m "msg" && rtk git push
+```
+
+## RTK Commands by Workflow
+
+### Build & Compile (80-90% savings)
+```bash
+rtk cargo build         # Cargo build output
+rtk cargo check         # Cargo check output
+rtk cargo clippy        # Clippy warnings grouped by file (80%)
+rtk tsc                 # TypeScript errors grouped by file/code (83%)
+rtk lint                # ESLint/Biome violations grouped (84%)
+rtk prettier --check    # Files needing format only (70%)
+rtk next build          # Next.js build with route metrics (87%)
+```
+
+### Test (60-99% savings)
+```bash
+rtk cargo test          # Cargo test failures only (90%)
+rtk go test             # Go test failures only (90%)
+rtk jest                # Jest failures only (99.5%)
+rtk vitest              # Vitest failures only (99.5%)
+rtk playwright test     # Playwright failures only (94%)
+rtk pytest              # Python test failures only (90%)
+rtk rake test           # Ruby test failures only (90%)
+rtk rspec               # RSpec test failures only (60%)
+rtk test <cmd>          # Generic test wrapper - failures only
+```
+
+### Git (59-80% savings)
+```bash
+rtk git status          # Compact status
+rtk git log             # Compact log (works with all git flags)
+rtk git diff            # Compact diff (80%)
+rtk git show            # Compact show (80%)
+rtk git add             # Ultra-compact confirmations (59%)
+rtk git commit          # Ultra-compact confirmations (59%)
+rtk git push            # Ultra-compact confirmations
+rtk git pull            # Ultra-compact confirmations
+rtk git branch          # Compact branch list
+rtk git fetch           # Compact fetch
+rtk git stash           # Compact stash
+rtk git worktree        # Compact worktree
+```
+
+Note: Git passthrough works for ALL subcommands, even those not explicitly listed.
+
+### GitHub (26-87% savings)
+```bash
+rtk gh pr view <num>    # Compact PR view (87%)
+rtk gh pr checks        # Compact PR checks (79%)
+rtk gh run list         # Compact workflow runs (82%)
+rtk gh issue list       # Compact issue list (80%)
+rtk gh api              # Compact API responses (26%)
+```
+
+### JavaScript/TypeScript Tooling (70-90% savings)
+```bash
+rtk pnpm list           # Compact dependency tree (70%)
+rtk pnpm outdated       # Compact outdated packages (80%)
+rtk pnpm install        # Compact install output (90%)
+rtk npm run <script>    # Compact npm script output
+rtk npx <cmd>           # Compact npx command output
+rtk prisma              # Prisma without ASCII art (88%)
+```
+
+### Files & Search (60-75% savings)
+```bash
+rtk ls <path>           # Tree format, compact (65%)
+rtk read <file>         # Code reading with filtering (60%)
+rtk grep <pattern>      # Search grouped by file (75%). Format flags (-c, -l, -L, -o, -Z) run raw.
+rtk find <pattern>      # Find grouped by directory (70%)
+```
+
+### Analysis & Debug (70-90% savings)
+```bash
+rtk err <cmd>           # Filter errors only from any command
+rtk log <file>          # Deduplicated logs with counts
+rtk json <file>         # JSON structure without values
+rtk deps                # Dependency overview
+rtk env                 # Environment variables compact
+rtk summary <cmd>       # Smart summary of command output
+rtk diff                # Ultra-compact diffs
+```
+
+### Infrastructure (85% savings)
+```bash
+rtk docker ps           # Compact container list
+rtk docker images       # Compact image list
+rtk docker logs <c>     # Deduplicated logs
+rtk kubectl get         # Compact resource list
+rtk kubectl logs        # Deduplicated pod logs
+```
+
+### Network (65-70% savings)
+```bash
+rtk curl <url>          # Compact HTTP responses (70%)
+rtk wget <url>          # Compact download output (65%)
+```
+
+### Meta Commands
+```bash
+rtk gain                # View token savings statistics
+rtk gain --history      # View command history with savings
+rtk discover            # Analyze Claude Code sessions for missed RTK usage
+rtk proxy <cmd>         # Run command without filtering (for debugging)
+rtk init                # Add RTK instructions to CLAUDE.md
+rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
+```
+
+## Token Savings Overview
+
+| Category | Commands | Typical Savings |
+|----------|----------|-----------------|
+| Tests | vitest, playwright, cargo test | 90-99% |
+| Build | next, tsc, lint, prettier | 70-87% |
+| Git | status, log, diff, add, commit | 59-80% |
+| GitHub | gh pr, gh run, gh issue | 26-87% |
+| Package Managers | pnpm, npm, npx | 70-90% |
+| Files | ls, read, grep, find | 60-75% |
+| Infrastructure | docker, kubectl | 85% |
+| Network | curl, wget | 65-70% |
+
+Overall average: **60-90% token reduction** on common development operations.
+<!-- /rtk-instructions -->
+
+## Repository Skills
+
+- Use `.claude/skills/make-release/SKILL.md` when preparing, validating, tagging, publishing, or handing off a `quantik-core` release. Read any matching release plan in `docs/superpowers/plans/` first and keep its progress checkboxes current.


### PR DESCRIPTION
## Summary
- Add a Claude skill for preparing and handing off quantik-core releases
- Add Claude and AGENTS entry points that point agents to the release skill
- Keep release workflow guardrails explicit: preserve user work, use .venv, run auto-lint before commits, and dev-check before pushes or release handoff

## Verification
- ./auto-lint.sh
- ./dev-check.sh (652 passed, coverage 92.43%; existing advisory flake8 output remains non-blocking in the script)