### PR TITLE
docs: preserve release plan and ignore local rtk state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # Project-specific ignores
+.rtk/
 benchmarks/results/
 *.prof
 *.lprof

--- a/docs/superpowers/plans/2026-06-22-1.0.0-release.md
+++ b/docs/superpowers/plans/2026-06-22-1.0.0-release.md
@@ -1,0 +1,1528 @@
+# Quantik Core 1.0.0 Release Implementation Plan
+
+> **Status note - 2026-07-13:** This file is kept as the historical 1.0.0 implementation plan and resumable release checklist. Its "Current Release Snapshot" records the state observed on 2026-06-22, not the current repository state. Current `main` already contains the 1.0.0 metadata, changelog, API stability docs, examples docs, build validation, benchmark evidence, and the `.claude/skills/make-release/SKILL.md` release workflow. Before tagging or publishing, re-check current PyPI/GitHub state and follow the release skill rather than assuming the stale snapshot is still true.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `quantik-core` 1.0.0 from a synchronized `main` branch with a stable public API, green quality gates, accurate PyPI metadata, consolidated changelog, and usable architecture/examples documentation.
+
+**Architecture:** Treat 1.0.0 as an API and packaging stabilization release, not a rewrite. Keep the stable public surface in `quantik_core.__init__`, make heavy memory/profiling/MCTS components explicit subpackages, and document which modules are stable versus experimental.
+
+**Tech Stack:** Python 3.10-3.13, setuptools, pytest, pytest-cov, Hypothesis, Black, flake8, mypy, GitHub Actions, PyPI trusted publishing, twine, build.
+
+---
+
+## Current Release Snapshot
+
+- PyPI latest is `0.1.1`, uploaded on 2025-09-05. PyPI only has `0.1.0` and `0.1.1`.
+- PyPI metadata still reports Alpha status, `requires_python >=3.9`, stale README text, and project URLs pointing at `github.com/mauroberlanda/quantik-core-py`.
+- The GitHub repository is `mberlanda/quantik-core-py`, default branch `main`, latest pushed commit `176fa7c` on 2026-04-21.
+- This local checkout is on `unit-tests-fixtures` at `d49d26a`, which is behind remote `main` by the April 2026 `#11` MCTS/opening-book/puzzle commit.
+- Current local dirty worktree before this plan: modified `tests/fixtures.py`, untracked `qfen_validation_results.txt`, untracked `validate_qfen_fixtures.py`.
+- Local verification with `PYTHONPATH=src .venv/bin/python -m pytest tests/ -q --cov=quantik_core --cov-report=term-missing`: `313 passed, 4 failed`, total coverage `89.90%`, fails the `90%` gate.
+- Local verification with `PYTHONPATH=src .venv/bin/python -m black --check .`: fails on `tests/fixtures.py` and `validate_qfen_fixtures.py`.
+- Local verification with `PYTHONPATH=src .venv/bin/python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`: passes.
+- Local verification with `PYTHONPATH=src .venv/bin/python -m mypy src/quantik_core/`: passes.
+
+Sources checked:
+
+- PyPI JSON: `https://pypi.org/pypi/quantik-core/json`
+- PyPI page: `https://pypi.org/project/quantik-core/`
+- GitHub repo API: `https://api.github.com/repos/mberlanda/quantik-core-py`
+- GitHub latest tree API: `https://api.github.com/repos/mberlanda/quantik-core-py/git/trees/176fa7cf515f486a6a65f83dfdb4d19257a611b5?recursive=1`
+
+## Implementation Progress - 2026-06-22
+
+- Created `release/v1.0.0` and fast-forwarded it to `origin/main` at `176fa7c`.
+- Updated package metadata to version `1.0.0`, production/stable classifier, Python `>=3.10`, and `mberlanda/quantik-core-py` project URLs.
+- Moved `types-psutil` out of runtime dependencies and added build/twine to the dev extra.
+- Fixed malformed QFEN examples in README and core docstrings.
+- Added `CHANGELOG.md`, `docs/ARCHITECTURE.md`, `docs/EXAMPLES.md`, and `docs/API_STABILITY.md`.
+- Added public API, import-contract, fixture-format, board `player=0`, and invalid-bitboard regression tests.
+- Fixed `QuantikBoard` optional-player handling, invalid 16-bit bitboard validation, lazy memory exports, and lazy symmetry LUT initialization.
+- Updated `dev-check.sh` to run tools through `.venv/bin/python -m ...` instead of relying on shell activation.
+- Verified in sandbox: `411 passed`, coverage `90.55%`; Black clean; full flake8 `0`; mypy clean.
+- Artifact build remains blocked in this session because `.venv` lacks `setuptools`/`wheel`, build isolation needs network, and the escalation request was rejected by the local approval system.
+
+## VoltAgent Review Inputs
+
+The release review used VoltAgent Subagents with these lenses:
+
+- `voltagent-subagents:qa-expert`: release is blocked by invalid fixture QFENs, coverage has no buffer, fixture validation is not collected by pytest, full flake8 is advisory, publish lacks `twine check`.
+- `voltagent-subagents:architect-reviewer` and `voltagent-subagents:code-reviewer`: public API export mismatch, version mismatch, stale docs, `QuantikBoard` mishandles explicit `player=0`, winner semantics need a stable contract, core imports pull heavy memory dependencies.
+- `voltagent-subagents:python-pro`: `validate_game_state()` accepts out-of-board bits, import cost is high because symmetry LUTs initialize eagerly, `pickle.load()` needs a trust-boundary policy, `types-psutil` should not be a runtime dependency.
+
+## File Structure
+
+- Modify `pyproject.toml`: version, classifiers, Python support, dependencies, project URLs, quality/tooling configuration.
+- Modify `src/quantik_core/__init__.py`: stable API exports, runtime version source, no unbound `__all__` entries.
+- Modify `src/quantik_core/state_validator.py`: enforce bitboard length, integer values, and `0 <= value <= 0xFFFF`.
+- Modify `src/quantik_core/board.py`: fix optional player handling and document legal-move semantics.
+- Modify `src/quantik_core/game_utils.py`: clarify winner attribution contract or split line-detection from winner attribution.
+- Modify `src/quantik_core/memory/__init__.py`: remove eager imports of compression/tree modules.
+- Modify `src/quantik_core/symmetry.py`: make LUT initialization lazy or measure and document accepted import cost.
+- Modify `src/quantik_core/storage/game_tree.py`: mark pickle checkpoint loading trusted-only or replace before stable API.
+- Modify `tests/fixtures.py`: repair malformed QFENs and separate valid parse fixtures from intentionally invalid game-state fixtures.
+- Create `tests/test_public_api.py`: import-contract and version tests.
+- Create `tests/test_fixtures.py`: fixture QFEN format and consistency tests.
+- Modify `tests/test_state_validator.py`: invalid bitboard value regression tests.
+- Modify `tests/test_board.py`: explicit `player=0` regression tests.
+- Modify `tests/test_storage.py`, `tests/test_memory_profiling.py`, `tests/test_game_stats.py`: coverage uplift around lowest-coverage branches.
+- After syncing remote `main`, modify or review `src/quantik_core/mcts.py`, `src/quantik_core/opening_book.py`, `tests/test_mcts.py`, `tests/test_opening_book.py`, `examples/mcts_demo.py`, and `examples/opening_book_demo.py`.
+- Create `CHANGELOG.md`: consolidated `0.1.1` to `1.0.0` changelog.
+- Create `docs/ARCHITECTURE.md`: package architecture and module responsibilities.
+- Create `docs/EXAMPLES.md`: tested usage examples.
+- Create `docs/API_STABILITY.md`: stable versus experimental surface.
+- Modify `README.md`: PyPI long description, valid QFEN examples, current feature list, docs links.
+- Modify `.github/workflows/test.yml`: make full lint a gate.
+- Modify `.github/workflows/build.yml`: install and twine-check artifacts.
+- Modify `.github/workflows/integration.yml`: smoke-test examples and optional dependencies.
+- Modify `.github/workflows/publish.yml`: gate publish on quality/build verification and run `twine check`.
+- Modify `dev-check.sh`: use a resolved interpreter and strict checks.
+- Create a dedicated docs cleanup branch for working docs: `docs/v1-working-docs-cleanup`.
+
+## Task 0: Preserve Worktree and Sync Release Baseline
+
+**Files:**
+- No source edits in this task.
+- Review: `tests/fixtures.py`
+- Review: `qfen_validation_results.txt`
+- Review: `validate_qfen_fixtures.py`
+
+- [ ] **Step 1: Capture current user work**
+
+Run:
+
+```bash
+git status --short --branch
+git diff -- tests/fixtures.py
+```
+
+Expected: branch is `unit-tests-fixtures`; existing user work is visible in `tests/fixtures.py`, `qfen_validation_results.txt`, and `validate_qfen_fixtures.py`.
+
+- [ ] **Step 2: Commit the user-owned fixture work before release edits**
+
+Commit the current fixture work on its current branch so release edits start from a named baseline:
+
+```bash
+git add tests/fixtures.py qfen_validation_results.txt validate_qfen_fixtures.py
+git commit -m "test: consolidate qfen fixture validation"
+```
+
+Expected: work is preserved and no release branch starts with unidentified dirty changes.
+
+- [ ] **Step 3: Sync local `main` with GitHub**
+
+Run:
+
+```bash
+git fetch origin main
+git switch main
+git pull --ff-only origin main
+git log --oneline -1
+```
+
+Expected: latest commit is `176fa7c` with message `feat: add MCTS engine, opening book database, and puzzle generator (#11)`.
+
+- [ ] **Step 4: Create the release branch**
+
+Run:
+
+```bash
+git switch -c release/v1.0.0
+```
+
+Expected: all 1.0.0 release edits happen on `release/v1.0.0`.
+
+## Task 1: Restore Green Fixture Baseline
+
+**Files:**
+- Modify: `tests/fixtures.py`
+- Create: `tests/test_fixtures.py`
+- Review: `qfen_validation_results.txt`
+- Test: `tests/test_storage.py`
+
+- [ ] **Step 1: Add failing fixture-format tests**
+
+Create `tests/test_fixtures.py`:
+
+```python
+import pytest
+
+from quantik_core.qfen import bb_from_qfen
+from tests.fixtures import CanonicalBitboardFactory, UnifiedTestCases
+
+
+@pytest.mark.parametrize("case", UnifiedTestCases.all_cases(), ids=lambda case: case.name)
+def test_unified_test_case_qfen_has_four_ranks_of_four_chars(case):
+    ranks = case.qfen.split("/")
+    assert len(ranks) == 4
+    assert all(len(rank) == 4 for rank in ranks), case.qfen
+    bb_from_qfen(case.qfen)
+
+
+def test_canonical_fixture_factory_cases_are_consistent():
+    for fixture in CanonicalBitboardFactory.all_fixtures():
+        assert fixture.state.to_qfen() == fixture.qfen
+        assert fixture.compact_bitboard.to_tuple() == fixture.bitboard
+```
+
+- [ ] **Step 2: Run the new tests and confirm failure**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_fixtures.py -q
+```
+
+Expected: failures identify malformed QFEN strings such as `..../..../..../..`.
+
+- [ ] **Step 3: Repair malformed QFEN literals**
+
+In `tests/fixtures.py`, every QFEN rank must have exactly four characters. Update the `qfen` string for each named `TestCase` as follows:
+
+| Test case name | Correct QFEN |
+| --- | --- |
+| `empty_board` | `..../..../..../....` |
+| `single_piece_corner` | `A.../..../..../....` |
+| `single_piece_center` | `..../..A./..../....` |
+| `alternating_moves` | `Ab../..../..../....` |
+| `winning_row` | `AbCd/..../..../....` |
+| `winning_column` | `A.../B.../C.../D...` |
+| `mixed_players_winning` | `AbcD/..../..../....` |
+| `qfen_single_piece` | `A.../..../..../....` |
+| `qfen_alternating_rows` | `AB../ba../..../....` |
+| `qfen_winning_line` | `ABCD/..../..../....` |
+| `utils_row_win_p0` | `ABCD/..../..../....` |
+| `utils_mixed_row_win` | `AbcD/..../..../....` |
+| `utils_column_mixed` | `A.../b.../C.../d...` |
+| `utils_incomplete_rows` | `AB../cd../..../....` |
+| `utils_incomplete_row` | `ABC./..../..../....` |
+| `utils_mixed_top_row` | `ABcd/..../..../....` |
+| `board_double_shapes` | `AA../..aa/..../....` |
+| `board_scattered_pieces` | `Ab../..../..Ac/....` |
+| `sym_basic_transform` | `A.../.b../..../....` |
+| `sym_rotated` | `...A/..b./..../....` |
+| `sym_color_swap` | `a.../.B../..../....` |
+| `sym_shape_perm` | `B.../.a../..../....` |
+| `sym_complex_transform` | `...b/..A./..../....` |
+| `sym_two_pieces` | `A.B./..../..../....` |
+| `sym_mixed_position` | `A..b/.c../..D./....` |
+| `validator_valid_balance` | `A.../..../..a./....` |
+| `validator_too_many_pieces` | `AAA./..../..../....` |
+| `validator_imbalanced` | `abc./..../..../....` |
+| `validator_same_shape_conflict` | `A.../a.../..../....` |
+
+Keep intentionally invalid game states if they are valid QFEN strings; tag them as invalid game states instead of malformed QFEN.
+
+- [ ] **Step 4: Run fixture and storage tests**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_fixtures.py tests/test_storage.py -q
+```
+
+Expected: fixture parsing passes and storage failures caused by malformed QFENs are gone.
+
+- [ ] **Step 5: Format fixture work**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m black tests/fixtures.py tests/test_fixtures.py validate_qfen_fixtures.py
+```
+
+Expected: Black completes without remaining formatting diffs.
+
+- [ ] **Step 6: Commit fixture stabilization**
+
+Run:
+
+```bash
+git add tests/fixtures.py tests/test_fixtures.py validate_qfen_fixtures.py qfen_validation_results.txt
+git commit -m "test: stabilize qfen fixture catalog"
+```
+
+Expected: release branch has a green fixture foundation.
+
+## Task 2: Fix State Validation for 1.0 Correctness
+
+**Files:**
+- Modify: `src/quantik_core/state_validator.py`
+- Modify: `tests/test_state_validator.py`
+
+- [ ] **Step 1: Add failing invalid-bitboard tests**
+
+Append to `tests/test_state_validator.py`:
+
+```python
+import pytest
+
+from quantik_core.state_validator import ValidationResult, validate_game_state
+
+
+def test_validate_game_state_rejects_bits_outside_4x4_board():
+    player, result = validate_game_state((1 << 16, 0, 0, 0, 0, 0, 0, 0))
+
+    assert player is None
+    assert result == ValidationResult.INVALID_POSITION
+
+
+@pytest.mark.parametrize(
+    "bad_bb",
+    [
+        (-1, 0, 0, 0, 0, 0, 0, 0),
+        (0, 0, 0, 0, 0, 0, 0, 0x10000),
+    ],
+)
+def test_validate_game_state_rejects_non_16_bit_values(bad_bb):
+    player, result = validate_game_state(bad_bb)
+
+    assert player is None
+    assert result == ValidationResult.INVALID_POSITION
+```
+
+- [ ] **Step 2: Run tests and confirm failure**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_state_validator.py -q
+```
+
+Expected: the new invalid-position tests fail before implementation.
+
+- [ ] **Step 3: Implement 16-bit value validation**
+
+In `src/quantik_core/state_validator.py`, add a board mask near the type aliases:
+
+```python
+BOARD_MASK = 0xFFFF
+```
+
+Then update `_validate_piece_counts_and_overlaps()` before `piece_count = bb_value.bit_count()`:
+
+```python
+        bb_value = bb[i]
+        if not isinstance(bb_value, int) or bb_value < 0 or bb_value > BOARD_MASK:
+            return ValidationResult.INVALID_POSITION, [], 0, 0
+
+        piece_count = bb_value.bit_count()
+```
+
+- [ ] **Step 4: Run validator and core tests**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_state_validator.py tests/test_core.py tests/test_qfen.py -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit validator fix**
+
+Run:
+
+```bash
+git add src/quantik_core/state_validator.py tests/test_state_validator.py
+git commit -m "fix: reject invalid bitboard positions"
+```
+
+## Task 3: Stabilize Public API and Version Metadata
+
+**Files:**
+- Modify: `src/quantik_core/__init__.py`
+- Modify: `pyproject.toml`
+- Create: `tests/test_public_api.py`
+
+- [ ] **Step 1: Add failing public API tests**
+
+Create `tests/test_public_api.py`:
+
+```python
+from importlib.metadata import version
+
+import quantik_core
+
+
+def test_public_all_exports_are_bound():
+    missing = [name for name in quantik_core.__all__ if not hasattr(quantik_core, name)]
+
+    assert missing == []
+
+
+def test_wildcard_import_contract():
+    namespace = {}
+    exec("from quantik_core import *", namespace)
+
+    for name in quantik_core.__all__:
+        assert name in namespace
+
+
+def test_runtime_version_matches_installed_distribution():
+    assert quantik_core.__version__ == version("quantik-core")
+```
+
+- [ ] **Step 2: Run public API tests and confirm failure**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pip install -e .
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_public_api.py -q
+```
+
+Expected: tests fail because `__version__` is `0.1.0` and `__all__` includes unbound names.
+
+- [ ] **Step 3: Define the stable top-level API**
+
+Update `src/quantik_core/__init__.py` so top-level exports are bound and limited to the stable API:
+
+```python
+"""Quantik Core - high-performance game state manipulation library."""
+
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:  # pragma: no cover
+    from importlib_metadata import PackageNotFoundError, version
+
+from .board import GameResult, MoveRecord, PlayerInventory, QuantikBoard
+from .commons import Bitboard, FLAG_CANON, PlayerId, VERSION
+from .core import State
+from .move import (
+    Move,
+    apply_move,
+    generate_legal_moves,
+    generate_legal_moves_list,
+    validate_move,
+)
+from .qfen import bb_from_qfen, bb_to_qfen
+from .state_validator import ValidationResult
+from .symmetry import SymmetryHandler, SymmetryTransform
+
+try:
+    __version__ = version("quantik-core")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0+editable"
+
+__author__ = "Mauro Berlanda"
+
+__all__ = [
+    "VERSION",
+    "FLAG_CANON",
+    "State",
+    "Bitboard",
+    "Move",
+    "validate_move",
+    "apply_move",
+    "generate_legal_moves",
+    "generate_legal_moves_list",
+    "bb_to_qfen",
+    "bb_from_qfen",
+    "ValidationResult",
+    "PlayerId",
+    "GameResult",
+    "SymmetryHandler",
+    "SymmetryTransform",
+    "QuantikBoard",
+    "PlayerInventory",
+    "MoveRecord",
+]
+```
+
+Document memory/storage/profiling APIs in `docs/API_STABILITY.md` instead of exporting them from the top level.
+
+- [ ] **Step 4: Update package version and classifiers**
+
+In `pyproject.toml`:
+
+```toml
+[project]
+version = "1.0.0"
+requires-python = ">=3.10"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Games/Entertainment :: Board Games",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+```
+
+Move `types-psutil` from runtime dependencies into `dev` dependencies:
+
+```toml
+dependencies = [
+    "psutil>=5.9.0",
+    "numpy>=1.21.0",
+    "zstandard>=0.19.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+    "hypothesis>=6.0",
+    "black>=23.0",
+    "flake8>=6.0",
+    "mypy>=1.0",
+    "pre-commit>=3.0",
+    "types-psutil>=5.9.0",
+    "build>=1.2.0",
+    "twine>=5.0.0",
+]
+```
+
+- [ ] **Step 5: Run public API and packaging checks**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pip install -e ".[dev,cbor]"
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_public_api.py -q
+PYTHONPATH=src .venv/bin/python -m mypy src/quantik_core/
+```
+
+Expected: public API tests pass and mypy remains clean.
+
+- [ ] **Step 6: Commit API stabilization**
+
+Run:
+
+```bash
+git add pyproject.toml src/quantik_core/__init__.py tests/test_public_api.py
+git commit -m "chore: stabilize public api for v1"
+```
+
+## Task 4: Fix Board Player Semantics
+
+**Files:**
+- Modify: `src/quantik_core/board.py`
+- Modify: `tests/test_board.py`
+
+- [ ] **Step 1: Add failing explicit-player tests**
+
+Append to `tests/test_board.py`:
+
+```python
+def test_generate_legal_moves_respects_explicit_player_zero_when_current_player_is_one():
+    board = QuantikBoard.from_qfen("A.../..../..../....")
+
+    assert board.current_player == 1
+    assert list(board.generate_legal_moves(0)) == []
+    assert all(move.player == 1 for move in board.generate_legal_moves())
+
+
+def test_has_legal_moves_respects_explicit_player_zero_when_current_player_is_one():
+    board = QuantikBoard.from_qfen("A.../..../..../....")
+
+    assert board.current_player == 1
+    assert board.has_legal_moves(0) is False
+    assert board.has_legal_moves(1) is True
+```
+
+- [ ] **Step 2: Run board tests and confirm failure**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_board.py -q
+```
+
+Expected: explicit `player=0` tests fail.
+
+- [ ] **Step 3: Replace truthiness fallback with `is None`**
+
+In `src/quantik_core/board.py`, change both optional-player fallbacks:
+
+```python
+        player = self._current_player if player is None else player
+```
+
+Apply this in `has_legal_moves()` and `generate_legal_moves()`.
+
+- [ ] **Step 4: Run board and move tests**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_board.py tests/test_move.py -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit board semantics fix**
+
+Run:
+
+```bash
+git add src/quantik_core/board.py tests/test_board.py
+git commit -m "fix: respect explicit player zero in board queries"
+```
+
+## Task 5: Reduce Import Coupling and Document Heavy Components
+
+**Files:**
+- Modify: `src/quantik_core/memory/__init__.py`
+- Modify: `src/quantik_core/symmetry.py`
+- Create: `tests/test_import_contracts.py`
+- Create: `docs/API_STABILITY.md`
+
+- [ ] **Step 1: Add import-contract tests**
+
+Create `tests/test_import_contracts.py`:
+
+```python
+import subprocess
+import sys
+
+
+def test_quantik_core_import_is_fast_enough_for_library_startup():
+    code = (
+        "import time; "
+        "start = time.perf_counter(); "
+        "import quantik_core; "
+        "print(time.perf_counter() - start)"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert float(completed.stdout.strip()) < 1.0
+
+
+def test_basic_state_does_not_require_optional_compression_imports():
+    code = (
+        "import sys; "
+        "from quantik_core import State; "
+        "State.empty(); "
+        "print('zstandard' in sys.modules)"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout.strip() == "False"
+```
+
+- [ ] **Step 2: Run import-contract tests and confirm failure**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_import_contracts.py -q
+```
+
+Expected: import cost or eager optional imports fail before refactor.
+
+- [ ] **Step 3: Make `memory.__init__` lazy**
+
+Replace eager imports in `src/quantik_core/memory/__init__.py` with lazy attribute loading:
+
+```python
+"""Memory optimization package for quantik-core."""
+
+from typing import Any
+
+__all__ = [
+    "UltraCompactState",
+    "CompactStatePool",
+    "CompactStateCollection",
+    "StateSerializer",
+    "CompressionLevel",
+    "BatchStateManager",
+    "CompactGameTreeNode",
+    "CompactGameTreeStorage",
+    "CompactGameTree",
+    "NODE_FLAG_TERMINAL",
+    "NODE_FLAG_EXPANDED",
+    "NODE_FLAG_WINNING_P0",
+    "NODE_FLAG_WINNING_P1",
+]
+
+
+def __getattr__(name: str) -> Any:
+    if name in {"UltraCompactState", "CompactStatePool", "CompactStateCollection"}:
+        from .compact_state import CompactStateCollection, CompactStatePool, UltraCompactState
+
+        return {
+            "UltraCompactState": UltraCompactState,
+            "CompactStatePool": CompactStatePool,
+            "CompactStateCollection": CompactStateCollection,
+        }[name]
+
+    if name in {"StateSerializer", "CompressionLevel", "BatchStateManager"}:
+        from .binary_serialization import BatchStateManager, CompressionLevel, StateSerializer
+
+        return {
+            "StateSerializer": StateSerializer,
+            "CompressionLevel": CompressionLevel,
+            "BatchStateManager": BatchStateManager,
+        }[name]
+
+    if name in {
+        "CompactGameTreeNode",
+        "CompactGameTreeStorage",
+        "CompactGameTree",
+        "NODE_FLAG_TERMINAL",
+        "NODE_FLAG_EXPANDED",
+        "NODE_FLAG_WINNING_P0",
+        "NODE_FLAG_WINNING_P1",
+    }:
+        from .compact_tree import (
+            CompactGameTree,
+            CompactGameTreeNode,
+            CompactGameTreeStorage,
+            NODE_FLAG_EXPANDED,
+            NODE_FLAG_TERMINAL,
+            NODE_FLAG_WINNING_P0,
+            NODE_FLAG_WINNING_P1,
+        )
+
+        return {
+            "CompactGameTreeNode": CompactGameTreeNode,
+            "CompactGameTreeStorage": CompactGameTreeStorage,
+            "CompactGameTree": CompactGameTree,
+            "NODE_FLAG_TERMINAL": NODE_FLAG_TERMINAL,
+            "NODE_FLAG_EXPANDED": NODE_FLAG_EXPANDED,
+            "NODE_FLAG_WINNING_P0": NODE_FLAG_WINNING_P0,
+            "NODE_FLAG_WINNING_P1": NODE_FLAG_WINNING_P1,
+        }[name]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+```
+
+- [ ] **Step 4: Make symmetry LUT initialization lazy**
+
+Move `SymmetryHandler._initialize_class()` behind first use:
+
+```python
+    @classmethod
+    def _ensure_initialized(cls) -> None:
+        if not cls._initialized:
+            cls._initialize_class()
+```
+
+Call `_ensure_initialized()` at the beginning of methods that read LUT-backed attributes, such as `get_canonical_payload()`, `get_canonical_key()`, and `permute16()`.
+
+- [ ] **Step 5: Document API stability**
+
+Create `docs/API_STABILITY.md`:
+
+```markdown
+# API Stability
+
+`quantik_core` top-level imports are the stable 1.x API:
+
+- `State`
+- `Move`
+- `validate_move`
+- `apply_move`
+- `generate_legal_moves`
+- `generate_legal_moves_list`
+- `QuantikBoard`
+- `PlayerInventory`
+- `GameResult`
+- `SymmetryHandler`
+- `SymmetryTransform`
+- `bb_to_qfen`
+- `bb_from_qfen`
+- `ValidationResult`
+
+Subpackages are importable directly, but may evolve in minor releases until their
+contracts are documented here:
+
+- `quantik_core.memory`
+- `quantik_core.storage`
+- `quantik_core.profiling`
+- `quantik_core.mcts`
+- `quantik_core.opening_book`
+```
+
+- [ ] **Step 6: Run import and API tests**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_import_contracts.py tests/test_public_api.py -q
+```
+
+Expected: import-contract and API tests pass.
+
+- [ ] **Step 7: Commit import and stability docs**
+
+Run:
+
+```bash
+git add src/quantik_core/memory/__init__.py src/quantik_core/symmetry.py tests/test_import_contracts.py docs/API_STABILITY.md
+git commit -m "refactor: decouple stable imports from heavy modules"
+```
+
+## Task 6: Define Winner and Serialization Contracts
+
+**Files:**
+- Modify: `src/quantik_core/game_utils.py`
+- Modify: `src/quantik_core/board.py`
+- Modify: `src/quantik_core/storage/game_tree.py`
+- Modify: `tests/test_game_utils.py`
+- Modify: `tests/test_board.py`
+- Modify: `tests/test_storage.py`
+- Modify: `docs/API_STABILITY.md`
+
+- [ ] **Step 1: Add winner-contract tests for ambiguous board states**
+
+Append to `tests/test_game_utils.py`:
+
+```python
+from quantik_core.core import State
+from quantik_core.game_utils import WinStatus, check_game_winner, has_winning_line
+
+
+def test_has_winning_line_is_separate_from_winner_attribution():
+    state = State.from_qfen("ABCD/..../cd../..ab")
+
+    assert has_winning_line(state.bb) is True
+    assert check_game_winner(state.bb) == WinStatus.UNKNOWN_WINNER
+```
+
+This release uses `UNKNOWN_WINNER` for static positions where a winning line exists but the winner cannot be attributed without move history.
+
+- [ ] **Step 2: Add checkpoint trust-boundary test**
+
+Append to `tests/test_storage.py`:
+
+```python
+def test_game_tree_load_checkpoint_requires_trusted_opt_in(tmp_path):
+    checkpoint = tmp_path / "tree.pkl"
+    checkpoint.write_bytes(b"not a trusted checkpoint")
+    tree = GameTree()
+
+    with pytest.raises(ValueError, match="trusted"):
+        tree.load_checkpoint(str(checkpoint))
+```
+
+- [ ] **Step 3: Implement winner contract**
+
+Add `UNKNOWN_WINNER` to `WinStatus` in both `src/quantik_core/game_utils.py` and `src/quantik_core/state_validator.py` so the duplicate enum definitions remain aligned:
+
+```python
+class WinStatus(IntEnum):
+    NO_WIN = 0
+    PLAYER_0_WINS = 1
+    PLAYER_1_WINS = 2
+    UNKNOWN_WINNER = 3
+```
+
+Then return `UNKNOWN_WINNER` for states where a winning line exists but move history is required for attribution.
+
+- [ ] **Step 4: Implement trusted-only checkpoint loading**
+
+Change `GameTree.load_checkpoint()` signature in `src/quantik_core/storage/game_tree.py`:
+
+```python
+    def load_checkpoint(
+        self, filename: str, compress: bool = True, trusted: bool = False
+    ) -> None:
+        if not trusted:
+            raise ValueError("GameTree checkpoints use pickle and require trusted=True")
+```
+
+Update tests and examples that load generated checkpoints to pass `trusted=True`.
+
+- [ ] **Step 5: Document the contracts**
+
+Update `docs/API_STABILITY.md` with:
+
+```markdown
+## Winner Attribution
+
+`has_winning_line()` answers whether a completed Quantik line exists. Winner
+attribution without move history is conservative: ambiguous static positions
+return `UNKNOWN_WINNER`.
+
+## Checkpoint Trust Boundary
+
+`GameTree.load_checkpoint(path, trusted=True)` reads pickle data. Only load
+checkpoints created by trusted local code.
+```
+
+- [ ] **Step 6: Run contract tests**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m pytest tests/test_game_utils.py tests/test_board.py tests/test_storage.py -q
+```
+
+Expected: winner and checkpoint contracts pass.
+
+- [ ] **Step 7: Commit contracts**
+
+Run:
+
+```bash
+git add src/quantik_core/game_utils.py src/quantik_core/board.py src/quantik_core/storage/game_tree.py tests/test_game_utils.py tests/test_board.py tests/test_storage.py docs/API_STABILITY.md
+git commit -m "fix: document stable game result and checkpoint contracts"
+```
+
+## Task 7: Improve Coverage and Quality Gates
+
+**Files:**
+- Modify: `tests/test_storage.py`
+- Modify: `tests/test_memory_profiling.py`
+- Modify: `tests/test_game_stats.py`
+- Modify: `tests/test_core.py`
+- Modify: `pyproject.toml`
+- Modify: `.github/workflows/test.yml`
+- Modify: `dev-check.sh`
+
+- [ ] **Step 1: Add storage coverage for checkpoint and merge paths**
+
+Append to `tests/test_storage.py`:
+
+```python
+def test_game_tree_checkpoint_roundtrip_uncompressed_trusted(tmp_path):
+    tree = GameTree()
+    state = GameState(BitboardPatterns.single_piece_at(0, 0, 0))
+    tree.add_node(state, value=0.75)
+    checkpoint = tmp_path / "tree.pkl"
+
+    tree.save_checkpoint(str(checkpoint), compress=False)
+
+    loaded = GameTree()
+    loaded.load_checkpoint(str(checkpoint), compress=False, trusted=True)
+
+    assert loaded.get_node(state)["value"] == 0.75
+    assert loaded.get_stats()["active_nodes"] == 1
+
+
+def test_game_tree_merge_results_weighted_average():
+    state = GameState(BitboardPatterns.single_piece_at(0, 0, 0))
+    left = GameTree()
+    right = GameTree()
+    left.add_node(state, value=0.25)
+    right.add_node(state, value=0.75)
+    left.get_node(state)["visits"] = 1
+    right.get_node(state)["visits"] = 3
+
+    left.merge_results(right)
+
+    merged = left.get_node(state)
+    assert merged["visits"] == 4
+    assert merged["value"] == pytest.approx(0.625)
+```
+
+- [ ] **Step 2: Add Hypothesis properties beyond core state**
+
+Add property tests for QFEN and move invariants:
+
+```python
+from hypothesis import given, strategies as st
+
+
+@given(st.integers(min_value=0, max_value=15), st.integers(min_value=0, max_value=3))
+def test_single_move_qfen_roundtrip(position, shape):
+    move = Move(player=0, shape=shape, position=position)
+    bb = apply_move(State.empty().bb, move)
+    state = State(bb)
+
+    assert State.from_qfen(state.to_qfen()).bb == state.bb
+```
+
+Place this in the test module that already imports `Move`, `State`, and `apply_move`, or add explicit imports.
+
+- [ ] **Step 3: Raise the release coverage floor**
+
+In `pyproject.toml`, once tests pass reliably, change:
+
+```toml
+"--cov-fail-under=92",
+```
+
+Keep branch-specific omissions explicit; do not lower coverage to tag 1.0.0.
+
+- [ ] **Step 4: Make flake8 strict in CI and local checks**
+
+In `.github/workflows/test.yml` and `dev-check.sh`, replace the advisory full check:
+
+```bash
+flake8 . --count --exit-zero --statistics
+```
+
+with:
+
+```bash
+flake8 src tests examples --count --statistics
+```
+
+Generated or intentionally complex examples must use exact per-file ignores in `.flake8`; do not keep `--exit-zero` for release CI.
+
+- [ ] **Step 5: Make local checks use the repo interpreter**
+
+Update `dev-check.sh` so it uses `python3` when `python` is unavailable:
+
+```bash
+if [ -z "${PYTHON_BIN:-}" ]; then
+    if command -v python >/dev/null 2>&1; then
+        PYTHON_BIN="python"
+    else
+        PYTHON_BIN="python3"
+    fi
+fi
+```
+
+Then use `$PYTHON_BIN -m venv .venv` and `$PYTHON_BIN -m build`.
+
+- [ ] **Step 6: Run the release quality gate**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m black --check src tests examples
+PYTHONPATH=src .venv/bin/python -m flake8 src tests examples --count --statistics
+PYTHONPATH=src .venv/bin/python -m mypy src/quantik_core/
+PYTHONPATH=src .venv/bin/python -m pytest tests -q --cov=quantik_core --cov-report=term-missing --cov-fail-under=92
+```
+
+Expected: all quality gates pass.
+
+- [ ] **Step 7: Commit quality uplift**
+
+Run:
+
+```bash
+git add pyproject.toml .github/workflows/test.yml dev-check.sh tests/test_storage.py tests/test_memory_profiling.py tests/test_game_stats.py tests/test_core.py
+git commit -m "test: raise release quality gates"
+```
+
+## Task 8: Consolidate Changelog from `v0.1.1` to `1.0.0`
+
+**Files:**
+- Create: `CHANGELOG.md`
+- Review: `README.md`
+- Review: `pyproject.toml`
+
+- [ ] **Step 1: Generate the source commit list**
+
+Run:
+
+```bash
+git log --reverse --date=short --pretty=format:"%h %ad %s" v0.1.1..HEAD
+```
+
+Expected: includes `#2`, `#3`, `#4`, `#5`, `#6`, `#7`, `#8`, `#10`, and `#11` after syncing `main`.
+
+- [ ] **Step 2: Create `CHANGELOG.md`**
+
+Create:
+
+```markdown
+# Changelog
+
+All notable changes to `quantik-core` are documented here.
+
+## 1.0.0 - 2026-06-22
+
+### Added
+
+- Added validated Quantik move representation, move validation, move application, and legal move generation.
+- Added `QuantikBoard` with inventory tracking, move history, undo, legal moves, win detection, and stalemate handling.
+- Added QFEN parsing/serialization helpers in a dedicated `qfen` module.
+- Added symmetry handling and canonical keys for rotations, reflections, color swaps, and shape permutations.
+- Added game statistics utilities and win-probability analysis examples.
+- Added compact bitboard/state/tree storage for memory-efficient game analysis.
+- Added binary and CBOR serialization helpers for cross-language state exchange.
+- Added memory profiling and benchmark utilities.
+- Added MCTS engine, opening-book database, and puzzle-generation examples from `#11`.
+
+### Changed
+
+- Reworked the package structure under `src/quantik_core`.
+- Integrated `CompactBitboard` as the internal `State` storage while preserving the tuple `bb` property.
+- Consolidated duplicated constants, validation helpers, bitboard index calculations, piece counting, and endgame detection.
+- Dropped Python 3.9 support and set the supported range to Python 3.10 through 3.13.
+- Stabilized top-level public exports for the 1.x API.
+
+### Fixed
+
+- Fixed QFEN fixture formatting and added fixture validation tests.
+- Fixed validation of out-of-board bitboard values.
+- Fixed explicit `player=0` handling in board legal-move queries.
+- Fixed package version mismatch between metadata and runtime.
+- Fixed stale PyPI/README examples with invalid QFEN strings.
+- Fixed CI and local quality gates so lint, format, type, coverage, build, and package checks fail on release blockers.
+
+### Security
+
+- Documented `GameTree.load_checkpoint()` as trusted-only because it uses pickle.
+
+### Migration Notes
+
+- `quantik_core` top-level imports now expose only the documented stable API.
+- Memory, storage, profiling, MCTS, and opening-book APIs remain available from their subpackages and are documented as specialized APIs.
+```
+
+- [ ] **Step 3: Validate changelog against Git history**
+
+Run:
+
+```bash
+git diff -- CHANGELOG.md
+git log --oneline v0.1.1..HEAD
+```
+
+Expected: every major feature family from the log appears in the changelog once.
+
+- [ ] **Step 4: Commit changelog**
+
+Run:
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add v1 changelog"
+```
+
+## Task 9: Rewrite README and PyPI Metadata
+
+**Files:**
+- Modify: `README.md`
+- Modify: `pyproject.toml`
+- Create: `docs/EXAMPLES.md`
+- Create: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Fix project URLs and docs metadata**
+
+In `pyproject.toml`, use the actual repository owner:
+
+```toml
+[project.urls]
+Homepage = "https://github.com/mberlanda/quantik-core-py"
+Repository = "https://github.com/mberlanda/quantik-core-py"
+Documentation = "https://github.com/mberlanda/quantik-core-py#readme"
+"Bug Tracker" = "https://github.com/mberlanda/quantik-core-py/issues"
+Changelog = "https://github.com/mberlanda/quantik-core-py/blob/main/CHANGELOG.md"
+```
+
+For 1.0.0, keep the Documentation URL on the GitHub README because Read the Docs is not verified in this release plan.
+
+- [ ] **Step 2: Fix invalid README QFEN examples**
+
+In `README.md`, replace all five-dot or three-character rank examples:
+
+```markdown
+QFEN: "..../..../..../...."
+QFEN: "AbCd/..../..../...."
+state = State.from_qfen("ABCD/..../..../....")
+print(f"Position: {qfen}")  # Output: ABCD/..../..../....
+```
+
+- [ ] **Step 3: Update README feature status**
+
+Replace stale feature text:
+
+```markdown
+**Current Implementation:**
+- **State Representation**: Bitboard-backed immutable game states
+- **QFEN**: Human-readable Quantik FEN parsing and serialization
+- **Move Logic**: Move validation, legal move generation, and board-level play helpers
+- **Endgame Logic**: Winning-line detection and board result helpers
+- **Canonicalization**: Symmetry-aware position normalization
+- **Serialization**: Binary, QFEN, and optional CBOR formats
+- **Analysis Tools**: Game statistics, compact storage, MCTS, opening-book, and puzzle-generation modules
+```
+
+- [ ] **Step 4: Add tested examples documentation**
+
+Create `docs/EXAMPLES.md` with smoke-testable snippets:
+
+````markdown
+# Examples
+
+## State and QFEN
+
+```python
+from quantik_core import State
+
+state = State.from_qfen("A.bC/..../d..B/...a")
+assert state.to_qfen() == "A.bC/..../d..B/...a"
+assert len(state.pack()) == 18
+```
+
+## Legal Moves
+
+```python
+from quantik_core import QuantikBoard
+
+board = QuantikBoard.from_qfen("A.../..../..../....")
+moves = list(board.generate_legal_moves())
+assert board.current_player == 1
+assert all(move.player == 1 for move in moves)
+```
+
+## Canonical Keys
+
+```python
+from quantik_core import State
+
+state = State.from_qfen("A.../..../..../....")
+key = state.canonical_key()
+assert len(key) == 18
+```
+````
+
+- [ ] **Step 5: Add architecture documentation**
+
+Create `docs/ARCHITECTURE.md`:
+
+```markdown
+# Architecture
+
+`quantik-core` is organized around a small stable core plus specialized analysis
+modules.
+
+## Core State
+
+- `quantik_core.core.State` owns immutable game-state serialization.
+- `quantik_core.qfen` converts between QFEN and the internal bitboard tuple.
+- `quantik_core.symmetry` computes canonical position keys.
+
+## Game Rules
+
+- `quantik_core.move` validates and applies individual moves.
+- `quantik_core.board` provides a higher-level board with inventories and move history.
+- `quantik_core.game_utils` contains shared rule helpers.
+- `quantik_core.state_validator` validates static bitboard legality.
+
+## Analysis and Storage
+
+- `quantik_core.memory` contains compact in-memory representations.
+- `quantik_core.storage` contains serialization and checkpoint-oriented helpers.
+- `quantik_core.game_stats` contains game-tree statistics.
+- `quantik_core.mcts` and `quantik_core.opening_book` provide search and book tooling.
+- `quantik_core.profiling` contains benchmark and memory measurement helpers.
+```
+
+- [ ] **Step 6: Smoke-test README and docs examples**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python examples/basic_usage.py
+PYTHONPATH=src .venv/bin/python examples/legal_moves_demo.py
+PYTHONPATH=src .venv/bin/python examples/mcts_demo.py
+PYTHONPATH=src .venv/bin/python examples/opening_book_demo.py
+```
+
+Expected: examples run without invalid-QFEN crashes after syncing latest `main`.
+
+- [ ] **Step 7: Commit docs and metadata**
+
+Run:
+
+```bash
+git add README.md pyproject.toml docs/EXAMPLES.md docs/ARCHITECTURE.md
+git commit -m "docs: refresh pypi readme and architecture"
+```
+
+## Task 10: Clean Working Docs on a Dedicated Branch
+
+**Files:**
+- Move or review: `GAME_TREE_ANALYSIS.md`
+- Move or review: `SYMMETRY_REDUCTION_DEMONSTRATION.md`
+- Move or review: `next_steps.md`
+- Move or review: `prompts/*.md`
+- Move or review: `docs/PARALLELIZATION_ANALYSIS.md`
+- Move or review: `docs/REWRITE_ANALYSIS.md`
+- Move or review: `docs/rewrite-plans/*.md`
+
+- [ ] **Step 1: Create docs cleanup branch from release branch**
+
+Run:
+
+```bash
+git switch -c docs/v1-working-docs-cleanup
+```
+
+Expected: working-doc cleanup is isolated from code/API release work.
+
+- [ ] **Step 2: Move retained working docs under `docs/working/`**
+
+Run:
+
+```bash
+mkdir -p docs/working/prompts docs/working/rewrite-plans
+git mv GAME_TREE_ANALYSIS.md docs/working/GAME_TREE_ANALYSIS.md
+git mv SYMMETRY_REDUCTION_DEMONSTRATION.md docs/working/SYMMETRY_REDUCTION_DEMONSTRATION.md
+git mv next_steps.md docs/working/next_steps.md
+git mv prompts/*.md docs/working/prompts/
+git mv docs/REWRITE_ANALYSIS.md docs/working/REWRITE_ANALYSIS.md
+git mv docs/PARALLELIZATION_ANALYSIS.md docs/working/PARALLELIZATION_ANALYSIS.md
+git mv docs/rewrite-plans/*.md docs/working/rewrite-plans/
+```
+
+Expected: root-level working docs no longer crowd the package landing surface.
+
+- [ ] **Step 3: Add a working-docs index**
+
+Create `docs/working/README.md`:
+
+```markdown
+# Working Notes
+
+These documents capture design explorations, prompts, rewrite notes, and analysis
+that informed the 1.0.0 release. They are retained for project history but are
+not part of the stable user documentation.
+```
+
+- [ ] **Step 4: Commit docs cleanup**
+
+Run:
+
+```bash
+git add docs/working
+git commit -m "docs: organize working notes"
+```
+
+- [ ] **Step 5: Squash merge docs cleanup into release**
+
+Run:
+
+```bash
+git switch release/v1.0.0
+git merge --squash docs/v1-working-docs-cleanup
+git commit -m "docs: organize v1 working notes"
+```
+
+Expected: docs cleanup enters the release branch as one reviewable commit.
+
+## Task 11: Harden Build, Integration, and Publish Workflows
+
+**Files:**
+- Modify: `.github/workflows/build.yml`
+- Modify: `.github/workflows/integration.yml`
+- Modify: `.github/workflows/publish.yml`
+- Modify: `.github/workflows/test.yml`
+- Modify: `dev-check.sh`
+
+- [ ] **Step 1: Add `twine check` to publish workflow**
+
+In `.github/workflows/publish.yml`, after build:
+
+```yaml
+    - name: Check package metadata
+      run: |
+        python -m pip install --upgrade twine
+        twine check dist/*
+```
+
+- [ ] **Step 2: Test installed wheel with core and optional CBOR**
+
+In `.github/workflows/build.yml`, extend install testing:
+
+```yaml
+    - name: Test wheel imports and optional CBOR
+      run: |
+        python - <<'PY'
+        from quantik_core import State
+        state = State.from_qfen("A.../..../..../....")
+        assert state.to_qfen() == "A.../..../..../...."
+        PY
+        python -m pip install cbor2
+        python - <<'PY'
+        from quantik_core import State
+        state = State.from_qfen("A.../..../..../....")
+        assert State.from_cbor(state.to_cbor()).to_qfen() == state.to_qfen()
+        PY
+```
+
+- [ ] **Step 3: Add example smoke tests to integration**
+
+In `.github/workflows/integration.yml`, run all short examples:
+
+```yaml
+    - name: Test examples
+      run: |
+        python examples/basic_usage.py
+        python examples/legal_moves_demo.py
+        python examples/mcts_demo.py
+        python examples/opening_book_demo.py
+```
+
+Keep long generators behind explicit limits or separate benchmark workflows.
+
+- [ ] **Step 4: Run local workflow-equivalent checks**
+
+Run:
+
+```bash
+./dev-check.sh
+```
+
+Expected: tests, Black, flake8, mypy, build, and twine checks pass from a clean checkout.
+
+- [ ] **Step 5: Commit workflow hardening**
+
+Run:
+
+```bash
+git add .github/workflows/build.yml .github/workflows/integration.yml .github/workflows/publish.yml .github/workflows/test.yml dev-check.sh
+git commit -m "ci: harden v1 release gates"
+```
+
+## Task 12: Final Release Candidate Verification
+
+**Files:**
+- No source edits unless verification fails.
+- Read: `dist/*`
+
+- [ ] **Step 1: Ensure clean release branch**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: clean `release/v1.0.0` branch.
+
+- [ ] **Step 2: Run full local release gate**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m black --check src tests examples
+PYTHONPATH=src .venv/bin/python -m flake8 src tests examples --count --statistics
+PYTHONPATH=src .venv/bin/python -m mypy src/quantik_core/
+PYTHONPATH=src .venv/bin/python -m pytest tests -q --cov=quantik_core --cov-report=term-missing --cov-fail-under=92
+PYTHONPATH=src .venv/bin/python -m build
+PYTHONPATH=src .venv/bin/python -m twine check dist/*
+```
+
+Expected: every command passes.
+
+- [ ] **Step 3: Install and smoke-test the built wheel in a temporary venv**
+
+Run:
+
+```bash
+python3 -m venv /tmp/quantik-core-v1-smoke
+/tmp/quantik-core-v1-smoke/bin/python -m pip install --upgrade pip
+/tmp/quantik-core-v1-smoke/bin/python -m pip install dist/quantik_core-1.0.0-py3-none-any.whl
+/tmp/quantik-core-v1-smoke/bin/python - <<'PY'
+from quantik_core import State, QuantikBoard
+state = State.from_qfen("A.../..../..../....")
+assert state.to_qfen() == "A.../..../..../...."
+board = QuantikBoard.from_qfen("A.../..../..../....")
+assert board.current_player == 1
+print("quantik-core 1.0.0 wheel smoke passed")
+PY
+```
+
+Expected: wheel installs and smoke test prints success.
+
+- [ ] **Step 4: Verify PyPI long description render**
+
+Run:
+
+```bash
+PYTHONPATH=src .venv/bin/python -m twine check dist/*
+```
+
+Expected: `PASSED` for wheel and sdist.
+
+- [ ] **Step 5: Merge release branch**
+
+Run:
+
+```bash
+git switch main
+git merge --ff-only release/v1.0.0
+git push origin main
+```
+
+Expected: `main` contains the release commits and CI starts.
+
+## Task 13: Tag and Publish `v1.0.0`
+
+**Files:**
+- No source edits.
+
+- [ ] **Step 1: Confirm CI green on `main`**
+
+Run:
+
+```bash
+gh run list --branch main --limit 10
+```
+
+Expected: latest test, build, and integration workflows for `main` are successful.
+
+- [ ] **Step 2: Create annotated tag**
+
+Run:
+
+```bash
+git tag -a v1.0.0 -m "quantik-core 1.0.0"
+git push origin v1.0.0
+```
+
+Expected: tag `v1.0.0` exists on GitHub.
+
+- [ ] **Step 3: Create GitHub release**
+
+Run:
+
+```bash
+gh release create v1.0.0 --title "quantik-core 1.0.0" --notes-file CHANGELOG.md
+```
+
+Expected: GitHub release is published, triggering the PyPI publish workflow.
+
+- [ ] **Step 4: Verify PyPI publication**
+
+Run:
+
+```bash
+python3 -m pip index versions quantik-core
+```
+
+Expected: `1.0.0` appears as the latest version.
+
+- [ ] **Step 5: Verify install from PyPI**
+
+Run:
+
+```bash
+python3 -m venv /tmp/quantik-core-pypi-smoke
+/tmp/quantik-core-pypi-smoke/bin/python -m pip install --upgrade pip
+/tmp/quantik-core-pypi-smoke/bin/python -m pip install quantik-core==1.0.0
+/tmp/quantik-core-pypi-smoke/bin/python - <<'PY'
+import quantik_core
+from quantik_core import State
+assert quantik_core.__version__ == "1.0.0"
+assert State.empty().to_qfen() == "..../..../..../...."
+print("PyPI smoke passed")
+PY
+```
+
+Expected: PyPI install works and reports `1.0.0`.
+
+## Self-Review
+
+- Spec coverage: The plan covers VoltAgent architecture/code/QA review, code quality and coverage, changelog from `0.1.1` to `1.0.0`, examples, architecture docs, PyPI metadata, working-doc cleanup branch, and the `v1.0.0` tag.
+- Placeholder scan: There are no `TBD` or `TODO` placeholders. Where the plan offers a decision, it provides the concrete preferred implementation.
+- Type consistency: The snippets use existing names (`State`, `Move`, `QuantikBoard`, `ValidationResult`, `GameTree`, `GameState`, `BitboardPatterns`) and introduce only documented additions (`UNKNOWN_WINNER`, `trusted` parameter) in the tasks where they are implemented.


### PR DESCRIPTION
## Summary
- Ignore local .rtk/ state in .gitignore
- Commit the historical 1.0.0 release implementation plan under docs/superpowers/plans/
- Add a status note clarifying the release plan snapshot is historical and current release work should use .claude/skills/make-release/SKILL.md

## Verification
- ./auto-lint.sh
- ./dev-check.sh: 652 passed, coverage 92.43%; artifacts built and twine check passed; existing advisory flake8 output remains non-blocking in the script