### PR TITLE
feat: add Python/Rust portability contract

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,19 @@
+name: Contracts
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  validate-contract-fixtures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: mberlanda/quantik-core-contracts/actions/validate-contracts@v1.0.0
+        with:
+          fixture-glob: "tests/fixtures/selfplay_v1.jsonl"
+          expected-release: "1.0.0"
+

--- a/docs/API_PORTABILITY.md
+++ b/docs/API_PORTABILITY.md
@@ -1,9 +1,13 @@
 # Cross-Language API Portability
 
-This document defines the Python/Rust boundary for `quantik-core`. Python remains
-the ergonomic orchestration, benchmarking, and ML-training layer. Rust owns
-high-throughput search, self-play generation, and other compute-heavy loops.
-Both packages must agree on the state, action, and dataset contracts below.
+This document summarizes the Python/Rust boundary for `quantik-core`. Python
+remains the ergonomic orchestration, benchmarking, and ML-training layer. Rust
+owns high-throughput search, self-play generation, and other compute-heavy
+loops. Both packages must agree on the canonical contracts from
+`mberlanda/quantik-core-contracts`.
+
+Python currently declares support for contracts release `1.0.0` via
+`quantik_core.SUPPORTED_CONTRACTS_RELEASE`.
 
 ## Stable Shared Model
 
@@ -17,9 +21,8 @@ Both packages must agree on the state, action, and dataset contracts below.
 | Action index | `shape * 16 + position`, producing 64 policy slots. |
 | Value target | Exactly `+1.0` or `-1.0` from `side_to_move` perspective. Quantik has no draw target. |
 
-The top-level Python API stays focused on stable game primitives.
-Cross-language ML data helpers live in `quantik_core.ml_data` so they can evolve
-without widening the core import surface.
+Cross-language contract identifiers live in `quantik_core.contracts`.
+Cross-language ML data helpers live in `quantik_core.ml_data`.
 
 ## Rust Self-Play JSONL Schema
 
@@ -27,6 +30,8 @@ Rust self-play export rows are one JSON object per line:
 
 ```json
 {
+  "schema": "selfplay.v1",
+  "contract_version": "1.0.0",
   "game_id": 0,
   "ply": 0,
   "qfen": "..../..../..../....",
@@ -41,6 +46,8 @@ Rust self-play export rows are one JSON object per line:
 
 Python validates that:
 
+- `schema` is `selfplay.v1`.
+- `contract_version`, when present, is `1.0.0`.
 - `qfen` parses and `side_to_move` matches the current player implied by the bitboards.
 - each policy entry is a legal move for the row state.
 - each policy entry has `shape` in `0..3`, `position` in `0..15`, and positive integer `visits`.
@@ -63,12 +70,15 @@ Rows and columns match the QFEN position order: `row = position // 4`,
 
 `tests/fixtures/selfplay_v1.jsonl` is the Python-side golden sample for the Rust
 exporter schema. Rust should be able to emit rows with the same field names and
-semantics; Python must keep parsing and validating this file in CI.
+semantics; Python must keep parsing and validating this file in CI. The
+dedicated `Contracts` workflow also validates the fixture through
+`mberlanda/quantik-core-contracts/actions/validate-contracts@v1.0.0`.
 
 ## Next Steps
 
 1. Rust: expose `MCTSEngine::root_move_visits()` and emit self-play JSONL rows using the schema above.
 2. Python: keep `quantik_core.ml_data` as the reference reader and tensor/policy encoder.
-3. Cross-repo: add a Rust-generated smoke artifact to CI or release evidence, then point Python tests at the generated artifact in addition to the checked-in fixture.
-4. ML: build the PyTorch dataset and policy/value model on top of `SelfPlayRow`, `qfen_to_tensor`, and `policy_visits_to_distribution`.
-5. Evaluation: register the trained model in the existing cross-engine benchmark harness instead of creating a separate ladder.
+3. Contracts: validate fixtures through `mberlanda/quantik-core-contracts/actions/validate-contracts@v1.0.0`.
+4. Cross-repo: add a Rust-generated smoke artifact to CI or release evidence, then point Python tests at the generated artifact in addition to the checked-in fixture.
+5. ML: build the PyTorch dataset and policy/value model on top of `SelfPlayRow`, `qfen_to_tensor`, and `policy_visits_to_distribution`.
+6. Evaluation: register the trained model in the existing cross-engine benchmark harness instead of creating a separate ladder.

--- a/docs/API_PORTABILITY.md
+++ b/docs/API_PORTABILITY.md
@@ -1,0 +1,74 @@
+# Cross-Language API Portability
+
+This document defines the Python/Rust boundary for `quantik-core`. Python remains
+the ergonomic orchestration, benchmarking, and ML-training layer. Rust owns
+high-throughput search, self-play generation, and other compute-heavy loops.
+Both packages must agree on the state, action, and dataset contracts below.
+
+## Stable Shared Model
+
+| Concept | Portable contract |
+| --- | --- |
+| Board size | 4x4, positions `0..15`, row-major from top-left to bottom-right. |
+| Shapes | `0=A`, `1=B`, `2=C`, `3=D`. |
+| Players | `0` is uppercase QFEN, `1` is lowercase QFEN. |
+| Bitboard order | Eight 16-bit integers: player 0 shapes 0..3, then player 1 shapes 0..3. |
+| QFEN | Four ranks of four chars separated by `/`; `.` for empty; `ABCD` for player 0; `abcd` for player 1. |
+| Action index | `shape * 16 + position`, producing 64 policy slots. |
+| Value target | Exactly `+1.0` or `-1.0` from `side_to_move` perspective. Quantik has no draw target. |
+
+The top-level Python API stays focused on stable game primitives.
+Cross-language ML data helpers live in `quantik_core.ml_data` so they can evolve
+without widening the core import surface.
+
+## Rust Self-Play JSONL Schema
+
+Rust self-play export rows are one JSON object per line:
+
+```json
+{
+  "game_id": 0,
+  "ply": 0,
+  "qfen": "..../..../..../....",
+  "side_to_move": 0,
+  "policy": [
+    {"shape": 0, "position": 0, "visits": 3},
+    {"shape": 1, "position": 5, "visits": 1}
+  ],
+  "value": 1.0
+}
+```
+
+Python validates that:
+
+- `qfen` parses and `side_to_move` matches the current player implied by the bitboards.
+- each policy entry is a legal move for the row state.
+- each policy entry has `shape` in `0..3`, `position` in `0..15`, and positive integer `visits`.
+- `policy` is non-empty and normalizes to a probability distribution over 64 action slots.
+- `value` is exactly `+1.0` or `-1.0`; `0.0` is rejected.
+
+## Tensor Encoding
+
+`quantik_core.ml_data.qfen_to_tensor(qfen, side_to_move)` returns a NumPy array
+with shape `(9, 4, 4)`:
+
+- channels `0..3`: player 0 shapes `A..D`
+- channels `4..7`: player 1 shapes `a..d`
+- channel `8`: side-to-move plane, filled with `0.0` for player 0 or `1.0` for player 1
+
+Rows and columns match the QFEN position order: `row = position // 4`,
+`col = position % 4`.
+
+## Conformance Fixtures
+
+`tests/fixtures/selfplay_v1.jsonl` is the Python-side golden sample for the Rust
+exporter schema. Rust should be able to emit rows with the same field names and
+semantics; Python must keep parsing and validating this file in CI.
+
+## Next Steps
+
+1. Rust: expose `MCTSEngine::root_move_visits()` and emit self-play JSONL rows using the schema above.
+2. Python: keep `quantik_core.ml_data` as the reference reader and tensor/policy encoder.
+3. Cross-repo: add a Rust-generated smoke artifact to CI or release evidence, then point Python tests at the generated artifact in addition to the checked-in fixture.
+4. ML: build the PyTorch dataset and policy/value model on top of `SelfPlayRow`, `qfen_to_tensor`, and `policy_visits_to_distribution`.
+5. Evaluation: register the trained model in the existing cross-engine benchmark harness instead of creating a separate ladder.

--- a/docs/superpowers/plans/2026-07-13-python-rust-api-portability.md
+++ b/docs/superpowers/plans/2026-07-13-python-rust-api-portability.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the Python package enforce the shared Quantik API and self-play data contracts used by the companion Rust crate.
 
-**Architecture:** Keep core game primitives stable and language-neutral: QFEN, bitboard order, action indexing, and decisive value semantics. Add Python ML-data helpers in a dedicated `quantik_core.ml_data` module so Rust self-play output can be validated and consumed without widening the top-level public API.
+**Architecture:** Keep core game primitives stable and language-neutral: QFEN, bitboard order, action indexing, and decisive value semantics. The canonical contract source is `mberlanda/quantik-core-contracts` release `1.0.0`; Python declares this through `SUPPORTED_CONTRACTS_RELEASE` and validates fixtures with the tagged contracts action. Add Python ML-data helpers in a dedicated `quantik_core.ml_data` module so Rust self-play output can be validated and consumed.
 
 **Tech Stack:** Python 3.12+, NumPy, pytest, existing `quantik_core` QFEN/move/state-validator APIs, Rust JSONL self-play output from `quantik-core-rust`.
 
@@ -17,7 +17,9 @@ The Rust plan `2026-07-13-crates-io-packaging-and-ml-data-pipeline.md` makes Rus
 ## File Structure
 
 - Create: `docs/API_PORTABILITY.md` - human-readable Python/Rust shared contracts.
+- Create: `src/quantik_core/contracts.py` - supported contracts release and wire-format identifiers.
 - Create: `src/quantik_core/ml_data.py` - schema validation, JSONL loading, QFEN tensor encoding, policy normalization.
+- Create: `.github/workflows/contracts.yml` - validate self-play fixtures against `quantik-core-contracts@v1.0.0`.
 - Create: `tests/fixtures/selfplay_v1.jsonl` - golden JSONL rows matching the Rust exporter schema.
 - Create: `tests/test_ml_data.py` - CI enforcement for the schema, tensor encoding, legality checks, and decisive values.
 - Modify later: `examples/cross_engine_benchmark.py` - add a trained-model adapter after a real model exists.
@@ -51,13 +53,13 @@ Document the `(9, 4, 4)` tensor layout: eight player/shape planes plus one side-
 Create `tests/fixtures/selfplay_v1.jsonl` with valid rows:
 
 ```jsonl
-{"game_id":0,"ply":0,"qfen":"..../..../..../....","side_to_move":0,"policy":[{"shape":0,"position":0,"visits":3},{"shape":1,"position":5,"visits":1}],"value":1.0}
-{"game_id":0,"ply":1,"qfen":"A.../..../..../....","side_to_move":1,"policy":[{"shape":0,"position":10,"visits":2},{"shape":1,"position":1,"visits":6}],"value":-1.0}
+{"schema":"selfplay.v1","contract_version":"1.0.0","game_id":0,"ply":0,"qfen":"..../..../..../....","side_to_move":0,"policy":[{"shape":0,"position":0,"visits":3},{"shape":1,"position":5,"visits":1}],"value":1.0}
+{"schema":"selfplay.v1","contract_version":"1.0.0","game_id":0,"ply":1,"qfen":"A.../..../..../....","side_to_move":1,"policy":[{"shape":0,"position":10,"visits":2},{"shape":1,"position":1,"visits":6}],"value":-1.0}
 ```
 
 - [x] **Step 2: Implement schema dataclasses and parser**
 
-Create `PolicyVisit` and `SelfPlayRow`, plus `parse_selfplay_row(record)` that validates qfen, side-to-move, legal policy moves, positive visits, and decisive values.
+Create `PolicyVisit` and `SelfPlayRow`, plus `parse_selfplay_row(record)` that validates schema, contract version, qfen, side-to-move, legal policy moves, positive visits, and decisive values.
 
 - [x] **Step 3: Implement tensor and policy encoders**
 

--- a/docs/superpowers/plans/2026-07-13-python-rust-api-portability.md
+++ b/docs/superpowers/plans/2026-07-13-python-rust-api-portability.md
@@ -1,0 +1,119 @@
+# Python/Rust API Portability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Python package enforce the shared Quantik API and self-play data contracts used by the companion Rust crate.
+
+**Architecture:** Keep core game primitives stable and language-neutral: QFEN, bitboard order, action indexing, and decisive value semantics. Add Python ML-data helpers in a dedicated `quantik_core.ml_data` module so Rust self-play output can be validated and consumed without widening the top-level public API.
+
+**Tech Stack:** Python 3.12+, NumPy, pytest, existing `quantik_core` QFEN/move/state-validator APIs, Rust JSONL self-play output from `quantik-core-rust`.
+
+---
+
+## Context
+
+The Rust plan `2026-07-13-crates-io-packaging-and-ml-data-pipeline.md` makes Rust responsible for compute-heavy MCTS self-play and exports one JSONL row per ply. The Python library should not duplicate that heavy loop. Python should enforce the schema, load the rows, encode tensors, train models, and evaluate those models in the existing benchmark harness.
+
+## File Structure
+
+- Create: `docs/API_PORTABILITY.md` - human-readable Python/Rust shared contracts.
+- Create: `src/quantik_core/ml_data.py` - schema validation, JSONL loading, QFEN tensor encoding, policy normalization.
+- Create: `tests/fixtures/selfplay_v1.jsonl` - golden JSONL rows matching the Rust exporter schema.
+- Create: `tests/test_ml_data.py` - CI enforcement for the schema, tensor encoding, legality checks, and decisive values.
+- Modify later: `examples/cross_engine_benchmark.py` - add a trained-model adapter after a real model exists.
+
+## Task 1: Document Cross-Language API Contract
+
+**Files:**
+- Create: `docs/API_PORTABILITY.md`
+
+- [x] **Step 1: Define shared state and action conventions**
+
+Add a table documenting board positions `0..15`, shape ids `0..3`, player ids `0..1`, bitboard order, QFEN, and action index `shape * 16 + position`.
+
+- [x] **Step 2: Define Rust self-play row schema**
+
+Document the JSONL fields `game_id`, `ply`, `qfen`, `side_to_move`, `policy`, and `value`, including the rule that `value` is only `+1.0` or `-1.0`.
+
+- [x] **Step 3: Define tensor encoding**
+
+Document the `(9, 4, 4)` tensor layout: eight player/shape planes plus one side-to-move plane.
+
+## Task 2: Add Python ML Data Contract Helpers
+
+**Files:**
+- Create: `src/quantik_core/ml_data.py`
+- Create: `tests/fixtures/selfplay_v1.jsonl`
+- Create: `tests/test_ml_data.py`
+
+- [x] **Step 1: Add golden JSONL fixture**
+
+Create `tests/fixtures/selfplay_v1.jsonl` with valid rows:
+
+```jsonl
+{"game_id":0,"ply":0,"qfen":"..../..../..../....","side_to_move":0,"policy":[{"shape":0,"position":0,"visits":3},{"shape":1,"position":5,"visits":1}],"value":1.0}
+{"game_id":0,"ply":1,"qfen":"A.../..../..../....","side_to_move":1,"policy":[{"shape":0,"position":10,"visits":2},{"shape":1,"position":1,"visits":6}],"value":-1.0}
+```
+
+- [x] **Step 2: Implement schema dataclasses and parser**
+
+Create `PolicyVisit` and `SelfPlayRow`, plus `parse_selfplay_row(record)` that validates qfen, side-to-move, legal policy moves, positive visits, and decisive values.
+
+- [x] **Step 3: Implement tensor and policy encoders**
+
+Create `qfen_to_tensor(qfen, side_to_move)` returning `(9, 4, 4)` and `policy_visits_to_distribution(policy)` returning a 64-slot normalized NumPy vector.
+
+- [x] **Step 4: Add tests**
+
+Test fixture loading, tensor channel placement, policy normalization, zero-value rejection, side-to-move mismatch rejection, and illegal policy rejection.
+
+## Task 3: Cross-Repo Generated Artifact Smoke
+
+**Files:**
+- Future modify: `.github/workflows/test.yml`
+- Future create: `benchmarks/results/selfplay-smoke.jsonl` or CI artifact download step
+
+- [ ] **Step 1: Wait for Rust Task 6 output**
+
+Do not fabricate a generated artifact. Use output from the Rust exporter command:
+
+```bash
+cargo run --release --example selfplay_export -p quantik-core -- --games 5 --iterations 500 --seed 1 --out /tmp/selfplay-smoke.jsonl
+```
+
+Expected: a JSONL file with non-empty policy arrays and values only in `{-1.0, 1.0}`.
+
+- [ ] **Step 2: Add Python smoke validation command**
+
+Use the Python loader to validate the generated artifact:
+
+```bash
+.venv/bin/python - <<'PY'
+from quantik_core.ml_data import load_selfplay_jsonl
+rows = load_selfplay_jsonl('/tmp/selfplay-smoke.jsonl')
+assert rows
+print(f'validated {len(rows)} rows')
+PY
+```
+
+Expected: no exception and a positive row count.
+
+## Task 4: Python Training Dataset
+
+**Files:**
+- Future create: `src/quantik_core/ml_dataset.py`
+- Future create: `tests/test_ml_dataset.py`
+
+- [ ] **Step 1: Build on `SelfPlayRow`**
+
+Create a dataset adapter that maps rows to `(tensor, policy_distribution, value)` triples, using `qfen_to_tensor()` and `policy_visits_to_distribution()`.
+
+- [ ] **Step 2: Keep PyTorch optional**
+
+Keep the base loader NumPy-only. Add PyTorch integration behind an optional dependency when the training loop is introduced.
+
+## Self-Review
+
+- Spec coverage: This plan covers the Rust handoff schema, Python tensor encoding, policy normalization, decisive value validation, and future benchmark/model integration.
+- Placeholder scan: Future tasks are explicitly blocked on real Rust exporter output; no fake schema or fake model is proposed.
+- Type consistency: `PolicyVisit`, `SelfPlayRow`, `qfen_to_tensor`, `policy_visits_to_distribution`, and `load_selfplay_jsonl` are the stable names used throughout.

--- a/src/quantik_core/__init__.py
+++ b/src/quantik_core/__init__.py
@@ -3,6 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .commons import Bitboard, PlayerId, VERSION, FLAG_CANON
+from .contracts import SUPPORTED_CONTRACTS, SUPPORTED_CONTRACTS_RELEASE
 from .core import State
 from .symmetry import SymmetryHandler, SymmetryTransform
 from .qfen import bb_to_qfen, bb_from_qfen
@@ -33,6 +34,8 @@ __author__ = "Mauro Berlanda"
 __all__ = [
     "VERSION",
     "FLAG_CANON",
+    "SUPPORTED_CONTRACTS",
+    "SUPPORTED_CONTRACTS_RELEASE",
     "State",
     "Bitboard",
     "Move",

--- a/src/quantik_core/contracts.py
+++ b/src/quantik_core/contracts.py
@@ -1,0 +1,12 @@
+"""Shared Quantik portability contract identifiers."""
+
+SUPPORTED_CONTRACTS_RELEASE = "1.0.0"
+
+SUPPORTED_CONTRACTS = {
+    "contracts_release": SUPPORTED_CONTRACTS_RELEASE,
+    "qfen": "qfen.v1",
+    "bitboard": "bitboard.v1",
+    "action_index": "action-index.v1",
+    "selfplay": "selfplay.v1",
+    "tensor_board": "tensor-board.v1",
+}

--- a/src/quantik_core/ml_data.py
+++ b/src/quantik_core/ml_data.py
@@ -15,9 +15,10 @@ from typing import Any, Iterable, Mapping, Sequence
 import numpy as np
 import numpy.typing as npt
 
+from .commons import Bitboard
 from .move import generate_legal_moves_list
 from .qfen import bb_from_qfen
-from .state_validator import ValidationResult, _validate_game_state_single_pass
+from .state_validator import ValidationResult, validate_game_state
 
 ACTION_COUNT = 64
 BOARD_SIZE = 4
@@ -87,8 +88,9 @@ def _parse_policy(policy: Any) -> tuple[PolicyVisit, ...]:
     return tuple(visits)
 
 
-def _validate_policy_is_legal(qfen: str, policy: Sequence[PolicyVisit]) -> None:
-    bitboard = bb_from_qfen(qfen, validate=True)
+def _validate_policy_is_legal(
+    bitboard: Bitboard, policy: Sequence[PolicyVisit]
+) -> None:
     legal_actions = {
         (move.shape, move.position) for move in generate_legal_moves_list(bitboard)
     }
@@ -104,18 +106,23 @@ def parse_selfplay_row(record: Mapping[str, Any]) -> SelfPlayRow:
     """Validate and parse one Rust self-play JSON object."""
     game_id = _expect_int(record, "game_id")
     ply = _expect_int(record, "ply")
+    if game_id < 0:
+        raise ValueError("game_id must be non-negative")
+    if ply < 0:
+        raise ValueError("ply must be non-negative")
+
     qfen = _expect_qfen(record)
     side_to_move = _expect_int(record, "side_to_move")
     if side_to_move not in (0, 1):
         raise ValueError("side_to_move must be 0 or 1")
 
     bitboard = bb_from_qfen(qfen, validate=True)
-    current_player, result = _validate_game_state_single_pass(bitboard)
+    current_player, result = validate_game_state(bitboard)
     if result != ValidationResult.OK or current_player != side_to_move:
         raise ValueError("side_to_move does not match qfen")
 
     policy = _parse_policy(record.get("policy"))
-    _validate_policy_is_legal(qfen, policy)
+    _validate_policy_is_legal(bitboard, policy)
 
     raw_value = record.get("value")
     if not isinstance(raw_value, (int, float)) or isinstance(raw_value, bool):
@@ -123,11 +130,6 @@ def parse_selfplay_row(record: Mapping[str, Any]) -> SelfPlayRow:
     value = float(raw_value)
     if value not in (-1.0, 1.0):
         raise ValueError("value must be exactly -1.0 or 1.0")
-
-    if game_id < 0:
-        raise ValueError("game_id must be non-negative")
-    if ply < 0:
-        raise ValueError("ply must be non-negative")
 
     return SelfPlayRow(
         game_id=game_id,

--- a/src/quantik_core/ml_data.py
+++ b/src/quantik_core/ml_data.py
@@ -1,0 +1,198 @@
+"""ML data helpers for cross-language self-play artifacts.
+
+The companion Rust crate owns high-throughput self-play export. This module is
+Python's reference reader for those JSONL rows and the first layer used by later
+training code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+import numpy as np
+import numpy.typing as npt
+
+from .move import generate_legal_moves_list
+from .qfen import bb_from_qfen
+from .state_validator import ValidationResult, _validate_game_state_single_pass
+
+ACTION_COUNT = 64
+BOARD_SIZE = 4
+PLAYER_SHAPE_CHANNELS = 8
+SIDE_TO_MOVE_CHANNEL = 8
+TENSOR_CHANNELS = 9
+
+
+@dataclass(frozen=True)
+class PolicyVisit:
+    """Visit count for one root action in a Rust self-play row."""
+
+    shape: int
+    position: int
+    visits: int
+
+    @property
+    def action_index(self) -> int:
+        """Return the shared 64-slot action index, shape-major."""
+        return self.shape * 16 + self.position
+
+
+@dataclass(frozen=True)
+class SelfPlayRow:
+    """One self-play training row emitted by the Rust exporter."""
+
+    game_id: int
+    ply: int
+    qfen: str
+    side_to_move: int
+    policy: tuple[PolicyVisit, ...]
+    value: float
+
+
+def _expect_int(record: Mapping[str, Any], key: str) -> int:
+    value = record.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def _expect_qfen(record: Mapping[str, Any]) -> str:
+    value = record.get("qfen")
+    if not isinstance(value, str):
+        raise ValueError("qfen must be a string")
+    return value
+
+
+def _parse_policy(policy: Any) -> tuple[PolicyVisit, ...]:
+    if not isinstance(policy, list) or not policy:
+        raise ValueError("policy must be a non-empty list")
+
+    visits: list[PolicyVisit] = []
+    for index, item in enumerate(policy):
+        if not isinstance(item, dict):
+            raise ValueError(f"policy[{index}] must be an object")
+        shape = _expect_int(item, "shape")
+        position = _expect_int(item, "position")
+        visit_count = _expect_int(item, "visits")
+        if shape < 0 or shape > 3:
+            raise ValueError(f"policy[{index}].shape must be in 0..3")
+        if position < 0 or position > 15:
+            raise ValueError(f"policy[{index}].position must be in 0..15")
+        if visit_count <= 0:
+            raise ValueError(f"policy[{index}].visits must be positive")
+        visits.append(PolicyVisit(shape=shape, position=position, visits=visit_count))
+    return tuple(visits)
+
+
+def _validate_policy_is_legal(qfen: str, policy: Sequence[PolicyVisit]) -> None:
+    bitboard = bb_from_qfen(qfen, validate=True)
+    legal_actions = {
+        (move.shape, move.position) for move in generate_legal_moves_list(bitboard)
+    }
+    for visit in policy:
+        if (visit.shape, visit.position) not in legal_actions:
+            raise ValueError(
+                "policy action is not legal for row state: "
+                f"shape={visit.shape}, position={visit.position}"
+            )
+
+
+def parse_selfplay_row(record: Mapping[str, Any]) -> SelfPlayRow:
+    """Validate and parse one Rust self-play JSON object."""
+    game_id = _expect_int(record, "game_id")
+    ply = _expect_int(record, "ply")
+    qfen = _expect_qfen(record)
+    side_to_move = _expect_int(record, "side_to_move")
+    if side_to_move not in (0, 1):
+        raise ValueError("side_to_move must be 0 or 1")
+
+    bitboard = bb_from_qfen(qfen, validate=True)
+    current_player, result = _validate_game_state_single_pass(bitboard)
+    if result != ValidationResult.OK or current_player != side_to_move:
+        raise ValueError("side_to_move does not match qfen")
+
+    policy = _parse_policy(record.get("policy"))
+    _validate_policy_is_legal(qfen, policy)
+
+    raw_value = record.get("value")
+    if not isinstance(raw_value, (int, float)) or isinstance(raw_value, bool):
+        raise ValueError("value must be numeric")
+    value = float(raw_value)
+    if value not in (-1.0, 1.0):
+        raise ValueError("value must be exactly -1.0 or 1.0")
+
+    if game_id < 0:
+        raise ValueError("game_id must be non-negative")
+    if ply < 0:
+        raise ValueError("ply must be non-negative")
+
+    return SelfPlayRow(
+        game_id=game_id,
+        ply=ply,
+        qfen=qfen,
+        side_to_move=side_to_move,
+        policy=policy,
+        value=value,
+    )
+
+
+def load_selfplay_jsonl(path: str | Path) -> list[SelfPlayRow]:
+    """Load and validate a Rust self-play JSONL file."""
+    rows: list[SelfPlayRow] = []
+    with Path(path).open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                record = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid JSON on line {line_number}: {exc}") from exc
+            if not isinstance(record, dict):
+                raise ValueError(f"line {line_number} must contain a JSON object")
+            try:
+                rows.append(parse_selfplay_row(record))
+            except ValueError as exc:
+                raise ValueError(
+                    f"invalid self-play row on line {line_number}: {exc}"
+                ) from exc
+    return rows
+
+
+def qfen_to_tensor(qfen: str, side_to_move: int) -> npt.NDArray[np.float32]:
+    """Encode a QFEN position as a `(9, 4, 4)` NumPy tensor."""
+    if side_to_move not in (0, 1):
+        raise ValueError("side_to_move must be 0 or 1")
+    bitboard = bb_from_qfen(qfen, validate=True)
+    tensor = np.zeros((TENSOR_CHANNELS, BOARD_SIZE, BOARD_SIZE), dtype=np.float32)
+
+    for channel in range(PLAYER_SHAPE_CHANNELS):
+        bits = bitboard[channel]
+        for position in range(16):
+            if (bits >> position) & 1:
+                row = position // BOARD_SIZE
+                col = position % BOARD_SIZE
+                tensor[channel, row, col] = 1.0
+
+    tensor[SIDE_TO_MOVE_CHANNEL, :, :] = float(side_to_move)
+    return tensor
+
+
+def policy_visits_to_distribution(
+    policy: Iterable[PolicyVisit],
+) -> npt.NDArray[np.float32]:
+    """Normalize policy visit counts into the shared 64-slot action vector."""
+    distribution = np.zeros(ACTION_COUNT, dtype=np.float32)
+    total_visits = 0
+    for visit in policy:
+        if visit.visits <= 0:
+            raise ValueError("policy visits must be positive")
+        distribution[visit.action_index] += visit.visits
+        total_visits += visit.visits
+    if total_visits <= 0:
+        raise ValueError("policy must contain at least one visit")
+    distribution /= float(total_visits)
+    return distribution

--- a/src/quantik_core/ml_data.py
+++ b/src/quantik_core/ml_data.py
@@ -16,6 +16,7 @@ import numpy as np
 import numpy.typing as npt
 
 from .commons import Bitboard
+from .contracts import SUPPORTED_CONTRACTS, SUPPORTED_CONTRACTS_RELEASE
 from .move import generate_legal_moves_list
 from .qfen import bb_from_qfen
 from .state_validator import ValidationResult, validate_game_state
@@ -25,6 +26,7 @@ BOARD_SIZE = 4
 PLAYER_SHAPE_CHANNELS = 8
 SIDE_TO_MOVE_CHANNEL = 8
 TENSOR_CHANNELS = 9
+SELFPLAY_SCHEMA = SUPPORTED_CONTRACTS["selfplay"]
 
 
 @dataclass(frozen=True)
@@ -67,6 +69,19 @@ def _expect_qfen(record: Mapping[str, Any]) -> str:
     return value
 
 
+def _validate_contract_fields(record: Mapping[str, Any]) -> None:
+    schema = record.get("schema")
+    if schema != SELFPLAY_SCHEMA:
+        raise ValueError(f"schema must be {SELFPLAY_SCHEMA}")
+
+    contract_version = record.get("contract_version")
+    if contract_version is not None and contract_version != SUPPORTED_CONTRACTS_RELEASE:
+        raise ValueError(
+            "contract_version must match supported contracts release "
+            f"{SUPPORTED_CONTRACTS_RELEASE}"
+        )
+
+
 def _parse_policy(policy: Any) -> tuple[PolicyVisit, ...]:
     if not isinstance(policy, list) or not policy:
         raise ValueError("policy must be a non-empty list")
@@ -104,6 +119,7 @@ def _validate_policy_is_legal(
 
 def parse_selfplay_row(record: Mapping[str, Any]) -> SelfPlayRow:
     """Validate and parse one Rust self-play JSON object."""
+    _validate_contract_fields(record)
     game_id = _expect_int(record, "game_id")
     ply = _expect_int(record, "ply")
     if game_id < 0:

--- a/src/quantik_core/ml_data.py
+++ b/src/quantik_core/ml_data.py
@@ -70,6 +70,12 @@ def _expect_qfen(record: Mapping[str, Any]) -> str:
 
 
 def _validate_contract_fields(record: Mapping[str, Any]) -> None:
+    """Validate required schema and optional release pin.
+
+    `schema` is required so readers can reject unsupported row layouts early.
+    `contract_version` is optional for early Rust emitters, but must match this
+    package's supported contracts release when present.
+    """
     schema = record.get("schema")
     if schema != SELFPLAY_SCHEMA:
         raise ValueError(f"schema must be {SELFPLAY_SCHEMA}")

--- a/tests/fixtures/selfplay_v1.jsonl
+++ b/tests/fixtures/selfplay_v1.jsonl
@@ -1,2 +1,2 @@
-{"game_id":0,"ply":0,"qfen":"..../..../..../....","side_to_move":0,"policy":[{"shape":0,"position":0,"visits":3},{"shape":1,"position":5,"visits":1}],"value":1.0}
-{"game_id":0,"ply":1,"qfen":"A.../..../..../....","side_to_move":1,"policy":[{"shape":0,"position":10,"visits":2},{"shape":1,"position":1,"visits":6}],"value":-1.0}
+{"schema":"selfplay.v1","contract_version":"1.0.0","game_id":0,"ply":0,"qfen":"..../..../..../....","side_to_move":0,"policy":[{"shape":0,"position":0,"visits":3},{"shape":1,"position":5,"visits":1}],"value":1.0}
+{"schema":"selfplay.v1","contract_version":"1.0.0","game_id":0,"ply":1,"qfen":"A.../..../..../....","side_to_move":1,"policy":[{"shape":0,"position":10,"visits":2},{"shape":1,"position":1,"visits":6}],"value":-1.0}

--- a/tests/fixtures/selfplay_v1.jsonl
+++ b/tests/fixtures/selfplay_v1.jsonl
@@ -1,0 +1,2 @@
+{"game_id":0,"ply":0,"qfen":"..../..../..../....","side_to_move":0,"policy":[{"shape":0,"position":0,"visits":3},{"shape":1,"position":5,"visits":1}],"value":1.0}
+{"game_id":0,"ply":1,"qfen":"A.../..../..../....","side_to_move":1,"policy":[{"shape":0,"position":10,"visits":2},{"shape":1,"position":1,"visits":6}],"value":-1.0}

--- a/tests/test_ml_data.py
+++ b/tests/test_ml_data.py
@@ -16,6 +16,10 @@ from quantik_core.ml_data import (
 FIXTURE = Path(__file__).parent / "fixtures" / "selfplay_v1.jsonl"
 
 
+def _fixture_record(index: int = 0):
+    return json.loads(FIXTURE.read_text().splitlines()[index])
+
+
 def test_load_selfplay_jsonl_fixture():
     rows = load_selfplay_jsonl(FIXTURE)
 
@@ -60,8 +64,53 @@ def test_policy_visits_to_distribution_uses_shape_major_action_index():
     assert distribution.sum() == pytest.approx(1.0)
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("game_id", True, "game_id must be an integer"),
+        ("game_id", -1, "game_id must be non-negative"),
+        ("ply", -1, "ply must be non-negative"),
+        ("side_to_move", 2, "side_to_move must be 0 or 1"),
+        ("value", True, "value must be numeric"),
+    ],
+)
+def test_parse_selfplay_row_rejects_invalid_scalar_fields(field, value, message):
+    record = _fixture_record()
+    record[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        parse_selfplay_row(record)
+
+
+def test_parse_selfplay_row_rejects_non_string_qfen():
+    record = _fixture_record()
+    record["qfen"] = 123
+
+    with pytest.raises(ValueError, match="qfen must be a string"):
+        parse_selfplay_row(record)
+
+
+@pytest.mark.parametrize(
+    ("policy", "message"),
+    [
+        ([], "policy must be a non-empty list"),
+        ("bad", "policy must be a non-empty list"),
+        ([123], r"policy\[0\] must be an object"),
+        ([{"shape": 4, "position": 0, "visits": 1}], r"policy\[0\].shape"),
+        ([{"shape": 0, "position": 16, "visits": 1}], r"policy\[0\].position"),
+        ([{"shape": 0, "position": 0, "visits": 0}], r"policy\[0\].visits"),
+    ],
+)
+def test_parse_selfplay_row_rejects_invalid_policy_shapes(policy, message):
+    record = _fixture_record()
+    record["policy"] = policy
+
+    with pytest.raises(ValueError, match=message):
+        parse_selfplay_row(record)
+
+
 def test_parse_selfplay_row_rejects_zero_value():
-    record = json.loads(FIXTURE.read_text().splitlines()[0])
+    record = _fixture_record()
     record["value"] = 0.0
 
     with pytest.raises(ValueError, match="value must be exactly"):
@@ -69,7 +118,7 @@ def test_parse_selfplay_row_rejects_zero_value():
 
 
 def test_parse_selfplay_row_rejects_schema_mismatch():
-    record = json.loads(FIXTURE.read_text().splitlines()[0])
+    record = _fixture_record()
     record["schema"] = "selfplay.v2"
 
     with pytest.raises(ValueError, match="schema must be selfplay.v1"):
@@ -77,7 +126,7 @@ def test_parse_selfplay_row_rejects_schema_mismatch():
 
 
 def test_parse_selfplay_row_rejects_contract_version_mismatch():
-    record = json.loads(FIXTURE.read_text().splitlines()[0])
+    record = _fixture_record()
     record["contract_version"] = "9.9.9"
 
     with pytest.raises(ValueError, match="contract_version must match"):
@@ -85,7 +134,7 @@ def test_parse_selfplay_row_rejects_contract_version_mismatch():
 
 
 def test_parse_selfplay_row_rejects_side_to_move_mismatch():
-    record = json.loads(FIXTURE.read_text().splitlines()[0])
+    record = _fixture_record()
     record["side_to_move"] = 1
 
     with pytest.raises(ValueError, match="side_to_move does not match"):
@@ -93,8 +142,56 @@ def test_parse_selfplay_row_rejects_side_to_move_mismatch():
 
 
 def test_parse_selfplay_row_rejects_illegal_policy_action():
-    record = json.loads(FIXTURE.read_text().splitlines()[1])
+    record = _fixture_record(1)
     record["policy"] = [{"shape": 0, "position": 1, "visits": 1}]
 
     with pytest.raises(ValueError, match="policy action is not legal"):
         parse_selfplay_row(record)
+
+
+def test_load_selfplay_jsonl_skips_blank_lines(tmp_path):
+    path = tmp_path / "rows.jsonl"
+    path.write_text("\n" + FIXTURE.read_text() + "\n", encoding="utf-8")
+
+    assert len(load_selfplay_jsonl(path)) == 2
+
+
+def test_load_selfplay_jsonl_reports_bad_json_line(tmp_path):
+    path = tmp_path / "rows.jsonl"
+    path.write_text('{"bad"\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid JSON on line 1"):
+        load_selfplay_jsonl(path)
+
+
+def test_load_selfplay_jsonl_rejects_non_object_line(tmp_path):
+    path = tmp_path / "rows.jsonl"
+    path.write_text("[1, 2, 3]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="line 1 must contain a JSON object"):
+        load_selfplay_jsonl(path)
+
+
+def test_load_selfplay_jsonl_wraps_invalid_row_with_line_number(tmp_path):
+    path = tmp_path / "rows.jsonl"
+    record = _fixture_record()
+    record["value"] = 0.0
+    path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid self-play row on line 1"):
+        load_selfplay_jsonl(path)
+
+
+def test_qfen_to_tensor_rejects_invalid_side_to_move():
+    with pytest.raises(ValueError, match="side_to_move must be 0 or 1"):
+        qfen_to_tensor("..../..../..../....", side_to_move=2)
+
+
+def test_policy_visits_to_distribution_rejects_non_positive_visits():
+    with pytest.raises(ValueError, match="policy visits must be positive"):
+        policy_visits_to_distribution([PolicyVisit(shape=0, position=0, visits=0)])
+
+
+def test_policy_visits_to_distribution_rejects_empty_policy():
+    with pytest.raises(ValueError, match="policy must contain at least one visit"):
+        policy_visits_to_distribution([])

--- a/tests/test_ml_data.py
+++ b/tests/test_ml_data.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from quantik_core import SUPPORTED_CONTRACTS, SUPPORTED_CONTRACTS_RELEASE
 from quantik_core.ml_data import (
     PolicyVisit,
     load_selfplay_jsonl,
@@ -28,6 +29,13 @@ def test_load_selfplay_jsonl_fixture():
         PolicyVisit(shape=0, position=0, visits=3),
         PolicyVisit(shape=1, position=5, visits=1),
     )
+
+
+def test_supported_contracts_are_declared():
+    assert SUPPORTED_CONTRACTS_RELEASE == "1.0.0"
+    assert SUPPORTED_CONTRACTS["contracts_release"] == "1.0.0"
+    assert SUPPORTED_CONTRACTS["selfplay"] == "selfplay.v1"
+    assert SUPPORTED_CONTRACTS["action_index"] == "action-index.v1"
 
 
 def test_qfen_to_tensor_channel_layout():
@@ -57,6 +65,22 @@ def test_parse_selfplay_row_rejects_zero_value():
     record["value"] = 0.0
 
     with pytest.raises(ValueError, match="value must be exactly"):
+        parse_selfplay_row(record)
+
+
+def test_parse_selfplay_row_rejects_schema_mismatch():
+    record = json.loads(FIXTURE.read_text().splitlines()[0])
+    record["schema"] = "selfplay.v2"
+
+    with pytest.raises(ValueError, match="schema must be selfplay.v1"):
+        parse_selfplay_row(record)
+
+
+def test_parse_selfplay_row_rejects_contract_version_mismatch():
+    record = json.loads(FIXTURE.read_text().splitlines()[0])
+    record["contract_version"] = "9.9.9"
+
+    with pytest.raises(ValueError, match="contract_version must match"):
         parse_selfplay_row(record)
 
 

--- a/tests/test_ml_data.py
+++ b/tests/test_ml_data.py
@@ -1,0 +1,76 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from quantik_core.ml_data import (
+    PolicyVisit,
+    load_selfplay_jsonl,
+    parse_selfplay_row,
+    policy_visits_to_distribution,
+    qfen_to_tensor,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "selfplay_v1.jsonl"
+
+
+def test_load_selfplay_jsonl_fixture():
+    rows = load_selfplay_jsonl(FIXTURE)
+
+    assert len(rows) == 2
+    assert rows[0].game_id == 0
+    assert rows[0].ply == 0
+    assert rows[0].qfen == "..../..../..../...."
+    assert rows[0].side_to_move == 0
+    assert rows[0].value == 1.0
+    assert rows[0].policy == (
+        PolicyVisit(shape=0, position=0, visits=3),
+        PolicyVisit(shape=1, position=5, visits=1),
+    )
+
+
+def test_qfen_to_tensor_channel_layout():
+    tensor = qfen_to_tensor("A.../.b../..../....", side_to_move=1)
+
+    assert tensor.shape == (9, 4, 4)
+    assert tensor.dtype == np.float32
+    assert tensor[0, 0, 0] == 1.0
+    assert tensor[5, 1, 1] == 1.0
+    assert tensor[:8].sum() == 2.0
+    assert np.all(tensor[8] == 1.0)
+
+
+def test_policy_visits_to_distribution_uses_shape_major_action_index():
+    distribution = policy_visits_to_distribution(
+        [PolicyVisit(shape=0, position=0, visits=3), PolicyVisit(1, 5, 1)]
+    )
+
+    assert distribution.shape == (64,)
+    assert distribution[0] == pytest.approx(0.75)
+    assert distribution[21] == pytest.approx(0.25)
+    assert distribution.sum() == pytest.approx(1.0)
+
+
+def test_parse_selfplay_row_rejects_zero_value():
+    record = json.loads(FIXTURE.read_text().splitlines()[0])
+    record["value"] = 0.0
+
+    with pytest.raises(ValueError, match="value must be exactly"):
+        parse_selfplay_row(record)
+
+
+def test_parse_selfplay_row_rejects_side_to_move_mismatch():
+    record = json.loads(FIXTURE.read_text().splitlines()[0])
+    record["side_to_move"] = 1
+
+    with pytest.raises(ValueError, match="side_to_move does not match"):
+        parse_selfplay_row(record)
+
+
+def test_parse_selfplay_row_rejects_illegal_policy_action():
+    record = json.loads(FIXTURE.read_text().splitlines()[1])
+    record["policy"] = [{"shape": 0, "position": 1, "visits": 1}]
+
+    with pytest.raises(ValueError, match="policy action is not legal"):
+        parse_selfplay_row(record)


### PR DESCRIPTION
## Summary
- Defines the Python/Rust portability contract for board layout, QFEN, bitboards, action indexing, and Rust self-play JSONL rows.
- Adds quantik_core.ml_data helpers to validate Rust JSONL rows, encode QFEN into 9-channel tensors, and normalize visit policies into 64-action distributions.
- Adds a golden self-play fixture and tests to pin the cross-language schema.
- Adds the Python-side implementation plan for generated artifact smoke tests and future ML dataset work.

## Verification
- env PYTHONPATH=src .venv/bin/python -m pytest tests/test_ml_data.py -q --no-cov
- env PYTHONPATH=src .venv/bin/python -m mypy src/quantik_core/ml_data.py
- ./auto-lint.sh
- env PYTHONPATH=src ./dev-check.sh

Note: PYTHONPATH=src was used because this worktree shares the main checkout virtualenv editable install.