### PR TITLE
Read opening knowledge artifact rows

### DIFF
--- a/src/quantik_core/artifact_data.py
+++ b/src/quantik_core/artifact_data.py
@@ -1,0 +1,320 @@
+"""Readers for Quantik artifact contracts beyond self-play rows.
+
+The contracts repository defines bulk observations and completed games as
+Parquet-first artifacts. This module intentionally starts with JSON/JSONL
+readers because the Rust generator can emit those without optional Parquet
+dependencies; a Parquet reader can materialize the same dataclasses later.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .commons import Bitboard
+from .contracts import SUPPORTED_CONTRACTS, SUPPORTED_CONTRACTS_RELEASE
+from .move import generate_legal_moves_list
+from .qfen import bb_from_qfen
+from .state_validator import ValidationResult, validate_game_state
+
+ACTION_COUNT = 64
+OBSERVATION_SCHEMA = SUPPORTED_CONTRACTS["observation"]
+GAME_RESULT_SCHEMA = SUPPORTED_CONTRACTS["game_result"]
+MODEL_CHECKPOINT_SCHEMA = SUPPORTED_CONTRACTS["model_checkpoint"]
+
+
+@dataclass(frozen=True)
+class ObservationRow:
+    """One `observation.v1` row from a search/evaluation run."""
+
+    run_id: str
+    row_id: int
+    position_key: str
+    ply: int
+    side_to_move: int
+    bitboards: Bitboard
+    legal_action_mask: int
+    engine_kind: str
+    engine_version: str
+    policy_visits: tuple[int, ...]
+    value: float
+    value_source: str
+    source_confidence: float
+    qfen: str | None = None
+
+
+@dataclass(frozen=True)
+class GameResultRow:
+    """One completed `game-result.v1` head-to-head game."""
+
+    game_id: str
+    p0_engine_kind: str
+    p1_engine_kind: str
+    initial_position_key: str
+    winner: int
+    plies: int
+    terminal_reason: str
+    move_action_indices: tuple[int, ...]
+    run_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ModelCheckpointManifest:
+    """Metadata for one `model-checkpoint.v1` artifact."""
+
+    model_id: str
+    model_family: str
+    input_contracts: tuple[str, ...]
+    output_contract: str
+    weights_format: str
+    weights_hash: str
+    size_bytes: int
+    training_data_manifest: str
+    calibration_report: str
+
+
+def _expect_int(record: Mapping[str, Any], key: str) -> int:
+    value = record.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{key} must be an integer")
+    return value
+
+
+def _expect_str(record: Mapping[str, Any], key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _expect_number(record: Mapping[str, Any], key: str) -> float:
+    value = record.get(key)
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"{key} must be numeric")
+    return float(value)
+
+
+def _validate_schema(record: Mapping[str, Any], expected_schema: str) -> None:
+    schema = record.get("schema")
+    if schema != expected_schema:
+        raise ValueError(f"schema must be {expected_schema}")
+    contract_version = record.get("contract_version")
+    if contract_version != SUPPORTED_CONTRACTS_RELEASE:
+        raise ValueError(
+            "contract_version must match supported contracts release "
+            f"{SUPPORTED_CONTRACTS_RELEASE}"
+        )
+
+
+def _parse_bitboards(value: Any) -> Bitboard:
+    if not isinstance(value, list) or len(value) != 8:
+        raise ValueError("bitboards must contain exactly 8 uint16 planes")
+    planes: list[int] = []
+    for index, plane in enumerate(value):
+        if not isinstance(plane, int) or isinstance(plane, bool):
+            raise ValueError(f"bitboards[{index}] must be an integer")
+        if plane < 0 or plane > 0xFFFF:
+            raise ValueError(f"bitboards[{index}] must be in 0..65535")
+        planes.append(plane)
+    return tuple(planes)  # type: ignore[return-value]
+
+
+def _parse_u64_mask(record: Mapping[str, Any], key: str) -> int:
+    value = _expect_int(record, key)
+    if value < 0 or value > 0xFFFF_FFFF_FFFF_FFFF:
+        raise ValueError(f"{key} must be a uint64")
+    return value
+
+
+def _parse_fixed_policy_visits(value: Any) -> tuple[int, ...]:
+    if not isinstance(value, list) or len(value) != ACTION_COUNT:
+        raise ValueError("policy_visits must contain exactly 64 integers")
+    visits: list[int] = []
+    for index, visit in enumerate(value):
+        if not isinstance(visit, int) or isinstance(visit, bool):
+            raise ValueError(f"policy_visits[{index}] must be an integer")
+        if visit < 0:
+            raise ValueError(f"policy_visits[{index}] must be non-negative")
+        visits.append(visit)
+    if sum(visits) <= 0:
+        raise ValueError("policy_visits must contain at least one visit")
+    return tuple(visits)
+
+
+def _legal_action_mask(bitboards: Bitboard) -> int:
+    mask = 0
+    for move in generate_legal_moves_list(bitboards):
+        mask |= 1 << (move.shape * 16 + move.position)
+    return mask
+
+
+def _validate_bitboards_and_side(
+    bitboards: Bitboard, side_to_move: int, qfen: str | None
+) -> None:
+    current_player, result = validate_game_state(bitboards)
+    if result != ValidationResult.OK or current_player != side_to_move:
+        raise ValueError("side_to_move does not match bitboards")
+    if qfen is not None and bb_from_qfen(qfen, validate=True) != bitboards:
+        raise ValueError("qfen does not match bitboards")
+
+
+def parse_observation_row(record: Mapping[str, Any]) -> ObservationRow:
+    """Validate and parse one `observation.v1` JSON object."""
+    _validate_schema(record, OBSERVATION_SCHEMA)
+    row_id = _expect_int(record, "row_id")
+    ply = _expect_int(record, "ply")
+    side_to_move = _expect_int(record, "side_to_move")
+    if row_id < 0:
+        raise ValueError("row_id must be non-negative")
+    if ply < 0:
+        raise ValueError("ply must be non-negative")
+    if side_to_move not in (0, 1):
+        raise ValueError("side_to_move must be 0 or 1")
+
+    bitboards = _parse_bitboards(record.get("bitboards"))
+    qfen_value = record.get("qfen")
+    qfen = qfen_value if isinstance(qfen_value, str) else None
+    _validate_bitboards_and_side(bitboards, side_to_move, qfen)
+
+    legal_action_mask = _parse_u64_mask(record, "legal_action_mask")
+    expected_mask = _legal_action_mask(bitboards)
+    if legal_action_mask != expected_mask:
+        raise ValueError("legal_action_mask does not match bitboards")
+
+    policy_visits = _parse_fixed_policy_visits(record.get("policy_visits"))
+    for action_index, visits in enumerate(policy_visits):
+        if visits and not ((legal_action_mask >> action_index) & 1):
+            raise ValueError(f"policy_visits[{action_index}] is not legal")
+
+    source_confidence = _expect_number(record, "source_confidence")
+    if not 0.0 <= source_confidence <= 1.0:
+        raise ValueError("source_confidence must be in 0.0..1.0")
+
+    return ObservationRow(
+        run_id=_expect_str(record, "run_id"),
+        row_id=row_id,
+        position_key=_expect_str(record, "position_key"),
+        ply=ply,
+        side_to_move=side_to_move,
+        bitboards=bitboards,
+        legal_action_mask=legal_action_mask,
+        engine_kind=_expect_str(record, "engine_kind"),
+        engine_version=_expect_str(record, "engine_version"),
+        policy_visits=policy_visits,
+        value=_expect_number(record, "value"),
+        value_source=_expect_str(record, "value_source"),
+        source_confidence=source_confidence,
+        qfen=qfen,
+    )
+
+
+def parse_game_result_row(record: Mapping[str, Any]) -> GameResultRow:
+    """Validate and parse one `game-result.v1` JSON object."""
+    _validate_schema(record, GAME_RESULT_SCHEMA)
+    winner = _expect_int(record, "winner")
+    plies = _expect_int(record, "plies")
+    if winner not in (0, 1):
+        raise ValueError("winner must be 0 or 1")
+    if plies < 0:
+        raise ValueError("plies must be non-negative")
+
+    moves_value = record.get("move_action_indices")
+    if not isinstance(moves_value, list):
+        raise ValueError("move_action_indices must be a list")
+    moves: list[int] = []
+    for index, action in enumerate(moves_value):
+        if not isinstance(action, int) or isinstance(action, bool):
+            raise ValueError(f"move_action_indices[{index}] must be an integer")
+        if action < 0 or action >= ACTION_COUNT:
+            raise ValueError(f"move_action_indices[{index}] must be in 0..63")
+        moves.append(action)
+    if plies != len(moves):
+        raise ValueError("plies must match move_action_indices length")
+
+    run_id_value = record.get("run_id")
+    return GameResultRow(
+        game_id=_expect_str(record, "game_id"),
+        p0_engine_kind=_expect_str(record, "p0_engine_kind"),
+        p1_engine_kind=_expect_str(record, "p1_engine_kind"),
+        initial_position_key=_expect_str(record, "initial_position_key"),
+        winner=winner,
+        plies=plies,
+        terminal_reason=_expect_str(record, "terminal_reason"),
+        move_action_indices=tuple(moves),
+        run_id=run_id_value if isinstance(run_id_value, str) else None,
+    )
+
+
+def parse_model_checkpoint_manifest(
+    record: Mapping[str, Any],
+) -> ModelCheckpointManifest:
+    """Validate and parse one `model-checkpoint.v1` manifest object."""
+    _validate_schema(record, MODEL_CHECKPOINT_SCHEMA)
+    input_contracts_value = record.get("input_contracts")
+    if not isinstance(input_contracts_value, list) or not input_contracts_value:
+        raise ValueError("input_contracts must be a non-empty list")
+    input_contracts = tuple(
+        contract
+        for contract in input_contracts_value
+        if isinstance(contract, str) and contract
+    )
+    if len(input_contracts) != len(input_contracts_value):
+        raise ValueError("input_contracts must contain only non-empty strings")
+    size_bytes = _expect_int(record, "size_bytes")
+    if size_bytes <= 0:
+        raise ValueError("size_bytes must be positive")
+
+    return ModelCheckpointManifest(
+        model_id=_expect_str(record, "model_id"),
+        model_family=_expect_str(record, "model_family"),
+        input_contracts=input_contracts,
+        output_contract=_expect_str(record, "output_contract"),
+        weights_format=_expect_str(record, "weights_format"),
+        weights_hash=_expect_str(record, "weights_hash"),
+        size_bytes=size_bytes,
+        training_data_manifest=_expect_str(record, "training_data_manifest"),
+        calibration_report=_expect_str(record, "calibration_report"),
+    )
+
+
+def _load_jsonl(path: str | Path, parser: Any, label: str) -> list[Any]:
+    rows: list[Any] = []
+    with Path(path).open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                record = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid JSON on line {line_number}: {exc}") from exc
+            if not isinstance(record, dict):
+                raise ValueError(f"line {line_number} must contain a JSON object")
+            try:
+                rows.append(parser(record))
+            except ValueError as exc:
+                raise ValueError(
+                    f"invalid {label} row on line {line_number}: {exc}"
+                ) from exc
+    return rows
+
+
+def load_observations_jsonl(path: str | Path) -> list[ObservationRow]:
+    """Load `observation.v1` JSONL rows."""
+    return _load_jsonl(path, parse_observation_row, "observation")
+
+
+def load_game_results_jsonl(path: str | Path) -> list[GameResultRow]:
+    """Load `game-result.v1` JSONL rows."""
+    return _load_jsonl(path, parse_game_result_row, "game-result")
+
+
+def load_model_checkpoint_manifest(path: str | Path) -> ModelCheckpointManifest:
+    """Load a `model-checkpoint.v1` manifest JSON file."""
+    with Path(path).open(encoding="utf-8") as handle:
+        record = json.load(handle)
+    if not isinstance(record, dict):
+        raise ValueError("model checkpoint manifest must be a JSON object")
+    return parse_model_checkpoint_manifest(record)

--- a/src/quantik_core/contracts.py
+++ b/src/quantik_core/contracts.py
@@ -9,4 +9,8 @@ SUPPORTED_CONTRACTS = {
     "action_index": "action-index.v1",
     "selfplay": "selfplay.v1",
     "tensor_board": "tensor-board.v1",
+    "opening_book": "opening-book.v1",
+    "observation": "observation.v1",
+    "game_result": "game-result.v1",
+    "model_checkpoint": "model-checkpoint.v1",
 }

--- a/tests/test_artifact_data.py
+++ b/tests/test_artifact_data.py
@@ -13,6 +13,7 @@ from quantik_core.artifact_data import (
     parse_model_checkpoint_manifest,
     parse_observation_row,
 )
+from quantik_core.move import generate_legal_moves_list
 
 
 def observation_record():
@@ -93,6 +94,99 @@ def test_parse_observation_row_rejects_bad_legal_action_mask():
         parse_observation_row(record)
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("row_id", True, "row_id must be an integer"),
+        ("row_id", -1, "row_id must be non-negative"),
+        ("ply", -1, "ply must be non-negative"),
+        ("side_to_move", 2, "side_to_move must be 0 or 1"),
+        ("source_confidence", True, "source_confidence must be numeric"),
+        ("source_confidence", 1.5, "source_confidence must be in 0.0..1.0"),
+        ("run_id", "", "run_id must be a non-empty string"),
+        ("legal_action_mask", -1, "legal_action_mask must be a uint64"),
+    ],
+)
+def test_parse_observation_row_rejects_invalid_scalar_fields(field, value, message):
+    record = observation_record()
+    record[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        parse_observation_row(record)
+
+
+@pytest.mark.parametrize(
+    ("bitboards", "message"),
+    [
+        ([0] * 7, "bitboards must contain exactly 8 uint16 planes"),
+        ([False] + [0] * 7, r"bitboards\[0\] must be an integer"),
+        ([0x10000] + [0] * 7, r"bitboards\[0\] must be in 0..65535"),
+    ],
+)
+def test_parse_observation_row_rejects_invalid_bitboards(bitboards, message):
+    record = observation_record()
+    record["bitboards"] = bitboards
+
+    with pytest.raises(ValueError, match=message):
+        parse_observation_row(record)
+
+
+@pytest.mark.parametrize(
+    ("policy_visits", "message"),
+    [
+        ([1] * 63, "policy_visits must contain exactly 64 integers"),
+        ([False] + [0] * 63, r"policy_visits\[0\] must be an integer"),
+        ([-1] + [0] * 63, r"policy_visits\[0\] must be non-negative"),
+        ([0] * 64, "policy_visits must contain at least one visit"),
+    ],
+)
+def test_parse_observation_row_rejects_invalid_policy_visits(policy_visits, message):
+    record = observation_record()
+    record["policy_visits"] = policy_visits
+
+    with pytest.raises(ValueError, match=message):
+        parse_observation_row(record)
+
+
+def test_parse_observation_row_rejects_schema_and_version_mismatch():
+    record = observation_record()
+    record["schema"] = "other.v1"
+    with pytest.raises(ValueError, match="schema must be observation.v1"):
+        parse_observation_row(record)
+
+    record = observation_record()
+    record["contract_version"] = "0.0.0"
+    with pytest.raises(ValueError, match="contract_version must match"):
+        parse_observation_row(record)
+
+
+def test_parse_observation_row_rejects_side_to_move_mismatch():
+    record = observation_record()
+    record["bitboards"] = [1, 0, 0, 0, 0, 0, 0, 0]
+    record["qfen"] = None
+
+    with pytest.raises(ValueError, match="side_to_move does not match bitboards"):
+        parse_observation_row(record)
+
+
+def test_parse_observation_row_rejects_policy_on_illegal_action():
+    bitboards = (1, 0, 0, 0, 0, 0, 0, 0)
+    legal_action_mask = 0
+    for move in generate_legal_moves_list(bitboards):
+        legal_action_mask |= 1 << (move.shape * 16 + move.position)
+
+    record = observation_record()
+    record["bitboards"] = list(bitboards)
+    record["qfen"] = None
+    record["side_to_move"] = 1
+    record["legal_action_mask"] = legal_action_mask
+    record["policy_visits"] = [0] * 64
+    record["policy_visits"][0] = 1
+
+    with pytest.raises(ValueError, match=r"policy_visits\[0\] is not legal"):
+        parse_observation_row(record)
+
+
 def test_parse_observation_row_rejects_bad_qfen_match():
     record = observation_record()
     record["qfen"] = "A.../..../..../...."
@@ -119,6 +213,39 @@ def test_parse_game_result_row_rejects_ply_mismatch():
         parse_game_result_row(record)
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("schema", "other.v1", "schema must be game-result.v1"),
+        ("winner", 2, "winner must be 0 or 1"),
+        ("plies", -1, "plies must be non-negative"),
+        ("game_id", "", "game_id must be a non-empty string"),
+    ],
+)
+def test_parse_game_result_row_rejects_invalid_scalar_fields(field, value, message):
+    record = game_result_record()
+    record[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        parse_game_result_row(record)
+
+
+@pytest.mark.parametrize(
+    ("moves", "message"),
+    [
+        ("0,1,2", "move_action_indices must be a list"),
+        ([True, 1, 2], r"move_action_indices\[0\] must be an integer"),
+        ([64, 1, 2], r"move_action_indices\[0\] must be in 0..63"),
+    ],
+)
+def test_parse_game_result_row_rejects_invalid_moves(moves, message):
+    record = game_result_record()
+    record["move_action_indices"] = moves
+
+    with pytest.raises(ValueError, match=message):
+        parse_game_result_row(record)
+
+
 def test_parse_model_checkpoint_manifest_accepts_valid_manifest():
     manifest = parse_model_checkpoint_manifest(model_manifest_record())
 
@@ -135,6 +262,24 @@ def test_parse_model_checkpoint_manifest_rejects_empty_input_contracts():
         parse_model_checkpoint_manifest(record)
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("schema", "other.v1", "schema must be model-checkpoint.v1"),
+        ("input_contracts", "bitboard.v1", "input_contracts must be a non-empty list"),
+        ("input_contracts", ["bitboard.v1", ""], "input_contracts must contain"),
+        ("size_bytes", 0, "size_bytes must be positive"),
+        ("weights_format", "", "weights_format must be a non-empty string"),
+    ],
+)
+def test_parse_model_checkpoint_manifest_rejects_invalid_fields(field, value, message):
+    record = model_manifest_record()
+    record[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        parse_model_checkpoint_manifest(record)
+
+
 def test_jsonl_loaders_report_line_numbers(tmp_path):
     observations = tmp_path / "observations.jsonl"
     observations.write_text(json.dumps(observation_record()) + "\n", encoding="utf-8")
@@ -148,8 +293,35 @@ def test_jsonl_loaders_report_line_numbers(tmp_path):
         load_game_results_jsonl(games)
 
 
+def test_jsonl_loader_rejects_bad_json_and_non_object_rows(tmp_path):
+    observations = tmp_path / "observations.jsonl"
+    observations.write_text("{bad json\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid JSON on line 1"):
+        load_observations_jsonl(observations)
+
+    observations.write_text("[1, 2, 3]\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="line 1 must contain a JSON object"):
+        load_observations_jsonl(observations)
+
+    bad_observation = observation_record()
+    bad_observation["row_id"] = -1
+    observations.write_text(json.dumps(bad_observation), encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid observation row on line 1"):
+        load_observations_jsonl(observations)
+
+
 def test_load_model_checkpoint_manifest(tmp_path):
     path = tmp_path / "model.json"
     path.write_text(json.dumps(model_manifest_record()), encoding="utf-8")
 
     assert load_model_checkpoint_manifest(path).weights_format == "safetensors"
+
+
+def test_load_model_checkpoint_manifest_rejects_non_object(tmp_path):
+    path = tmp_path / "model.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+
+    with pytest.raises(
+        ValueError, match="model checkpoint manifest must be a JSON object"
+    ):
+        load_model_checkpoint_manifest(path)

--- a/tests/test_artifact_data.py
+++ b/tests/test_artifact_data.py
@@ -1,0 +1,155 @@
+import json
+
+import pytest
+
+from quantik_core.artifact_data import (
+    GAME_RESULT_SCHEMA,
+    MODEL_CHECKPOINT_SCHEMA,
+    OBSERVATION_SCHEMA,
+    load_game_results_jsonl,
+    load_model_checkpoint_manifest,
+    load_observations_jsonl,
+    parse_game_result_row,
+    parse_model_checkpoint_manifest,
+    parse_observation_row,
+)
+
+
+def observation_record():
+    visits = [0] * 64
+    visits[0] = 1
+    return {
+        "schema": OBSERVATION_SCHEMA,
+        "contract_version": "1.0.0",
+        "run_id": "run-1",
+        "row_id": 0,
+        "position_key": "00",
+        "ply": 0,
+        "side_to_move": 0,
+        "bitboards": [0] * 8,
+        "qfen": "..../..../..../....",
+        "legal_action_mask": (1 << 64) - 1,
+        "engine_kind": "mcts",
+        "engine_version": "0.1.0",
+        "elapsed_ms": 12,
+        "policy_visits": visits,
+        "value": 0.25,
+        "value_source": "heuristic",
+        "source_confidence": 0.5,
+    }
+
+
+def game_result_record():
+    return {
+        "schema": GAME_RESULT_SCHEMA,
+        "contract_version": "1.0.0",
+        "game_id": "game-1",
+        "started_at": "2026-07-14T00:00:00+0200",
+        "p0_engine_kind": "mcts",
+        "p0_engine_version": "0.1.0",
+        "p1_engine_kind": "minimax",
+        "p1_engine_version": "0.1.0",
+        "initial_position_key": "00",
+        "winner": 1,
+        "plies": 3,
+        "terminal_reason": "win_condition_or_no_legal_moves",
+        "move_action_indices": [0, 17, 2],
+        "run_id": "run-1",
+    }
+
+
+def model_manifest_record():
+    return {
+        "schema": MODEL_CHECKPOINT_SCHEMA,
+        "contract_version": "1.0.0",
+        "model_id": "quantik-qnue-small",
+        "model_family": "qnue",
+        "created_at": "2026-07-14T00:00:00+0200",
+        "input_contracts": ["bitboard.v1", "action-index.v1"],
+        "output_contract": "policy-value.v1",
+        "weights_format": "safetensors",
+        "weights_hash": "sha256:abc",
+        "size_bytes": 42,
+        "training_data_manifest": "sha256:def",
+        "calibration_report": "sha256:ghi",
+    }
+
+
+def test_parse_observation_row_accepts_valid_contract_row():
+    row = parse_observation_row(observation_record())
+
+    assert row.run_id == "run-1"
+    assert row.row_id == 0
+    assert row.bitboards == (0, 0, 0, 0, 0, 0, 0, 0)
+    assert row.policy_visits[0] == 1
+    assert row.legal_action_mask == (1 << 64) - 1
+
+
+def test_parse_observation_row_rejects_bad_legal_action_mask():
+    record = observation_record()
+    record["legal_action_mask"] = 1
+
+    with pytest.raises(ValueError, match="legal_action_mask does not match bitboards"):
+        parse_observation_row(record)
+
+
+def test_parse_observation_row_rejects_bad_qfen_match():
+    record = observation_record()
+    record["qfen"] = "A.../..../..../...."
+
+    with pytest.raises(ValueError, match="qfen does not match bitboards"):
+        parse_observation_row(record)
+
+
+def test_parse_game_result_row_accepts_valid_contract_row():
+    row = parse_game_result_row(game_result_record())
+
+    assert row.game_id == "game-1"
+    assert row.p0_engine_kind == "mcts"
+    assert row.p1_engine_kind == "minimax"
+    assert row.winner == 1
+    assert row.move_action_indices == (0, 17, 2)
+
+
+def test_parse_game_result_row_rejects_ply_mismatch():
+    record = game_result_record()
+    record["plies"] = 2
+
+    with pytest.raises(ValueError, match="plies must match"):
+        parse_game_result_row(record)
+
+
+def test_parse_model_checkpoint_manifest_accepts_valid_manifest():
+    manifest = parse_model_checkpoint_manifest(model_manifest_record())
+
+    assert manifest.model_id == "quantik-qnue-small"
+    assert manifest.input_contracts == ("bitboard.v1", "action-index.v1")
+    assert manifest.size_bytes == 42
+
+
+def test_parse_model_checkpoint_manifest_rejects_empty_input_contracts():
+    record = model_manifest_record()
+    record["input_contracts"] = []
+
+    with pytest.raises(ValueError, match="input_contracts must be a non-empty list"):
+        parse_model_checkpoint_manifest(record)
+
+
+def test_jsonl_loaders_report_line_numbers(tmp_path):
+    observations = tmp_path / "observations.jsonl"
+    observations.write_text(json.dumps(observation_record()) + "\n", encoding="utf-8")
+    assert len(load_observations_jsonl(observations)) == 1
+
+    games = tmp_path / "games.jsonl"
+    bad_game = game_result_record()
+    bad_game["winner"] = 3
+    games.write_text(json.dumps(bad_game) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid game-result row on line 1"):
+        load_game_results_jsonl(games)
+
+
+def test_load_model_checkpoint_manifest(tmp_path):
+    path = tmp_path / "model.json"
+    path.write_text(json.dumps(model_manifest_record()), encoding="utf-8")
+
+    assert load_model_checkpoint_manifest(path).weights_format == "safetensors"

--- a/tests/test_ml_data.py
+++ b/tests/test_ml_data.py
@@ -40,6 +40,10 @@ def test_supported_contracts_are_declared():
     assert SUPPORTED_CONTRACTS["contracts_release"] == "1.0.0"
     assert SUPPORTED_CONTRACTS["selfplay"] == "selfplay.v1"
     assert SUPPORTED_CONTRACTS["action_index"] == "action-index.v1"
+    assert SUPPORTED_CONTRACTS["opening_book"] == "opening-book.v1"
+    assert SUPPORTED_CONTRACTS["observation"] == "observation.v1"
+    assert SUPPORTED_CONTRACTS["game_result"] == "game-result.v1"
+    assert SUPPORTED_CONTRACTS["model_checkpoint"] == "model-checkpoint.v1"
 
 
 def test_qfen_to_tensor_channel_layout():


### PR DESCRIPTION
## Summary
- register the opening knowledge contract IDs in SUPPORTED_CONTRACTS
- add strict JSON/JSONL readers for observation.v1 and game-result.v1 rows
- add model-checkpoint.v1 manifest parsing for later engine import work

## Dependency
- Conceptually follows mberlanda/quantik-core-contracts#3 for schema semantics.
- Intended to consume rows exported by mberlanda/quantik-core-rust#21.

## Verification
- pytest tests/test_artifact_data.py tests/test_ml_data.py -q --no-cov
- mypy src/quantik_core/artifact_data.py src/quantik_core/contracts.py
- black --check --diff on touched files
- flake8 critical/full warning pass on touched files
- ./dev-check.sh passed outside sandbox after local multiprocessing socket bind was blocked inside sandbox