### PR TITLE
Implement model-checkpoint.v1 parser for Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,6 +244,7 @@ data/
 *.csv
 *.json
 !tuning/weights.json
+!tests/fixtures/model-checkpoint-v1.json
 !benchmarks/depth4-canonical/
 !benchmarks/depth4-canonical/*.json
 *.pkl

--- a/src/quantik_core/artifact_data.py
+++ b/src/quantik_core/artifact_data.py
@@ -23,6 +23,12 @@ ACTION_COUNT = 64
 OBSERVATION_SCHEMA = SUPPORTED_CONTRACTS["observation"]
 GAME_RESULT_SCHEMA = SUPPORTED_CONTRACTS["game_result"]
 MODEL_CHECKPOINT_SCHEMA = SUPPORTED_CONTRACTS["model_checkpoint"]
+_SUPPORTED_WEIGHTS_FORMATS = frozenset(("safetensors", "onnx", "npz", "custom-binary"))
+_SUPPORTED_INPUT_CONTRACTS = frozenset(
+    contract
+    for key, contract in SUPPORTED_CONTRACTS.items()
+    if key not in ("contracts_release", "model_checkpoint")
+)
 
 
 @dataclass(frozen=True)
@@ -64,8 +70,11 @@ class GameResultRow:
 class ModelCheckpointManifest:
     """Metadata for one `model-checkpoint.v1` artifact."""
 
+    schema: str
+    contract_version: str
     model_id: str
     model_family: str
+    created_at: str
     input_contracts: tuple[str, ...]
     output_contract: str
     weights_format: str
@@ -73,6 +82,13 @@ class ModelCheckpointManifest:
     size_bytes: int
     training_data_manifest: str
     calibration_report: str
+    feature_hash: str | None = None
+    quantization: str | None = None
+    parameter_count: int | None = None
+    architecture: str | None = None
+    legal_action_mask_required: bool | None = None
+    recommended_engine_order: tuple[str, ...] | None = None
+    notes: str | None = None
 
 
 def _expect_int(record: Mapping[str, Any], key: str) -> int:
@@ -84,9 +100,51 @@ def _expect_int(record: Mapping[str, Any], key: str) -> int:
 
 def _expect_str(record: Mapping[str, Any], key: str) -> str:
     value = record.get(key)
-    if not isinstance(value, str) or not value:
+    if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{key} must be a non-empty string")
     return value
+
+
+def _expect_optional_str(record: Mapping[str, Any], key: str) -> str | None:
+    if key not in record or record.get(key) is None:
+        return None
+    return _expect_str(record, key)
+
+
+def _expect_optional_positive_int(record: Mapping[str, Any], key: str) -> int | None:
+    if key not in record or record.get(key) is None:
+        return None
+    value = _expect_int(record, key)
+    if value <= 0:
+        raise ValueError(f"{key} must be positive")
+    return value
+
+
+def _expect_optional_bool(record: Mapping[str, Any], key: str) -> bool | None:
+    if key not in record or record.get(key) is None:
+        return None
+    value = record.get(key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a boolean")
+    return value
+
+
+def _expect_optional_str_tuple(
+    record: Mapping[str, Any], key: str
+) -> tuple[str, ...] | None:
+    if key not in record or record.get(key) is None:
+        return None
+    value = record.get(key)
+    if not isinstance(value, list):
+        raise ValueError(f"{key} must be a list")
+    items: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{key}[{index}] must be a non-empty string")
+        items.append(item)
+    if not items:
+        raise ValueError(f"{key} must be non-empty when present")
+    return tuple(items)
 
 
 def _expect_number(record: Mapping[str, Any], key: str) -> float:
@@ -255,27 +313,44 @@ def parse_model_checkpoint_manifest(
     input_contracts_value = record.get("input_contracts")
     if not isinstance(input_contracts_value, list) or not input_contracts_value:
         raise ValueError("input_contracts must be a non-empty list")
-    input_contracts = tuple(
-        contract
-        for contract in input_contracts_value
-        if isinstance(contract, str) and contract
-    )
-    if len(input_contracts) != len(input_contracts_value):
-        raise ValueError("input_contracts must contain only non-empty strings")
+    input_contracts: list[str] = []
+    for index, contract in enumerate(input_contracts_value):
+        if not isinstance(contract, str) or not contract.strip():
+            raise ValueError(f"input_contracts[{index}] must be a non-empty string")
+        if contract not in _SUPPORTED_INPUT_CONTRACTS:
+            raise ValueError(f"unsupported input contract: {contract}")
+        input_contracts.append(contract)
     size_bytes = _expect_int(record, "size_bytes")
     if size_bytes <= 0:
         raise ValueError("size_bytes must be positive")
+    weights_format = _expect_str(record, "weights_format")
+    if weights_format not in _SUPPORTED_WEIGHTS_FORMATS:
+        raise ValueError(f"unsupported weights_format: {weights_format}")
 
     return ModelCheckpointManifest(
+        schema=MODEL_CHECKPOINT_SCHEMA,
+        contract_version=SUPPORTED_CONTRACTS_RELEASE,
         model_id=_expect_str(record, "model_id"),
         model_family=_expect_str(record, "model_family"),
-        input_contracts=input_contracts,
+        created_at=_expect_str(record, "created_at"),
+        input_contracts=tuple(input_contracts),
         output_contract=_expect_str(record, "output_contract"),
-        weights_format=_expect_str(record, "weights_format"),
+        weights_format=weights_format,
         weights_hash=_expect_str(record, "weights_hash"),
         size_bytes=size_bytes,
         training_data_manifest=_expect_str(record, "training_data_manifest"),
         calibration_report=_expect_str(record, "calibration_report"),
+        feature_hash=_expect_optional_str(record, "feature_hash"),
+        quantization=_expect_optional_str(record, "quantization"),
+        parameter_count=_expect_optional_positive_int(record, "parameter_count"),
+        architecture=_expect_optional_str(record, "architecture"),
+        legal_action_mask_required=_expect_optional_bool(
+            record, "legal_action_mask_required"
+        ),
+        recommended_engine_order=_expect_optional_str_tuple(
+            record, "recommended_engine_order"
+        ),
+        notes=_expect_optional_str(record, "notes"),
     )
 
 

--- a/src/quantik_core/artifact_data.py
+++ b/src/quantik_core/artifact_data.py
@@ -328,8 +328,8 @@ def parse_model_checkpoint_manifest(
         raise ValueError(f"unsupported weights_format: {weights_format}")
 
     return ModelCheckpointManifest(
-        schema=MODEL_CHECKPOINT_SCHEMA,
-        contract_version=SUPPORTED_CONTRACTS_RELEASE,
+        schema=_expect_str(record, "schema"),
+        contract_version=_expect_str(record, "contract_version"),
         model_id=_expect_str(record, "model_id"),
         model_family=_expect_str(record, "model_family"),
         created_at=_expect_str(record, "created_at"),

--- a/src/quantik_core/contracts.py
+++ b/src/quantik_core/contracts.py
@@ -9,6 +9,7 @@ SUPPORTED_CONTRACTS = {
     "action_index": "action-index.v1",
     "selfplay": "selfplay.v1",
     "tensor_board": "tensor-board.v1",
+    "arrow_parquet_selfplay": "arrow-parquet-selfplay.v1",
     "opening_book": "opening-book.v1",
     "opening_book_summary": "opening-book-summary.v1",
     "observation": "observation.v1",

--- a/tests/fixtures/model-checkpoint-v1.json
+++ b/tests/fixtures/model-checkpoint-v1.json
@@ -1,0 +1,26 @@
+{
+  "schema": "model-checkpoint.v1",
+  "contract_version": "1.1.0",
+  "model_id": "quantik-policy-value-fixture",
+  "model_family": "policy-value",
+  "created_at": "2026-07-14T12:00:00Z",
+  "input_contracts": [
+    "observation.v1"
+  ],
+  "output_contract": "policy-value.v1",
+  "weights_format": "safetensors",
+  "weights_hash": "sha256:0123456789abcdef",
+  "size_bytes": 1024,
+  "training_data_manifest": "fixtures/training-data-manifest.json",
+  "calibration_report": "fixtures/calibration-report.json",
+  "feature_hash": "sha256:abcdef0123456789",
+  "quantization": "float32",
+  "parameter_count": 123456,
+  "architecture": "tiny-transformer",
+  "legal_action_mask_required": true,
+  "recommended_engine_order": [
+    "rust",
+    "python"
+  ],
+  "notes": "Small metadata-only fixture for model-checkpoint.v1 parser tests."
+}

--- a/tests/test_artifact_data.py
+++ b/tests/test_artifact_data.py
@@ -278,6 +278,8 @@ def test_parse_model_checkpoint_manifest_accepts_opening_book_summary_input():
 def test_load_model_checkpoint_manifest_fixture():
     manifest = load_model_checkpoint_manifest(MODEL_CHECKPOINT_FIXTURE)
 
+    assert manifest.schema == MODEL_CHECKPOINT_SCHEMA
+    assert manifest.contract_version == "1.1.0"
     assert manifest.model_id == "quantik-policy-value-fixture"
     assert manifest.input_contracts == ("observation.v1",)
     assert manifest.weights_format == "safetensors"

--- a/tests/test_artifact_data.py
+++ b/tests/test_artifact_data.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -14,6 +15,10 @@ from quantik_core.artifact_data import (
     parse_observation_row,
 )
 from quantik_core.move import generate_legal_moves_list
+
+MODEL_CHECKPOINT_FIXTURE = (
+    Path(__file__).parent / "fixtures" / "model-checkpoint-v1.json"
+)
 
 
 def observation_record():
@@ -74,6 +79,10 @@ def model_manifest_record():
         "training_data_manifest": "sha256:def",
         "calibration_report": "sha256:ghi",
     }
+
+
+def model_manifest_fixture_record():
+    return json.loads(MODEL_CHECKPOINT_FIXTURE.read_text(encoding="utf-8"))
 
 
 def test_parse_observation_row_accepts_valid_contract_row():
@@ -249,9 +258,39 @@ def test_parse_game_result_row_rejects_invalid_moves(moves, message):
 def test_parse_model_checkpoint_manifest_accepts_valid_manifest():
     manifest = parse_model_checkpoint_manifest(model_manifest_record())
 
+    assert manifest.schema == MODEL_CHECKPOINT_SCHEMA
+    assert manifest.contract_version == "1.1.0"
     assert manifest.model_id == "quantik-qnue-small"
+    assert manifest.created_at == "2026-07-14T00:00:00+0200"
     assert manifest.input_contracts == ("bitboard.v1", "action-index.v1")
     assert manifest.size_bytes == 42
+
+
+def test_parse_model_checkpoint_manifest_accepts_opening_book_summary_input():
+    record = model_manifest_record()
+    record["input_contracts"] = ["opening-book-summary.v1"]
+
+    manifest = parse_model_checkpoint_manifest(record)
+
+    assert manifest.input_contracts == ("opening-book-summary.v1",)
+
+
+def test_load_model_checkpoint_manifest_fixture():
+    manifest = load_model_checkpoint_manifest(MODEL_CHECKPOINT_FIXTURE)
+
+    assert manifest.model_id == "quantik-policy-value-fixture"
+    assert manifest.input_contracts == ("observation.v1",)
+    assert manifest.weights_format == "safetensors"
+    assert manifest.feature_hash == "sha256:abcdef0123456789"
+    assert manifest.quantization == "float32"
+    assert manifest.parameter_count == 123456
+    assert manifest.architecture == "tiny-transformer"
+    assert manifest.legal_action_mask_required is True
+    assert manifest.recommended_engine_order == ("rust", "python")
+    assert (
+        manifest.notes
+        == "Small metadata-only fixture for model-checkpoint.v1 parser tests."
+    )
 
 
 def test_parse_model_checkpoint_manifest_rejects_empty_input_contracts():
@@ -266,10 +305,38 @@ def test_parse_model_checkpoint_manifest_rejects_empty_input_contracts():
     ("field", "value", "message"),
     [
         ("schema", "other.v1", "schema must be model-checkpoint.v1"),
+        (
+            "contract_version",
+            "1.0.0",
+            "contract_version must match supported contracts release 1.1.0",
+        ),
+        ("model_id", "   ", "model_id must be a non-empty string"),
         ("input_contracts", "bitboard.v1", "input_contracts must be a non-empty list"),
-        ("input_contracts", ["bitboard.v1", ""], "input_contracts must contain"),
+        (
+            "input_contracts",
+            ["bitboard.v1", "   "],
+            r"input_contracts\[1\] must be a non-empty string",
+        ),
+        (
+            "input_contracts",
+            ["unknown.v1"],
+            "unsupported input contract: unknown.v1",
+        ),
         ("size_bytes", 0, "size_bytes must be positive"),
         ("weights_format", "", "weights_format must be a non-empty string"),
+        ("weights_format", "pickle", "unsupported weights_format: pickle"),
+        ("feature_hash", "   ", "feature_hash must be a non-empty string"),
+        ("parameter_count", 0, "parameter_count must be positive"),
+        (
+            "legal_action_mask_required",
+            "yes",
+            "legal_action_mask_required must be a boolean",
+        ),
+        (
+            "recommended_engine_order",
+            ["rust", "   "],
+            r"recommended_engine_order\[1\] must be a non-empty string",
+        ),
     ],
 )
 def test_parse_model_checkpoint_manifest_rejects_invalid_fields(field, value, message):

--- a/tests/test_artifact_data.py
+++ b/tests/test_artifact_data.py
@@ -311,6 +311,8 @@ def test_parse_model_checkpoint_manifest_rejects_empty_input_contracts():
             "contract_version must match supported contracts release 1.1.0",
         ),
         ("model_id", "   ", "model_id must be a non-empty string"),
+        ("model_family", "   ", "model_family must be a non-empty string"),
+        ("created_at", "   ", "created_at must be a non-empty string"),
         ("input_contracts", "bitboard.v1", "input_contracts must be a non-empty list"),
         (
             "input_contracts",
@@ -322,9 +324,17 @@ def test_parse_model_checkpoint_manifest_rejects_empty_input_contracts():
             ["unknown.v1"],
             "unsupported input contract: unknown.v1",
         ),
-        ("size_bytes", 0, "size_bytes must be positive"),
+        ("output_contract", "   ", "output_contract must be a non-empty string"),
         ("weights_format", "", "weights_format must be a non-empty string"),
         ("weights_format", "pickle", "unsupported weights_format: pickle"),
+        ("weights_hash", "   ", "weights_hash must be a non-empty string"),
+        ("size_bytes", 0, "size_bytes must be positive"),
+        (
+            "training_data_manifest",
+            "   ",
+            "training_data_manifest must be a non-empty string",
+        ),
+        ("calibration_report", "   ", "calibration_report must be a non-empty string"),
         ("feature_hash", "   ", "feature_hash must be a non-empty string"),
         ("parameter_count", 0, "parameter_count must be positive"),
         (

--- a/tests/test_ml_data.py
+++ b/tests/test_ml_data.py
@@ -40,6 +40,7 @@ def test_supported_contracts_are_declared():
     assert SUPPORTED_CONTRACTS["contracts_release"] == "1.1.0"
     assert SUPPORTED_CONTRACTS["selfplay"] == "selfplay.v1"
     assert SUPPORTED_CONTRACTS["action_index"] == "action-index.v1"
+    assert SUPPORTED_CONTRACTS["arrow_parquet_selfplay"] == "arrow-parquet-selfplay.v1"
     assert SUPPORTED_CONTRACTS["opening_book"] == "opening-book.v1"
     assert SUPPORTED_CONTRACTS["opening_book_summary"] == "opening-book-summary.v1"
     assert SUPPORTED_CONTRACTS["observation"] == "observation.v1"


### PR DESCRIPTION
## Summary
- harden Python model-checkpoint.v1 manifest parsing
- add optional-field validation and supported input/weights checks
- add a parity fixture and targeted tests

Contract doc: https://github.com/mberlanda/quantik-core-contracts/blob/main/docs/model-checkpoint-v1.md

## Tests
- ./auto-lint.sh
- PYTHONPATH=src .venv/bin/python -m pytest tests/test_artifact_data.py tests/test_ml_data.py tests/test_import_contracts.py -q --no-cov

## Review
Please request Copilot review against the linked contract doc above.