### PR TITLE
Cover model checkpoint opening-book input parity

### DIFF
--- a/tests/test_artifact_data.py
+++ b/tests/test_artifact_data.py
@@ -275,6 +275,15 @@ def test_parse_model_checkpoint_manifest_accepts_opening_book_summary_input():
     assert manifest.input_contracts == ("opening-book-summary.v1",)
 
 
+def test_parse_model_checkpoint_manifest_accepts_opening_book_input():
+    record = model_manifest_record()
+    record["input_contracts"] = ["opening-book.v1"]
+
+    manifest = parse_model_checkpoint_manifest(record)
+
+    assert manifest.input_contracts == ("opening-book.v1",)
+
+
 def test_load_model_checkpoint_manifest_fixture():
     manifest = load_model_checkpoint_manifest(MODEL_CHECKPOINT_FIXTURE)
 


### PR DESCRIPTION
## Summary
- add Python coverage that model-checkpoint.v1 accepts opening-book.v1 as an input contract
- keeps Python parity with the Rust model-checkpoint parser coverage

Contract doc:
- https://github.com/mberlanda/quantik-core-contracts/blob/main/docs/model-checkpoint-v1.md

## Validation
- .venv/bin/python -m pytest tests/test_artifact_data.py tests/test_ml_data.py tests/test_import_contracts.py -q --no-cov