### PR TITLE
Add self-play dense storage parity in Python

### DIFF
--- a/docs/API_PORTABILITY.md
+++ b/docs/API_PORTABILITY.md
@@ -6,7 +6,7 @@ owns high-throughput search, self-play generation, and other compute-heavy
 loops. Both packages must agree on the canonical contracts from
 `mberlanda/quantik-core-contracts`.
 
-Python currently declares support for contracts release `1.0.0` via
+Python currently declares support for contracts release `1.1.0` via
 `quantik_core.SUPPORTED_CONTRACTS_RELEASE`.
 
 ## Stable Shared Model
@@ -31,7 +31,7 @@ Rust self-play export rows are one JSON object per line:
 ```json
 {
   "schema": "selfplay.v1",
-  "contract_version": "1.0.0",
+  "contract_version": "1.1.0",
   "game_id": 0,
   "ply": 0,
   "qfen": "..../..../..../....",
@@ -47,12 +47,20 @@ Rust self-play export rows are one JSON object per line:
 Python validates that:
 
 - `schema` is `selfplay.v1`.
-- `contract_version`, when present, is `1.0.0`.
+- `contract_version`, when present, is `1.1.0`.
 - `qfen` parses and `side_to_move` matches the current player implied by the bitboards.
 - each policy entry is a legal move for the row state.
 - each policy entry has `shape` in `0..3`, `position` in `0..15`, and positive integer `visits`.
 - `policy` is non-empty and normalizes to a probability distribution over 64 action slots.
 - `value` is exactly `+1.0` or `-1.0`; `0.0` is rejected.
+
+## Arrow/Parquet Self-Play Shape
+
+Bulk self-play storage uses `arrow-parquet-selfplay.v1` as the physical
+contract while preserving `selfplay.v1` row semantics. Python exposes
+`selfplay_row_to_arrow_parquet_record()` to materialize the physical columns:
+`logical_schema`, `contract_version`, `game_id`, `ply`, `side_to_move`,
+`bitboards`, dense `policy_visits[64]`, integer `value`, and optional `qfen`.
 
 ## Tensor Encoding
 
@@ -72,13 +80,13 @@ Rows and columns match the QFEN position order: `row = position // 4`,
 exporter schema. Rust should be able to emit rows with the same field names and
 semantics; Python must keep parsing and validating this file in CI. The
 dedicated `Contracts` workflow also validates the fixture through
-`mberlanda/quantik-core-contracts/actions/validate-contracts@v1.0.0`.
+`mberlanda/quantik-core-contracts/actions/validate-contracts@v1.1.0`.
 
 ## Next Steps
 
-1. Rust: expose `MCTSEngine::root_move_visits()` and emit self-play JSONL rows using the schema above.
-2. Python: keep `quantik_core.ml_data` as the reference reader and tensor/policy encoder.
-3. Contracts: validate fixtures through `mberlanda/quantik-core-contracts/actions/validate-contracts@v1.0.0`.
+1. Rust: keep `MCTSEngine::root_move_visits()` exports routed through the `selfplay.v1` contract builder.
+2. Python: keep `quantik_core.ml_data` as the reference reader, tensor/policy encoder, and dense storage-record converter.
+3. Contracts: validate fixtures through `mberlanda/quantik-core-contracts/actions/validate-contracts@v1.1.0`.
 4. Cross-repo: add a Rust-generated smoke artifact to CI or release evidence, then point Python tests at the generated artifact in addition to the checked-in fixture.
 5. ML: build the PyTorch dataset and policy/value model on top of `SelfPlayRow`, `qfen_to_tensor`, and `policy_visits_to_distribution`.
 6. Evaluation: register the trained model in the existing cross-engine benchmark harness instead of creating a separate ladder.

--- a/src/quantik_core/ml_data.py
+++ b/src/quantik_core/ml_data.py
@@ -93,6 +93,7 @@ def _parse_policy(policy: Any) -> tuple[PolicyVisit, ...]:
         raise ValueError("policy must be a non-empty list")
 
     visits: list[PolicyVisit] = []
+    seen_actions: set[tuple[int, int]] = set()
     for index, item in enumerate(policy):
         if not isinstance(item, dict):
             raise ValueError(f"policy[{index}] must be an object")
@@ -105,6 +106,12 @@ def _parse_policy(policy: Any) -> tuple[PolicyVisit, ...]:
             raise ValueError(f"policy[{index}].position must be in 0..15")
         if visit_count <= 0:
             raise ValueError(f"policy[{index}].visits must be positive")
+        action = (shape, position)
+        if action in seen_actions:
+            raise ValueError(
+                f"policy[{index}] duplicates shape={shape}, position={position}"
+            )
+        seen_actions.add(action)
         visits.append(PolicyVisit(shape=shape, position=position, visits=visit_count))
     return tuple(visits)
 
@@ -209,14 +216,43 @@ def policy_visits_to_distribution(
     policy: Iterable[PolicyVisit],
 ) -> npt.NDArray[np.float32]:
     """Normalize policy visit counts into the shared 64-slot action vector."""
-    distribution = np.zeros(ACTION_COUNT, dtype=np.float32)
-    total_visits = 0
+    dense = policy_visits_to_dense(policy)
+    total_visits = sum(dense)
+    if total_visits <= 0:
+        raise ValueError("policy must contain at least one visit")
+    distribution = np.asarray(dense, dtype=np.float32)
+    distribution /= float(total_visits)
+    return distribution
+
+
+def policy_visits_to_dense(policy: Iterable[PolicyVisit]) -> tuple[int, ...]:
+    """Materialize policy visits as the Arrow/Parquet 64-slot action vector."""
+    dense = [0] * ACTION_COUNT
+    saw_visit = False
     for visit in policy:
         if visit.visits <= 0:
             raise ValueError("policy visits must be positive")
-        distribution[visit.action_index] += visit.visits
-        total_visits += visit.visits
-    if total_visits <= 0:
+        dense[visit.action_index] += visit.visits
+        saw_visit = True
+    if not saw_visit:
         raise ValueError("policy must contain at least one visit")
-    distribution /= float(total_visits)
-    return distribution
+    return tuple(dense)
+
+
+def selfplay_row_to_arrow_parquet_record(row: SelfPlayRow) -> dict[str, Any]:
+    """Convert a logical `selfplay.v1` row to the physical bulk-storage shape."""
+    if row.ply > 65535:
+        raise ValueError("ply must fit in uint16 for arrow-parquet-selfplay.v1")
+    if row.value not in (-1.0, 1.0):
+        raise ValueError("value must be exactly -1.0 or 1.0")
+    return {
+        "logical_schema": SELFPLAY_SCHEMA,
+        "contract_version": SUPPORTED_CONTRACTS_RELEASE,
+        "game_id": row.game_id,
+        "ply": row.ply,
+        "side_to_move": row.side_to_move,
+        "bitboards": bb_from_qfen(row.qfen, validate=True),
+        "policy_visits": policy_visits_to_dense(row.policy),
+        "value": int(row.value),
+        "qfen": row.qfen,
+    }

--- a/src/quantik_core/ml_data.py
+++ b/src/quantik_core/ml_data.py
@@ -218,8 +218,6 @@ def policy_visits_to_distribution(
     """Normalize policy visit counts into the shared 64-slot action vector."""
     dense = policy_visits_to_dense(policy)
     total_visits = sum(dense)
-    if total_visits <= 0:
-        raise ValueError("policy must contain at least one visit")
     distribution = np.asarray(dense, dtype=np.float32)
     distribution /= float(total_visits)
     return distribution

--- a/tests/test_ml_data.py
+++ b/tests/test_ml_data.py
@@ -9,8 +9,10 @@ from quantik_core.ml_data import (
     PolicyVisit,
     load_selfplay_jsonl,
     parse_selfplay_row,
+    policy_visits_to_dense,
     policy_visits_to_distribution,
     qfen_to_tensor,
+    selfplay_row_to_arrow_parquet_record,
 )
 
 FIXTURE = Path(__file__).parent / "fixtures" / "selfplay_v1.jsonl"
@@ -70,6 +72,47 @@ def test_policy_visits_to_distribution_uses_shape_major_action_index():
     assert distribution.sum() == pytest.approx(1.0)
 
 
+def test_policy_visits_to_dense_uses_arrow_parquet_physical_layout():
+    dense = policy_visits_to_dense(
+        [PolicyVisit(shape=0, position=0, visits=3), PolicyVisit(1, 5, 1)]
+    )
+
+    assert len(dense) == 64
+    assert dense[0] == 3
+    assert dense[21] == 1
+    assert sum(dense) == 4
+
+
+def test_selfplay_row_to_arrow_parquet_record_keeps_contract_metadata():
+    row = parse_selfplay_row(_fixture_record())
+
+    record = selfplay_row_to_arrow_parquet_record(row)
+
+    assert record["logical_schema"] == "selfplay.v1"
+    assert record["contract_version"] == SUPPORTED_CONTRACTS_RELEASE
+    assert record["game_id"] == row.game_id
+    assert record["bitboards"] == (0, 0, 0, 0, 0, 0, 0, 0)
+    assert record["policy_visits"][0] == 3
+    assert record["policy_visits"][21] == 1
+    assert record["value"] == 1
+    assert "policy" not in record
+
+
+def test_selfplay_row_to_arrow_parquet_record_rejects_ply_outside_uint16():
+    row = parse_selfplay_row(_fixture_record())
+    row = type(row)(
+        game_id=row.game_id,
+        ply=65536,
+        qfen=row.qfen,
+        side_to_move=row.side_to_move,
+        policy=row.policy,
+        value=row.value,
+    )
+
+    with pytest.raises(ValueError, match="ply must fit in uint16"):
+        selfplay_row_to_arrow_parquet_record(row)
+
+
 @pytest.mark.parametrize(
     ("field", "value", "message"),
     [
@@ -105,6 +148,13 @@ def test_parse_selfplay_row_rejects_non_string_qfen():
         ([{"shape": 4, "position": 0, "visits": 1}], r"policy\[0\].shape"),
         ([{"shape": 0, "position": 16, "visits": 1}], r"policy\[0\].position"),
         ([{"shape": 0, "position": 0, "visits": 0}], r"policy\[0\].visits"),
+        (
+            [
+                {"shape": 0, "position": 0, "visits": 1},
+                {"shape": 0, "position": 0, "visits": 2},
+            ],
+            r"policy\[1\] duplicates shape=0, position=0",
+        ),
     ],
 )
 def test_parse_selfplay_row_rejects_invalid_policy_shapes(policy, message):
@@ -201,3 +251,8 @@ def test_policy_visits_to_distribution_rejects_non_positive_visits():
 def test_policy_visits_to_distribution_rejects_empty_policy():
     with pytest.raises(ValueError, match="policy must contain at least one visit"):
         policy_visits_to_distribution([])
+
+
+def test_policy_visits_to_dense_rejects_empty_policy():
+    with pytest.raises(ValueError, match="policy must contain at least one visit"):
+        policy_visits_to_dense([])

--- a/tests/test_ml_data.py
+++ b/tests/test_ml_data.py
@@ -113,6 +113,21 @@ def test_selfplay_row_to_arrow_parquet_record_rejects_ply_outside_uint16():
         selfplay_row_to_arrow_parquet_record(row)
 
 
+def test_selfplay_row_to_arrow_parquet_record_rejects_non_decisive_value():
+    row = parse_selfplay_row(_fixture_record())
+    row = type(row)(
+        game_id=row.game_id,
+        ply=row.ply,
+        qfen=row.qfen,
+        side_to_move=row.side_to_move,
+        policy=row.policy,
+        value=0.0,
+    )
+
+    with pytest.raises(ValueError, match="value must be exactly"):
+        selfplay_row_to_arrow_parquet_record(row)
+
+
 @pytest.mark.parametrize(
     ("field", "value", "message"),
     [


### PR DESCRIPTION
## Summary
- reject duplicate self-play policy actions during JSONL parsing
- add dense policy_visits[64] conversion and arrow-parquet-selfplay.v1 physical record projection
- update API portability docs to contracts release 1.1.0 and the dense storage shape

Contract docs: https://github.com/mberlanda/quantik-core-contracts/blob/main/docs/selfplay-v1.md and https://github.com/mberlanda/quantik-core-contracts/blob/main/docs/storage-representations.md

## Validation
- ./auto-lint.sh
- ./dev-check.sh
- .venv/bin/python -m pytest --no-cov tests/test_ml_data.py
- git diff --check