### PR TITLE
Implement self-play Parquet I/O in Python

### DIFF
--- a/docs/API_PORTABILITY.md
+++ b/docs/API_PORTABILITY.md
@@ -62,6 +62,12 @@ contract while preserving `selfplay.v1` row semantics. Python exposes
 `logical_schema`, `contract_version`, `game_id`, `ply`, `side_to_move`,
 `bitboards`, dense `policy_visits[64]`, integer `value`, and optional `qfen`.
 
+Install `quantik-core[arrow]` to enable real Parquet I/O through
+`write_selfplay_parquet()` and `load_selfplay_parquet()`. Writers attach
+Parquet key/value metadata for `physical_schema`, `logical_schema`,
+`logical_contract`, `contracts_release`, and `contract_version`; readers reject
+files whose metadata or physical Arrow schema drift from the contract.
+
 ## Tensor Encoding
 
 `quantik_core.ml_data.qfen_to_tensor(qfen, side_to_move)` returns a NumPy array

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ dev = [
 cbor = [
     "cbor2>=6,<7",
 ]
+arrow = [
+    "pyarrow>=16,<22",
+]
 docs = [
     "sphinx>=5.0",
     "sphinx-rtd-theme>=1.0",
@@ -58,7 +61,7 @@ benchmark = [
     "pytest-benchmark>=4.0",
 ]
 all = [
-    "quantik-core[dev,cbor,docs,benchmark]",
+    "quantik-core[dev,cbor,arrow,docs,benchmark]",
 ]
 
 [project.urls]

--- a/src/quantik_core/ml_data.py
+++ b/src/quantik_core/ml_data.py
@@ -8,9 +8,10 @@ training code.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import importlib
 import json
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -18,7 +19,7 @@ import numpy.typing as npt
 from .commons import Bitboard
 from .contracts import SUPPORTED_CONTRACTS, SUPPORTED_CONTRACTS_RELEASE
 from .move import generate_legal_moves_list
-from .qfen import bb_from_qfen
+from .qfen import bb_from_qfen, bb_to_qfen
 from .state_validator import ValidationResult, validate_game_state
 
 ACTION_COUNT = 64
@@ -27,6 +28,14 @@ PLAYER_SHAPE_CHANNELS = 8
 SIDE_TO_MOVE_CHANNEL = 8
 TENSOR_CHANNELS = 9
 SELFPLAY_SCHEMA = SUPPORTED_CONTRACTS["selfplay"]
+ARROW_PARQUET_SELFPLAY_SCHEMA = SUPPORTED_CONTRACTS["arrow_parquet_selfplay"]
+SELFPLAY_PARQUET_METADATA = {
+    b"physical_schema": ARROW_PARQUET_SELFPLAY_SCHEMA.encode("utf-8"),
+    b"logical_schema": SELFPLAY_SCHEMA.encode("utf-8"),
+    b"logical_contract": SELFPLAY_SCHEMA.encode("utf-8"),
+    b"contracts_release": SUPPORTED_CONTRACTS_RELEASE.encode("utf-8"),
+    b"contract_version": SUPPORTED_CONTRACTS_RELEASE.encode("utf-8"),
+}
 
 
 @dataclass(frozen=True)
@@ -237,8 +246,35 @@ def policy_visits_to_dense(policy: Iterable[PolicyVisit]) -> tuple[int, ...]:
     return tuple(dense)
 
 
+def _selfplay_row_to_logical_record(row: SelfPlayRow) -> dict[str, Any]:
+    return {
+        "schema": SELFPLAY_SCHEMA,
+        "contract_version": SUPPORTED_CONTRACTS_RELEASE,
+        "game_id": row.game_id,
+        "ply": row.ply,
+        "qfen": row.qfen,
+        "side_to_move": row.side_to_move,
+        "policy": [
+            {
+                "shape": visit.shape,
+                "position": visit.position,
+                "visits": visit.visits,
+            }
+            for visit in row.policy
+        ],
+        "value": row.value,
+    }
+
+
+def _coerce_selfplay_row(row: SelfPlayRow | Mapping[str, Any]) -> SelfPlayRow:
+    if isinstance(row, SelfPlayRow):
+        return parse_selfplay_row(_selfplay_row_to_logical_record(row))
+    return parse_selfplay_row(row)
+
+
 def selfplay_row_to_arrow_parquet_record(row: SelfPlayRow) -> dict[str, Any]:
     """Convert a logical `selfplay.v1` row to the physical bulk-storage shape."""
+    row = _coerce_selfplay_row(row)
     if row.ply > 65535:
         raise ValueError("ply must fit in uint16 for arrow-parquet-selfplay.v1")
     if row.value not in (-1.0, 1.0):
@@ -254,3 +290,151 @@ def selfplay_row_to_arrow_parquet_record(row: SelfPlayRow) -> dict[str, Any]:
         "value": int(row.value),
         "qfen": row.qfen,
     }
+
+
+def _require_pyarrow() -> tuple[Any, Any]:
+    try:
+        pa = importlib.import_module("pyarrow")
+        pq = importlib.import_module("pyarrow.parquet")
+    except ImportError as exc:
+        raise ImportError(
+            "pyarrow is required for self-play Parquet I/O; install "
+            "quantik-core[arrow]"
+        ) from exc
+    return pa, pq
+
+
+def _selfplay_parquet_schema(pa: Any) -> Any:
+    return pa.schema(
+        [
+            pa.field("logical_schema", pa.string(), nullable=False),
+            pa.field("contract_version", pa.string(), nullable=False),
+            pa.field("game_id", pa.uint64(), nullable=False),
+            pa.field("ply", pa.uint16(), nullable=False),
+            pa.field("side_to_move", pa.uint8(), nullable=False),
+            pa.field(
+                "bitboards",
+                pa.list_(pa.uint16(), list_size=PLAYER_SHAPE_CHANNELS),
+                nullable=False,
+            ),
+            pa.field(
+                "policy_visits",
+                pa.list_(pa.uint32(), list_size=ACTION_COUNT),
+                nullable=False,
+            ),
+            pa.field("value", pa.int8(), nullable=False),
+            pa.field("qfen", pa.string(), nullable=True),
+        ],
+        metadata=SELFPLAY_PARQUET_METADATA,
+    )
+
+
+def write_selfplay_parquet(
+    rows: Iterable[SelfPlayRow | Mapping[str, Any]], path: str | Path
+) -> None:
+    """Write logical `selfplay.v1` rows to physical Parquet storage.
+
+    The file is tagged with `arrow-parquet-selfplay.v1` metadata while rows keep
+    `selfplay.v1` semantics through the dense physical columns.
+    """
+    pa, pq = _require_pyarrow()
+    schema = _selfplay_parquet_schema(pa)
+    records = [
+        selfplay_row_to_arrow_parquet_record(_coerce_selfplay_row(row)) for row in rows
+    ]
+    table = pa.Table.from_pylist(records, schema=schema)
+    pq.write_table(table, Path(path))
+
+
+def _validate_selfplay_parquet_metadata(metadata: Mapping[bytes, bytes] | None) -> None:
+    metadata = metadata or {}
+    labels = {
+        b"physical_schema": "physical schema",
+        b"logical_schema": "logical schema",
+        b"logical_contract": "logical contract",
+        b"contracts_release": "contracts release",
+        b"contract_version": "contract version",
+    }
+    for key, expected in SELFPLAY_PARQUET_METADATA.items():
+        if metadata.get(key) != expected:
+            raise ValueError(
+                f"{labels[key]} metadata must be {expected.decode('utf-8')}"
+            )
+
+
+def _expect_fixed_int_vector(
+    record: Mapping[str, Any], key: str, length: int
+) -> tuple[int, ...]:
+    value = record.get(key)
+    if not isinstance(value, list) or len(value) != length:
+        raise ValueError(f"{key} must contain exactly {length} integers")
+    items: list[int] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, int) or isinstance(item, bool):
+            raise ValueError(f"{key}[{index}] must be an integer")
+        items.append(item)
+    return tuple(items)
+
+
+def _sparse_policy_from_dense(policy_visits: Sequence[int]) -> list[dict[str, int]]:
+    policy: list[dict[str, int]] = []
+    for action_index, visits in enumerate(policy_visits):
+        if visits < 0:
+            raise ValueError(f"policy_visits[{action_index}] must be non-negative")
+        if visits == 0:
+            continue
+        shape, position = divmod(action_index, BOARD_SIZE * BOARD_SIZE)
+        policy.append({"shape": shape, "position": position, "visits": visits})
+    if not policy:
+        raise ValueError("policy must contain at least one visit")
+    return policy
+
+
+def _logical_record_from_parquet_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    bitboards = cast(
+        Bitboard,
+        _expect_fixed_int_vector(record, "bitboards", PLAYER_SHAPE_CHANNELS),
+    )
+    policy_visits = _expect_fixed_int_vector(record, "policy_visits", ACTION_COUNT)
+
+    qfen = record.get("qfen")
+    if qfen is None:
+        qfen = bb_to_qfen(bitboards)
+    elif not isinstance(qfen, str):
+        raise ValueError("qfen must be a string when present")
+    if bb_from_qfen(qfen, validate=True) != bitboards:
+        raise ValueError("bitboards do not match qfen")
+    value = record.get("value")
+    if value not in (-1, 1):
+        raise ValueError("value must be exactly -1 or 1")
+
+    return {
+        "schema": record.get("logical_schema"),
+        "contract_version": record.get("contract_version"),
+        "game_id": record.get("game_id"),
+        "ply": record.get("ply"),
+        "qfen": qfen,
+        "side_to_move": record.get("side_to_move"),
+        "policy": _sparse_policy_from_dense(policy_visits),
+        "value": float(value),
+    }
+
+
+def load_selfplay_parquet(path: str | Path) -> list[SelfPlayRow]:
+    """Load physical Parquet storage and validate as logical `selfplay.v1` rows."""
+    pa, pq = _require_pyarrow()
+    table = pq.read_table(Path(path))
+    schema = _selfplay_parquet_schema(pa)
+    _validate_selfplay_parquet_metadata(table.schema.metadata)
+    if table.schema.remove_metadata() != schema.remove_metadata():
+        raise ValueError("arrow-parquet-selfplay.v1 schema must match the contract")
+
+    rows: list[SelfPlayRow] = []
+    for row_number, record in enumerate(table.to_pylist(), start=1):
+        try:
+            rows.append(parse_selfplay_row(_logical_record_from_parquet_record(record)))
+        except ValueError as exc:
+            raise ValueError(
+                f"invalid self-play parquet row {row_number}: {exc}"
+            ) from exc
+    return rows

--- a/tests/test_ml_data.py
+++ b/tests/test_ml_data.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import sys
 
 import numpy as np
 import pytest
@@ -7,12 +8,14 @@ import pytest
 from quantik_core import SUPPORTED_CONTRACTS, SUPPORTED_CONTRACTS_RELEASE
 from quantik_core.ml_data import (
     PolicyVisit,
+    load_selfplay_parquet,
     load_selfplay_jsonl,
     parse_selfplay_row,
     policy_visits_to_dense,
     policy_visits_to_distribution,
     qfen_to_tensor,
     selfplay_row_to_arrow_parquet_record,
+    write_selfplay_parquet,
 )
 
 FIXTURE = Path(__file__).parent / "fixtures" / "selfplay_v1.jsonl"
@@ -126,6 +129,80 @@ def test_selfplay_row_to_arrow_parquet_record_rejects_non_decisive_value():
 
     with pytest.raises(ValueError, match="value must be exactly"):
         selfplay_row_to_arrow_parquet_record(row)
+
+
+def test_selfplay_parquet_helpers_report_missing_pyarrow(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, "pyarrow", None)
+    row = parse_selfplay_row(_fixture_record())
+
+    with pytest.raises(ImportError, match=r"quantik-core\[arrow\]"):
+        write_selfplay_parquet([row], tmp_path / "rows.parquet")
+
+    with pytest.raises(ImportError, match=r"quantik-core\[arrow\]"):
+        load_selfplay_parquet(tmp_path / "rows.parquet")
+
+
+def test_selfplay_parquet_roundtrips_rows_and_metadata(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    path = tmp_path / "rows.parquet"
+    rows = load_selfplay_jsonl(FIXTURE)
+
+    write_selfplay_parquet(rows, path)
+
+    loaded = load_selfplay_parquet(path)
+    table = pq.read_table(path)
+    metadata = table.schema.metadata or {}
+
+    assert loaded == rows
+    assert metadata[b"physical_schema"] == b"arrow-parquet-selfplay.v1"
+    assert metadata[b"logical_schema"] == b"selfplay.v1"
+    assert metadata[b"logical_contract"] == b"selfplay.v1"
+    assert metadata[b"contracts_release"] == SUPPORTED_CONTRACTS_RELEASE.encode("utf-8")
+    assert metadata[b"contract_version"] == SUPPORTED_CONTRACTS_RELEASE.encode("utf-8")
+    assert table.schema.field("bitboards").type == pa.list_(pa.uint16(), list_size=8)
+    assert table.schema.field("policy_visits").type == pa.list_(
+        pa.uint32(), list_size=64
+    )
+
+
+def test_load_selfplay_parquet_rejects_metadata_drift(tmp_path):
+    pq = pytest.importorskip("pyarrow.parquet")
+    path = tmp_path / "rows.parquet"
+    row = parse_selfplay_row(_fixture_record())
+    write_selfplay_parquet([row], path)
+
+    table = pq.read_table(path)
+    drifted = table.replace_schema_metadata(
+        {
+            **(table.schema.metadata or {}),
+            b"physical_schema": b"arrow-parquet-selfplay.v2",
+        }
+    )
+    pq.write_table(drifted, path)
+
+    with pytest.raises(ValueError, match="physical schema metadata"):
+        load_selfplay_parquet(path)
+
+
+def test_load_selfplay_parquet_rejects_dense_policy_drift(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    path = tmp_path / "rows.parquet"
+    row = parse_selfplay_row(_fixture_record())
+    write_selfplay_parquet([row], path)
+
+    table = pq.read_table(path)
+    columns = []
+    for name in table.column_names:
+        if name == "policy_visits":
+            columns.append(pa.array([[0] * 64], type=pa.list_(pa.uint32(), 64)))
+        else:
+            columns.append(table[name])
+    pq.write_table(pa.Table.from_arrays(columns, schema=table.schema), path)
+
+    with pytest.raises(ValueError, match="policy must contain at least one visit"):
+        load_selfplay_parquet(path)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add optional pyarrow extra for arrow-parquet-selfplay.v1 I/O
- write/read Parquet files with contract metadata and physical schema validation
- add roundtrip and drift rejection tests

Contract docs:
- https://github.com/mberlanda/quantik-core-contracts/blob/main/docs/selfplay-v1.md
- https://github.com/mberlanda/quantik-core-contracts/blob/main/docs/storage-representations.md
- https://github.com/mberlanda/quantik-core-contracts/blob/main/schemas/arrow-parquet-selfplay-v1.json

## Validation
- ./auto-lint.sh
- .venv/bin/python -m pytest tests/test_ml_data.py -q --no-cov
- ./dev-check.sh