### PR TITLE
Consume Rust selfplay.v1 smoke fixture

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: mberlanda/quantik-core-contracts/actions/validate-contracts@v1.1.0
         with:
-          fixture-glob: "tests/fixtures/selfplay_v1.jsonl"
+          fixture-glob: "tests/fixtures/selfplay*.jsonl"
           expected-release: "1.1.0"
 
   opening-book-consistency:

--- a/docs/API_PORTABILITY.md
+++ b/docs/API_PORTABILITY.md
@@ -83,16 +83,16 @@ Rows and columns match the QFEN position order: `row = position // 4`,
 ## Conformance Fixtures
 
 `tests/fixtures/selfplay_v1.jsonl` is the Python-side golden sample for the Rust
-exporter schema. Rust should be able to emit rows with the same field names and
-semantics; Python must keep parsing and validating this file in CI. The
-dedicated `Contracts` workflow also validates the fixture through
-`mberlanda/quantik-core-contracts/actions/validate-contracts@v1.1.0`.
+exporter schema. `tests/fixtures/selfplay_v1_rust_smoke.jsonl` mirrors the
+checked-in Rust-builder smoke rows so Python keeps proving that Rust-emitted
+JSONL remains consumable. The dedicated `Contracts` workflow also validates the
+fixture through `mberlanda/quantik-core-contracts/actions/validate-contracts@v1.1.0`.
 
 ## Next Steps
 
 1. Rust: keep `MCTSEngine::root_move_visits()` exports routed through the `selfplay.v1` contract builder.
 2. Python: keep `quantik_core.ml_data` as the reference reader, tensor/policy encoder, and dense storage-record converter.
 3. Contracts: validate fixtures through `mberlanda/quantik-core-contracts/actions/validate-contracts@v1.1.0`.
-4. Cross-repo: add a Rust-generated smoke artifact to CI or release evidence, then point Python tests at the generated artifact in addition to the checked-in fixture.
+4. Cross-repo: add live producer/consumer CI wiring once release artifacts are published, using the checked-in Rust smoke fixture as the minimum evidence floor.
 5. ML: build the PyTorch dataset and policy/value model on top of `SelfPlayRow`, `qfen_to_tensor`, and `policy_visits_to_distribution`.
 6. Evaluation: register the trained model in the existing cross-engine benchmark harness instead of creating a separate ladder.

--- a/tests/fixtures/selfplay_v1_rust_smoke.jsonl
+++ b/tests/fixtures/selfplay_v1_rust_smoke.jsonl
@@ -1,0 +1,2 @@
+{"contract_version":"1.1.0","game_id":0,"ply":0,"policy":[{"position":0,"shape":0,"visits":3},{"position":5,"shape":1,"visits":1}],"qfen":"..../..../..../....","schema":"selfplay.v1","side_to_move":0,"value":1.0}
+{"contract_version":"1.1.0","game_id":0,"ply":1,"policy":[{"position":10,"shape":0,"visits":2},{"position":1,"shape":1,"visits":6}],"qfen":"A.../..../..../....","schema":"selfplay.v1","side_to_move":1,"value":-1.0}

--- a/tests/test_ml_data.py
+++ b/tests/test_ml_data.py
@@ -19,6 +19,7 @@ from quantik_core.ml_data import (
 )
 
 FIXTURE = Path(__file__).parent / "fixtures" / "selfplay_v1.jsonl"
+RUST_SMOKE_FIXTURE = Path(__file__).parent / "fixtures" / "selfplay_v1_rust_smoke.jsonl"
 
 
 def _fixture_record(index: int = 0):
@@ -37,6 +38,18 @@ def test_load_selfplay_jsonl_fixture():
     assert rows[0].policy == (
         PolicyVisit(shape=0, position=0, visits=3),
         PolicyVisit(shape=1, position=5, visits=1),
+    )
+
+
+def test_load_rust_generated_selfplay_smoke_fixture():
+    rows = load_selfplay_jsonl(RUST_SMOKE_FIXTURE)
+
+    assert len(rows) == 2
+    assert [row.ply for row in rows] == [0, 1]
+    assert [row.value for row in rows] == [1.0, -1.0]
+    assert rows[1].policy == (
+        PolicyVisit(shape=0, position=10, visits=2),
+        PolicyVisit(shape=1, position=1, visits=6),
     )
 
 


### PR DESCRIPTION
## Summary
- add Python consumer coverage for the Rust selfplay.v1 smoke fixture
- widen the contracts workflow fixture glob to validate all selfplay JSONL samples
- update API portability docs now that Rust smoke evidence exists

Contract doc: https://github.com/mberlanda/quantik-core-contracts/blob/main/docs/selfplay-v1.md

## Validation
- ./auto-lint.sh
- .venv/bin/python -m pytest tests/test_ml_data.py --no-cov
- ./dev-check.sh