### PR TITLE
Add Python API portability report CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ Documentation = "https://github.com/mberlanda/quantik-core-py#readme"
 "Bug Tracker" = "https://github.com/mberlanda/quantik-core-py/issues"
 Changelog = "https://github.com/mberlanda/quantik-core-py/blob/main/CHANGELOG.md"
 
+[project.scripts]
+quantik-api-portability-report = "quantik_core.api_portability_report:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/quantik_core/api_portability_report.py
+++ b/src/quantik_core/api_portability_report.py
@@ -1,0 +1,242 @@
+"""Produce normalized Quantik API portability reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any, Sequence, cast
+
+from .commons import FLAG_CANON, VERSION, Bitboard, PlayerId
+from .game_utils import WinStatus, check_game_winner
+from .move import Move, generate_legal_moves_list, validate_move
+from .qfen import bb_from_qfen, bb_to_qfen
+from .state_validator import validate_game_state
+from .symmetry import SymmetryHandler
+
+REPORT_SCHEMA = "api-portability-report.v1"
+FIXTURE_SCHEMA = "api-portability-fixtures.v1"
+FIXTURE_PATH = Path("fixtures/api-portability/game-state-v1.json")
+CONTRACT_KEYS = ("qfen", "bitboard", "action_index")
+
+
+def _package_version() -> str:
+    try:
+        return version("quantik-core")
+    except PackageNotFoundError:
+        return "0+editable"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected a JSON object")
+    return data
+
+
+def _contracts_release(contracts_root: Path, manifest: dict[str, Any]) -> str:
+    release = manifest.get("release_version")
+    if isinstance(release, str):
+        release = release.strip()
+    if not isinstance(release, str) or not release:
+        raise ValueError("contracts release_version must be a non-empty string")
+
+    version_path = contracts_root / "VERSION"
+    if not version_path.exists():
+        raise ValueError(f"{version_path}: VERSION file is required")
+    version_text = version_path.read_text(encoding="utf-8").strip()
+    if not version_text:
+        raise ValueError(f"{version_path}: VERSION must be non-empty")
+    if version_text != release:
+        raise ValueError(
+            f"{version_path}: VERSION {version_text!r} does not match "
+            f"contracts.json release_version {release!r}"
+        )
+    return release
+
+
+def _contract_ids(manifest: dict[str, Any]) -> dict[str, str]:
+    contracts = manifest.get("contracts")
+    if not isinstance(contracts, dict):
+        raise ValueError("contracts.json must contain a contracts object")
+
+    ids: dict[str, str] = {}
+    for key in CONTRACT_KEYS:
+        contract = contracts.get(key)
+        if not isinstance(contract, dict) or not isinstance(contract.get("id"), str):
+            raise ValueError(f"contracts.json missing contract id for {key}")
+        ids[key] = contract["id"]
+    return ids
+
+
+def _action_index(move: Move) -> int:
+    return move.shape * 16 + move.position
+
+
+def _legal_actions(bb: Bitboard) -> tuple[str, list[int]]:
+    action_indices = sorted(
+        _action_index(move) for move in generate_legal_moves_list(bb)
+    )
+    mask = 0
+    for action_index in action_indices:
+        mask |= 1 << action_index
+    return f"0x{mask:016x}", action_indices
+
+
+def _validate_fixture_metadata(
+    contracts_root: Path, fixture: dict[str, Any], contracts_release: str
+) -> None:
+    fixture_path = contracts_root / FIXTURE_PATH
+    if fixture.get("schema") != FIXTURE_SCHEMA:
+        raise ValueError(f"{fixture_path}: schema must be {FIXTURE_SCHEMA}")
+    if fixture.get("contract_version") != contracts_release:
+        raise ValueError(
+            f"{fixture_path}: contract_version must match {contracts_release}"
+        )
+
+
+def _winner_name(bb: Bitboard) -> str:
+    winner = check_game_winner(bb)
+    if winner == WinStatus.PLAYER_0_WINS:
+        return "player0"
+    if winner == WinStatus.PLAYER_1_WINS:
+        return "player1"
+    return "none"
+
+
+def _terminal_winner(
+    winner: str, side_to_move: PlayerId, legal_action_indices: list[int]
+) -> tuple[bool, str]:
+    if winner != "none":
+        return True, winner
+    if legal_action_indices:
+        return False, "none"
+    return True, "player1" if side_to_move == 0 else "player0"
+
+
+def _fixture_int(case_move: dict[str, Any], key: str, upper_bound: int) -> int:
+    value = case_move.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"move.{key} must be an integer")
+    if value < 0 or value > upper_bound:
+        raise ValueError(f"move.{key} must be between 0 and {upper_bound}")
+    return value
+
+
+def _move_report(
+    case_move: dict[str, Any], bb: Bitboard, side_to_move: PlayerId
+) -> dict[str, Any]:
+    shape = _fixture_int(case_move, "shape", 3)
+    position = _fixture_int(case_move, "position", 15)
+    move = Move(player=side_to_move, shape=shape, position=position)
+    validation = validate_move(bb, move)
+
+    report: dict[str, Any] = {
+        "shape": shape,
+        "position": position,
+        "action_index": _action_index(move),
+        "is_legal": validation.is_valid,
+    }
+    if validation.is_valid:
+        if validation.new_bb is None:
+            raise ValueError("valid move did not return a new bitboard")
+        report["after_qfen"] = bb_to_qfen(cast(Bitboard, validation.new_bb))
+    else:
+        report["after_qfen"] = None
+    return report
+
+
+def _case_report(case: dict[str, Any]) -> dict[str, Any]:
+    case_id = case.get("case_id")
+    qfen = case.get("qfen")
+    case_move = case.get("move")
+    if not isinstance(case_id, str) or not case_id:
+        raise ValueError("game_state_case.case_id must be a non-empty string")
+    if not isinstance(qfen, str):
+        raise ValueError(f"{case_id}: qfen must be a string")
+    if not isinstance(case_move, dict):
+        raise ValueError(f"{case_id}: move must be an object")
+
+    try:
+        bb = bb_from_qfen(qfen, validate=False)
+    except ValueError as exc:
+        raise ValueError(f"{case_id}: qfen parse failed: {exc}") from exc
+    normalized_qfen = bb_to_qfen(bb)
+    side_to_move, validation_result = validate_game_state(bb)
+    if side_to_move is None:
+        raise ValueError(f"{case_id}: invalid game state {validation_result.name}")
+
+    canonical_bb, _ = SymmetryHandler.find_canonical_form(bb)
+    legal_action_mask, legal_action_indices = _legal_actions(bb)
+    winner = _winner_name(bb)
+    terminal, winner = _terminal_winner(winner, side_to_move, legal_action_indices)
+    canonical_key = bytes([VERSION, FLAG_CANON]) + struct.pack("<8H", *canonical_bb)
+
+    return {
+        "case_id": case_id,
+        "qfen": normalized_qfen,
+        "bitboards": list(bb),
+        "side_to_move": side_to_move,
+        "canonical_qfen": bb_to_qfen(canonical_bb),
+        "canonical_key": canonical_key.hex(),
+        "orbit_size": SymmetryHandler.count_orbit_size(bb),
+        "legal_action_mask": legal_action_mask,
+        "legal_action_indices": legal_action_indices,
+        "terminal": terminal,
+        "winner": winner,
+        "move": _move_report(case_move, bb, side_to_move),
+    }
+
+
+def build_report(contracts_root: Path) -> dict[str, Any]:
+    manifest = _load_json(contracts_root / "contracts.json")
+    fixture = _load_json(contracts_root / FIXTURE_PATH)
+    contracts_release = _contracts_release(contracts_root, manifest)
+    _validate_fixture_metadata(contracts_root, fixture, contracts_release)
+    cases = fixture.get("game_state_cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError(
+            f"{contracts_root / FIXTURE_PATH}: game_state_cases must be a non-empty list"
+        )
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict):
+            raise ValueError(
+                f"{contracts_root / FIXTURE_PATH}: game_state_cases[{index}] "
+                "must be an object"
+            )
+
+    return {
+        "schema": REPORT_SCHEMA,
+        "contracts_release": contracts_release,
+        "implementation": {
+            "language": "python",
+            "package": "quantik-core",
+            "version": _package_version(),
+        },
+        "contract_ids": _contract_ids(manifest),
+        "cases": sorted(
+            (_case_report(case) for case in cases),
+            key=lambda item: item["case_id"],
+        ),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contracts-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    report = build_report(args.contracts_root)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        json.dump(report, handle, sort_keys=True)
+        handle.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_api_portability_report.py
+++ b/tests/test_api_portability_report.py
@@ -1,0 +1,496 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import tomllib
+
+import quantik_core.api_portability_report as apr
+from quantik_core.api_portability_report import build_report, main
+
+
+def make_contracts_root(tmp_path: Path) -> Path:
+    contracts_root = tmp_path / "contracts"
+    fixture_dir = contracts_root / "fixtures" / "api-portability"
+    fixture_dir.mkdir(parents=True)
+    (contracts_root / "VERSION").write_text("1.1.0\n", encoding="utf-8")
+    (contracts_root / "contracts.json").write_text(
+        json.dumps(
+            {
+                "release_version": "1.1.0",
+                "contracts": {
+                    "qfen": {"id": "qfen.v1"},
+                    "bitboard": {"id": "bitboard.v1"},
+                    "action_index": {"id": "action-index.v1"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (fixture_dir / "game-state-v1.json").write_text(
+        json.dumps(
+            {
+                "schema": "api-portability-fixtures.v1",
+                "contract_version": "1.1.0",
+                "game_state_cases": [
+                    {
+                        "case_id": "empty-board",
+                        "qfen": "..../..../..../....",
+                        "move": {"shape": 0, "position": 0},
+                    },
+                    {
+                        "case_id": "single-p0-corner",
+                        "qfen": "A.../..../..../....",
+                        "move": {"shape": 1, "position": 5},
+                    },
+                    {
+                        "case_id": "single-p0-occupied-corner",
+                        "qfen": "A.../..../..../....",
+                        "move": {"shape": 1, "position": 0},
+                    },
+                    {
+                        "case_id": "mixed-asymmetric",
+                        "qfen": "Ab../..c./...D/....",
+                        "move": {"shape": 2, "position": 12},
+                    },
+                    {
+                        "case_id": "stalemate-p1-blocked",
+                        "qfen": "A..C/bbd./CD.A/.adB",
+                        "move": {"shape": 0, "position": 0},
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return contracts_root
+
+
+def fixture_path(contracts_root: Path) -> Path:
+    return contracts_root / "fixtures" / "api-portability" / "game-state-v1.json"
+
+
+def load_fixture(contracts_root: Path) -> dict[str, Any]:
+    return cast(
+        dict[str, Any],
+        json.loads(fixture_path(contracts_root).read_text(encoding="utf-8")),
+    )
+
+
+def write_fixture(contracts_root: Path, fixture: dict[str, Any]) -> None:
+    fixture_path(contracts_root).write_text(json.dumps(fixture), encoding="utf-8")
+
+
+def test_api_portability_report_cli_writes_normalized_report(tmp_path: Path) -> None:
+    output = tmp_path / "python-api-portability-report.json"
+    contracts_root = make_contracts_root(tmp_path)
+
+    exit_code = main(["--contracts-root", str(contracts_root), "--output", str(output)])
+
+    assert exit_code == 0
+    raw = output.read_text(encoding="utf-8")
+    assert raw.endswith("\n")
+    report = json.loads(raw)
+    assert report["schema"] == "api-portability-report.v1"
+    assert report["contracts_release"] == "1.1.0"
+    assert report["implementation"] == {
+        "language": "python",
+        "package": "quantik-core",
+        "version": "1.1.0",
+    }
+    assert report["contract_ids"] == {
+        "qfen": "qfen.v1",
+        "bitboard": "bitboard.v1",
+        "action_index": "action-index.v1",
+    }
+    assert [case["case_id"] for case in report["cases"]] == [
+        "empty-board",
+        "mixed-asymmetric",
+        "single-p0-corner",
+        "single-p0-occupied-corner",
+        "stalemate-p1-blocked",
+    ]
+
+    empty, mixed, single, occupied, stalemate = report["cases"]
+    assert empty == {
+        "case_id": "empty-board",
+        "qfen": "..../..../..../....",
+        "bitboards": [0, 0, 0, 0, 0, 0, 0, 0],
+        "side_to_move": 0,
+        "canonical_qfen": "..../..../..../....",
+        "canonical_key": "010200000000000000000000000000000000",
+        "orbit_size": 1,
+        "legal_action_mask": "0xffffffffffffffff",
+        "legal_action_indices": list(range(64)),
+        "terminal": False,
+        "winner": "none",
+        "move": {
+            "shape": 0,
+            "position": 0,
+            "action_index": 0,
+            "is_legal": True,
+            "after_qfen": "A.../..../..../....",
+        },
+    }
+    assert mixed["case_id"] == "mixed-asymmetric"
+    assert mixed["qfen"] == "Ab../..c./...D/...."
+    assert mixed["bitboards"] == [1, 0, 0, 2048, 0, 2, 64, 0]
+    assert mixed["side_to_move"] == 0
+    assert mixed["canonical_qfen"] == "..aD/.b../C.../...."
+    assert mixed["canonical_key"] == "010200000000000108000400200000000000"
+    assert mixed["orbit_size"] == 192
+    assert mixed["legal_action_mask"] == "0xf7bcb300d580f7bc"
+    assert mixed["legal_action_indices"] == [
+        2,
+        3,
+        4,
+        5,
+        7,
+        8,
+        9,
+        10,
+        12,
+        13,
+        14,
+        15,
+        23,
+        24,
+        26,
+        28,
+        30,
+        31,
+        40,
+        41,
+        44,
+        45,
+        47,
+        50,
+        51,
+        52,
+        53,
+        55,
+        56,
+        57,
+        58,
+        60,
+        61,
+        62,
+        63,
+    ]
+    assert mixed["terminal"] is False
+    assert mixed["winner"] == "none"
+    assert mixed["move"] == {
+        "shape": 2,
+        "position": 12,
+        "action_index": 44,
+        "is_legal": True,
+        "after_qfen": "Ab../..c./...D/C...",
+    }
+
+    assert single["case_id"] == "single-p0-corner"
+    assert single["qfen"] == "A.../..../..../...."
+    assert single["bitboards"] == [1, 0, 0, 0, 0, 0, 0, 0]
+    assert single["side_to_move"] == 1
+    assert single["canonical_qfen"] == "..../..../..../D..."
+    assert single["canonical_key"] == "010200000000000000100000000000000000"
+    assert single["orbit_size"] == 16
+    assert single["legal_action_mask"] == "0xfffefffefffeeec0"
+    assert single["legal_action_indices"] == [
+        6,
+        7,
+        9,
+        10,
+        11,
+        13,
+        14,
+        15,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        45,
+        46,
+        47,
+        49,
+        50,
+        51,
+        52,
+        53,
+        54,
+        55,
+        56,
+        57,
+        58,
+        59,
+        60,
+        61,
+        62,
+        63,
+    ]
+    assert single["terminal"] is False
+    assert single["winner"] == "none"
+    assert single["move"] == {
+        "shape": 1,
+        "position": 5,
+        "action_index": 21,
+        "is_legal": True,
+        "after_qfen": "A.../.b../..../....",
+    }
+
+    assert occupied["case_id"] == "single-p0-occupied-corner"
+    assert occupied["move"] == {
+        "shape": 1,
+        "position": 0,
+        "action_index": 16,
+        "is_legal": False,
+        "after_qfen": None,
+    }
+
+    assert stalemate["case_id"] == "stalemate-p1-blocked"
+    assert stalemate["side_to_move"] == 1
+    assert stalemate["legal_action_indices"] == []
+    assert stalemate["legal_action_mask"] == "0x0000000000000000"
+    assert stalemate["terminal"] is True
+    assert stalemate["winner"] == "player0"
+    assert stalemate["move"] == {
+        "shape": 0,
+        "position": 0,
+        "action_index": 0,
+        "is_legal": False,
+        "after_qfen": None,
+    }
+
+
+def test_api_portability_report_module_execution(tmp_path: Path) -> None:
+    output = tmp_path / "module-report.json"
+    contracts_root = make_contracts_root(tmp_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "quantik_core.api_portability_report",
+            "--contracts-root",
+            str(contracts_root),
+            "--output",
+            str(output),
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(output.read_text(encoding="utf-8"))["schema"] == (
+        "api-portability-report.v1"
+    )
+
+
+def test_api_portability_report_console_script_is_registered() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    pyproject = tomllib.loads(
+        (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    assert pyproject["project"]["scripts"]["quantik-api-portability-report"] == (
+        "quantik_core.api_portability_report:main"
+    )
+
+
+def test_api_portability_report_rejects_contract_version_drift(
+    tmp_path: Path,
+) -> None:
+    contracts_root = make_contracts_root(tmp_path)
+    (contracts_root / "VERSION").write_text("1.0.0\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not match"):
+        build_report(contracts_root)
+
+
+def test_api_portability_report_requires_version_file(tmp_path: Path) -> None:
+    contracts_root = make_contracts_root(tmp_path)
+    (contracts_root / "VERSION").unlink()
+
+    with pytest.raises(ValueError, match="VERSION file is required"):
+        build_report(contracts_root)
+
+    (contracts_root / "VERSION").write_text("\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="VERSION must be non-empty"):
+        build_report(contracts_root)
+
+
+def test_api_portability_report_rejects_fixture_metadata_drift(
+    tmp_path: Path,
+) -> None:
+    contracts_root = make_contracts_root(tmp_path)
+    fixture = load_fixture(contracts_root)
+    fixture["schema"] = "wrong-schema.v1"
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match="schema must be api-portability-fixtures.v1"):
+        build_report(contracts_root)
+
+    fixture["schema"] = "api-portability-fixtures.v1"
+    fixture["contract_version"] = "1.0.0"
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match="contract_version must match 1.1.0"):
+        build_report(contracts_root)
+
+
+def test_api_portability_report_rejects_invalid_case_and_move(
+    tmp_path: Path,
+) -> None:
+    contracts_root = make_contracts_root(tmp_path)
+    fixture = load_fixture(contracts_root)
+    fixture["game_state_cases"][0]["case_id"] = ""
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match="case_id must be a non-empty string"):
+        build_report(contracts_root)
+
+    fixture["game_state_cases"][0]["case_id"] = "bad-move"
+    fixture["game_state_cases"][0]["move"]["shape"] = 4
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match="move.shape must be between 0 and 3"):
+        build_report(contracts_root)
+
+    fixture["game_state_cases"][0]["move"]["shape"] = True
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match="move.shape must be an integer"):
+        build_report(contracts_root)
+
+    fixture["game_state_cases"][0]["move"] = {"shape": 0, "position": -1}
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match="move.position must be between 0 and 15"):
+        build_report(contracts_root)
+
+
+def test_api_portability_report_rejects_invalid_qfen_with_case_context(
+    tmp_path: Path,
+) -> None:
+    contracts_root = make_contracts_root(tmp_path)
+    fixture = load_fixture(contracts_root)
+    fixture["game_state_cases"][0]["qfen"] = "bad"
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match="empty-board: qfen parse failed"):
+        build_report(contracts_root)
+
+    fixture["game_state_cases"][0]["qfen"] = 12
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match="empty-board: qfen must be a string"):
+        build_report(contracts_root)
+
+    fixture["game_state_cases"][0]["qfen"] = "..../..../..../...."
+    fixture["game_state_cases"][0]["move"] = "bad-move"
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match="empty-board: move must be an object"):
+        build_report(contracts_root)
+
+
+def test_api_portability_report_rejects_empty_or_non_object_cases(
+    tmp_path: Path,
+) -> None:
+    contracts_root = make_contracts_root(tmp_path)
+    fixture = load_fixture(contracts_root)
+    fixture["game_state_cases"] = []
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match="game_state_cases must be a non-empty list"):
+        build_report(contracts_root)
+
+    fixture["game_state_cases"] = ["not-an-object"]
+    write_fixture(contracts_root, fixture)
+
+    with pytest.raises(ValueError, match=r"game_state_cases\[0\] must be an object"):
+        build_report(contracts_root)
+
+
+def test_api_portability_report_rejects_malformed_manifest(tmp_path: Path) -> None:
+    contracts_root = make_contracts_root(tmp_path)
+    (contracts_root / "contracts.json").write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="expected a JSON object"):
+        build_report(contracts_root)
+
+
+def test_api_portability_report_rejects_missing_contract_id(tmp_path: Path) -> None:
+    contracts_root = make_contracts_root(tmp_path)
+    manifest = json.loads(
+        (contracts_root / "contracts.json").read_text(encoding="utf-8")
+    )
+    del manifest["contracts"]["action_index"]
+    (contracts_root / "contracts.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="missing contract id for action_index"):
+        build_report(contracts_root)
+
+
+def test_api_portability_report_uses_editable_version_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    contracts_root = make_contracts_root(tmp_path)
+
+    def missing_package(_: str) -> str:
+        raise apr.PackageNotFoundError
+
+    monkeypatch.setattr(apr, "version", missing_package)
+
+    assert build_report(contracts_root)["implementation"]["version"] == "0+editable"
+
+
+def test_api_portability_report_winner_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(apr, "check_game_winner", lambda _: apr.WinStatus.PLAYER_0_WINS)
+    assert apr._winner_name((0, 0, 0, 0, 0, 0, 0, 0)) == "player0"
+
+    monkeypatch.setattr(apr, "check_game_winner", lambda _: apr.WinStatus.PLAYER_1_WINS)
+    assert apr._winner_name((0, 0, 0, 0, 0, 0, 0, 0)) == "player1"
+
+
+def test_api_portability_report_rejects_valid_move_without_bitboard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MissingBitboardValidation:
+        is_valid = True
+        new_bb = None
+
+    monkeypatch.setattr(apr, "validate_move", lambda *_: MissingBitboardValidation())
+
+    with pytest.raises(ValueError, match="valid move did not return a new bitboard"):
+        apr._move_report({"shape": 0, "position": 0}, (0, 0, 0, 0, 0, 0, 0, 0), 0)


### PR DESCRIPTION
## Summary
- Add quantik-api-portability-report CLI and module entry point
- Emit normalized api-portability-report.v1 cases from the contracts fixture
- Cover CLI/module output and script registration with tests

Contract doc: https://github.com/mberlanda/quantik-core-contracts/blob/main/docs/api-portability-testing.md

## Verification
- .venv/bin/python -m pytest --no-cov tests/test_api_portability_report.py
- ./auto-lint.sh
- .venv/bin/mypy src/quantik_core/api_portability_report.py tests/test_api_portability_report.py
- python3 scripts/compare_api_portability_reports.py /private/tmp/python-api-portability-report.json /private/tmp/rust-api-portability-report.json