### PR TITLE
Add training dataset view

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ Documentation = "https://github.com/mberlanda/quantik-core-py#readme"
 Changelog = "https://github.com/mberlanda/quantik-core-py/blob/main/CHANGELOG.md"
 
 [project.scripts]
+quantik-training-dataset = "quantik_core.training_dataset:main"
 quantik-api-portability-report = "quantik_core.api_portability_report:main"
 
 [tool.setuptools.packages.find]

--- a/src/quantik_core/__init__.py
+++ b/src/quantik_core/__init__.py
@@ -23,6 +23,14 @@ from .board import (
 )
 from .evaluation import EvalConfig, evaluate
 from .minimax import MinimaxConfig, MinimaxEngine, MinimaxResult
+from .training_dataset import (
+    TrainingDatasetView,
+    load_training_view_from_observations_jsonl,
+    load_training_view_from_observations_parquet,
+    load_training_view_npz,
+    training_view_from_observations,
+    write_training_view_npz,
+)
 
 try:
     __version__ = version("quantik-core")
@@ -58,4 +66,10 @@ __all__ = [
     "MinimaxConfig",
     "MinimaxEngine",
     "MinimaxResult",
+    "TrainingDatasetView",
+    "training_view_from_observations",
+    "load_training_view_from_observations_jsonl",
+    "load_training_view_from_observations_parquet",
+    "write_training_view_npz",
+    "load_training_view_npz",
 ]

--- a/src/quantik_core/training_dataset.py
+++ b/src/quantik_core/training_dataset.py
@@ -1,0 +1,260 @@
+"""NumPy-first training views over Quantik artifact contracts.
+
+The contracts repository owns durable artifact shapes. This module is the
+Python training-facing projection: validated rows become dense arrays that are
+stable across stacks and cheap to hand to a model trainer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+import numpy as np
+import numpy.typing as npt
+
+from .artifact_data import (
+    ObservationRow,
+    load_observations_jsonl,
+    load_observations_parquet,
+)
+from .ml_data import (
+    ACTION_COUNT,
+    BOARD_SIZE,
+    PLAYER_SHAPE_CHANNELS,
+    SIDE_TO_MOVE_CHANNEL,
+    TENSOR_CHANNELS,
+)
+
+DEFAULT_VALUE_SOURCE_WEIGHTS: Mapping[str, float] = {
+    "exact": 1.0,
+    "tablebase": 1.0,
+    "opening-book": 1.0,
+    "opening_book": 1.0,
+    "bounded": 0.9,
+    "strong-search": 0.85,
+    "strong_search": 0.85,
+    "search": 0.7,
+    "mcts": 0.7,
+    "minimax": 0.7,
+    "beam": 0.6,
+    "h2h": 0.45,
+    "game-result": 0.45,
+    "game_result": 0.45,
+    "heuristic": 0.25,
+    "synthetic": 0.2,
+}
+
+
+@dataclass(frozen=True)
+class TrainingDatasetView:
+    """Dense training arrays derived from artifact rows."""
+
+    tensors: npt.NDArray[np.float32]
+    bitboards: npt.NDArray[np.uint16]
+    side_to_move: npt.NDArray[np.uint8]
+    legal_action_mask: npt.NDArray[np.uint64]
+    policy_target: npt.NDArray[np.float32]
+    value_target: npt.NDArray[np.float32]
+    sample_weight: npt.NDArray[np.float32]
+    source_tags: tuple[tuple[str, ...], ...]
+
+    def __len__(self) -> int:
+        return int(self.value_target.shape[0])
+
+
+def _policy_target(policy_visits: tuple[int, ...]) -> npt.NDArray[np.float32]:
+    if len(policy_visits) != ACTION_COUNT:
+        raise ValueError(f"policy_visits must contain {ACTION_COUNT} entries")
+    visits = np.asarray(policy_visits, dtype=np.float32)
+    total = float(visits.sum())
+    if total <= 0.0:
+        raise ValueError("policy_visits must contain at least one visit")
+    return visits / total
+
+
+def _value_source_weight(
+    value_source: str, value_source_weights: Mapping[str, float] | None
+) -> float:
+    weights = value_source_weights or DEFAULT_VALUE_SOURCE_WEIGHTS
+    return float(weights.get(value_source.lower(), 0.5))
+
+
+def _sample_weight(
+    row: ObservationRow, value_source_weights: Mapping[str, float] | None
+) -> float:
+    weight = row.source_confidence * _value_source_weight(
+        row.value_source, value_source_weights
+    )
+    return float(min(1.0, max(0.0, weight)))
+
+
+def _source_tags(row: ObservationRow) -> tuple[str, ...]:
+    total_visits = sum(row.policy_visits)
+    tags = [
+        f"schema:{row.schema}",
+        f"run:{row.run_id}",
+        f"engine:{row.engine_kind}",
+        f"value:{row.value_source}",
+    ]
+    if total_visits == 1:
+        tags.append("policy:single-visit")
+    return tuple(tags)
+
+
+def _bitboards_to_tensor(
+    bitboards: tuple[int, ...], side_to_move: int
+) -> npt.NDArray[np.float32]:
+    if len(bitboards) != PLAYER_SHAPE_CHANNELS:
+        raise ValueError(f"bitboards must contain {PLAYER_SHAPE_CHANNELS} planes")
+    if side_to_move not in (0, 1):
+        raise ValueError("side_to_move must be 0 or 1")
+
+    tensor = np.zeros((TENSOR_CHANNELS, BOARD_SIZE, BOARD_SIZE), dtype=np.float32)
+    for channel, bits in enumerate(bitboards):
+        for position in range(BOARD_SIZE * BOARD_SIZE):
+            if (bits >> position) & 1:
+                row = position // BOARD_SIZE
+                col = position % BOARD_SIZE
+                tensor[channel, row, col] = 1.0
+    tensor[SIDE_TO_MOVE_CHANNEL, :, :] = float(side_to_move)
+    return tensor
+
+
+def training_view_from_observations(
+    rows: Iterable[ObservationRow],
+    *,
+    value_source_weights: Mapping[str, float] | None = None,
+) -> TrainingDatasetView:
+    """Project `observation.v1` rows into dense policy/value training arrays."""
+    materialized = list(rows)
+    if not materialized:
+        raise ValueError("training view requires at least one observation row")
+
+    tensors = np.stack(
+        [_bitboards_to_tensor(row.bitboards, row.side_to_move) for row in materialized]
+    ).astype(np.float32, copy=False)
+    bitboards = np.asarray(
+        [row.bitboards for row in materialized],
+        dtype=np.uint16,
+    )
+    side_to_move = np.asarray(
+        [row.side_to_move for row in materialized],
+        dtype=np.uint8,
+    )
+    legal_action_mask = np.asarray(
+        [row.legal_action_mask for row in materialized],
+        dtype=np.uint64,
+    )
+    policy_target = np.stack(
+        [_policy_target(row.policy_visits) for row in materialized]
+    ).astype(np.float32, copy=False)
+    value_target = np.asarray(
+        [min(1.0, max(-1.0, row.value)) for row in materialized],
+        dtype=np.float32,
+    )
+    sample_weight = np.asarray(
+        [_sample_weight(row, value_source_weights) for row in materialized],
+        dtype=np.float32,
+    )
+    source_tags = tuple(_source_tags(row) for row in materialized)
+
+    if tensors.shape[1:] != (PLAYER_SHAPE_CHANNELS + 1, 4, 4):
+        raise ValueError("training tensors must have shape (n, 9, 4, 4)")
+    return TrainingDatasetView(
+        tensors=tensors,
+        bitboards=bitboards,
+        side_to_move=side_to_move,
+        legal_action_mask=legal_action_mask,
+        policy_target=policy_target,
+        value_target=value_target,
+        sample_weight=sample_weight,
+        source_tags=source_tags,
+    )
+
+
+def load_training_view_from_observations_jsonl(
+    path: str | Path,
+    *,
+    value_source_weights: Mapping[str, float] | None = None,
+) -> TrainingDatasetView:
+    """Load `observation.v1` JSONL and return the NumPy training view."""
+    return training_view_from_observations(
+        load_observations_jsonl(path),
+        value_source_weights=value_source_weights,
+    )
+
+
+def load_training_view_from_observations_parquet(
+    path: str | Path,
+    *,
+    value_source_weights: Mapping[str, float] | None = None,
+) -> TrainingDatasetView:
+    """Load `observation.v1` Parquet and return the NumPy training view."""
+    return training_view_from_observations(
+        load_observations_parquet(path),
+        value_source_weights=value_source_weights,
+    )
+
+
+def write_training_view_npz(view: TrainingDatasetView, path: str | Path) -> None:
+    """Write a compressed NumPy training dataset artifact."""
+    encoded_tags = np.asarray(
+        [json.dumps(tags, separators=(",", ":")) for tags in view.source_tags],
+        dtype=np.str_,
+    )
+    np.savez_compressed(
+        Path(path),
+        tensors=view.tensors,
+        bitboards=view.bitboards,
+        side_to_move=view.side_to_move,
+        legal_action_mask=view.legal_action_mask,
+        policy_target=view.policy_target,
+        value_target=view.value_target,
+        sample_weight=view.sample_weight,
+        source_tags=encoded_tags,
+    )
+
+
+def load_training_view_npz(path: str | Path) -> TrainingDatasetView:
+    """Load a compressed NumPy training dataset artifact."""
+    with np.load(Path(path), allow_pickle=False) as data:
+        source_tags = tuple(
+            tuple(json.loads(str(item))) for item in data["source_tags"].tolist()
+        )
+        return TrainingDatasetView(
+            tensors=data["tensors"].astype(np.float32, copy=False),
+            bitboards=data["bitboards"].astype(np.uint16, copy=False),
+            side_to_move=data["side_to_move"].astype(np.uint8, copy=False),
+            legal_action_mask=data["legal_action_mask"].astype(np.uint64, copy=False),
+            policy_target=data["policy_target"].astype(np.float32, copy=False),
+            value_target=data["value_target"].astype(np.float32, copy=False),
+            sample_weight=data["sample_weight"].astype(np.float32, copy=False),
+            source_tags=source_tags,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Materialize observation.v1 rows as a NumPy training view."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--observations-jsonl")
+    source.add_argument("--observations-parquet")
+    parser.add_argument("--output-npz", required=True)
+    args = parser.parse_args(argv)
+
+    if args.observations_jsonl:
+        view = load_training_view_from_observations_jsonl(args.observations_jsonl)
+    else:
+        view = load_training_view_from_observations_parquet(args.observations_parquet)
+    write_training_view_npz(view, args.output_npz)
+    print(f"wrote training dataset view: {args.output_npz} rows={len(view)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_training_dataset.py
+++ b/tests/test_training_dataset.py
@@ -1,0 +1,216 @@
+import json
+import tempfile
+import tomllib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from quantik_core.artifact_data import (
+    OBSERVATION_SCHEMA,
+    ObservationRow,
+    load_observations_jsonl,
+    write_observations_parquet,
+)
+from quantik_core.training_dataset import (
+    TrainingDatasetView,
+    load_training_view_npz,
+    load_training_view_from_observations_jsonl,
+    load_training_view_from_observations_parquet,
+    main,
+    training_view_from_observations,
+    write_training_view_npz,
+)
+
+
+def observation_record(row_id: int = 0):
+    visits = [0] * 64
+    visits[0] = 3
+    visits[21] = 1
+    return {
+        "schema": OBSERVATION_SCHEMA,
+        "contract_version": "1.1.0",
+        "run_id": "run-1",
+        "row_id": row_id,
+        "position_key": f"pos-{row_id}",
+        "ply": 0,
+        "side_to_move": 0,
+        "bitboards": [0] * 8,
+        "qfen": "..../..../..../....",
+        "legal_action_mask": (1 << 64) - 1,
+        "engine_kind": "mcts",
+        "engine_version": "0.1.0",
+        "elapsed_ms": 12,
+        "policy_visits": visits,
+        "value": 0.25,
+        "value_source": "strong-search",
+        "source_confidence": 0.8,
+    }
+
+
+def test_training_view_from_observations_materializes_numpy_targets():
+    rows = load_observations_jsonl_from_records([observation_record()])
+
+    view = training_view_from_observations(rows)
+
+    assert len(view) == 1
+    assert view.tensors.shape == (1, 9, 4, 4)
+    assert view.tensors.dtype == np.float32
+    assert view.bitboards.shape == (1, 8)
+    assert view.bitboards.dtype == np.uint16
+    assert view.side_to_move.tolist() == [0]
+    assert view.legal_action_mask.dtype == np.uint64
+    assert view.policy_target.shape == (1, 64)
+    assert view.policy_target[0, 0] == pytest.approx(0.75)
+    assert view.policy_target[0, 21] == pytest.approx(0.25)
+    assert view.policy_target[0].sum() == pytest.approx(1.0)
+    assert view.value_target.tolist() == pytest.approx([0.25])
+    assert view.sample_weight.tolist() == pytest.approx([0.68])
+    assert "engine:mcts" in view.source_tags[0]
+    assert "value:strong-search" in view.source_tags[0]
+
+
+def test_training_view_tags_single_visit_policy_and_clips_value():
+    record = observation_record()
+    record["policy_visits"] = [0] * 64
+    record["policy_visits"][0] = 1
+    record["value"] = 2.0
+    record["value_source"] = "synthetic"
+    record["source_confidence"] = 1.0
+    rows = load_observations_jsonl_from_records([record])
+
+    view = training_view_from_observations(rows)
+
+    assert view.value_target.tolist() == pytest.approx([1.0])
+    assert view.sample_weight.tolist() == pytest.approx([0.2])
+    assert "policy:single-visit" in view.source_tags[0]
+
+
+def test_training_view_uses_materialized_bitboards_without_qfen_roundtrip():
+    visits = [0] * 64
+    visits[21] = 1
+    row = ObservationRow(
+        schema=OBSERVATION_SCHEMA,
+        contract_version="1.1.0",
+        run_id="run-1",
+        row_id=0,
+        position_key="pos-0",
+        ply=1,
+        side_to_move=1,
+        bitboards=(1, 0, 0, 0, 0, 0, 0, 0),
+        legal_action_mask=0,
+        engine_kind="mcts",
+        engine_version="0.1.0",
+        elapsed_ms=12,
+        policy_visits=tuple(visits),
+        value=0.25,
+        value_source="strong-search",
+        source_confidence=0.8,
+        qfen="not-a-qfen",
+    )
+
+    view = training_view_from_observations([row])
+
+    assert view.tensors[0, 0, 0, 0] == 1.0
+    assert view.tensors[0, 8].tolist() == [[1.0] * 4] * 4
+
+
+def test_load_training_view_from_observations_jsonl(tmp_path):
+    path = tmp_path / "observations.jsonl"
+    path.write_text(json.dumps(observation_record()) + "\n", encoding="utf-8")
+
+    view = load_training_view_from_observations_jsonl(path)
+
+    assert len(view) == 1
+    assert view.policy_target[0, 0] == pytest.approx(0.75)
+
+
+def test_load_training_view_from_observations_parquet(tmp_path):
+    pytest.importorskip("pyarrow")
+    source_path = tmp_path / "observations.jsonl"
+    parquet_path = tmp_path / "observations.parquet"
+    source_path.write_text(json.dumps(observation_record()) + "\n", encoding="utf-8")
+    write_observations_parquet(load_observations_jsonl(source_path), parquet_path)
+
+    view = load_training_view_from_observations_parquet(parquet_path)
+
+    assert len(view) == 1
+    assert view.policy_target[0, 21] == pytest.approx(0.25)
+
+
+def test_training_view_npz_roundtrip(tmp_path):
+    rows = load_observations_jsonl_from_records([observation_record()])
+    view = training_view_from_observations(rows)
+    path = tmp_path / "training-view.npz"
+
+    write_training_view_npz(view, path)
+    loaded = load_training_view_npz(path)
+
+    assert np.array_equal(loaded.bitboards, view.bitboards)
+    assert np.allclose(loaded.policy_target, view.policy_target)
+    assert loaded.source_tags == view.source_tags
+
+
+def test_training_view_npz_roundtrips_empty_and_separator_tags(tmp_path):
+    view = TrainingDatasetView(
+        tensors=np.zeros((2, 9, 4, 4), dtype=np.float32),
+        bitboards=np.zeros((2, 8), dtype=np.uint16),
+        side_to_move=np.zeros(2, dtype=np.uint8),
+        legal_action_mask=np.zeros(2, dtype=np.uint64),
+        policy_target=np.zeros((2, 64), dtype=np.float32),
+        value_target=np.zeros(2, dtype=np.float32),
+        sample_weight=np.ones(2, dtype=np.float32),
+        source_tags=((), ("tag\x1fwith-separator", "plain")),
+    )
+    path = tmp_path / "training-view.npz"
+
+    write_training_view_npz(view, path)
+    loaded = load_training_view_npz(path)
+
+    assert loaded.source_tags == view.source_tags
+
+
+def test_training_dataset_cli_writes_npz(tmp_path):
+    source_path = tmp_path / "observations.jsonl"
+    output_path = tmp_path / "training-view.npz"
+    source_path.write_text(json.dumps(observation_record()) + "\n", encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "--observations-jsonl",
+                str(source_path),
+                "--output-npz",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+
+    assert len(load_training_view_npz(output_path)) == 1
+
+
+def test_training_dataset_cli_is_packaged_as_console_script(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    repo_root = Path(__file__).resolve().parents[1]
+    pyproject = tomllib.loads(
+        (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    assert pyproject["project"]["scripts"]["quantik-training-dataset"] == (
+        "quantik_core.training_dataset:main"
+    )
+
+
+def test_training_view_requires_rows():
+    with pytest.raises(ValueError, match="at least one observation row"):
+        training_view_from_observations([])
+
+
+def load_observations_jsonl_from_records(records):
+    lines = [json.dumps(record) for record in records]
+    # Keep test rows on disk so they pass through the public JSONL parser.
+    with tempfile.TemporaryDirectory() as directory:
+        file_path = Path(directory) / "observations.jsonl"
+        file_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return load_observations_jsonl(file_path)


### PR DESCRIPTION
## Summary

- Add `TrainingDatasetView` for NumPy-first policy/value arrays from `observation.v1` rows.
- Add JSONL/Parquet loaders, compressed NPZ save/load helpers, and the `quantik-training-dataset` console script.
- Export the training view helpers from the package top level.

## Test Plan

- `./auto-lint.sh`
- `.venv/bin/python -m pytest tests/test_training_dataset.py -q --no-cov`
- `./dev-check.sh`

## Notes

- Contract source: https://github.com/mberlanda/quantik-core-contracts/blob/main/docs/observation-v1.md
- Local code review completed; reviewer findings on CLI packaging and NPZ tag encoding were fixed before PR creation.
