### PR TITLE
Search telemetry Python mirror: engines, exporter, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ binary = state.pack()  # Just 18 bytes
 - [Minimax Documentation](docs/MINIMAX.md) - Alpha-beta search with a fitted handcrafted evaluation
 - [MCTS Documentation](docs/MCTS.md) - Monte Carlo Tree Search implementation details
 - [Beam Search Documentation](docs/BEAM_SEARCH.md) - Memory-bounded terminal-state search
+- [Search Telemetry](docs/search-telemetry.md) - Event counters, value semantics, and root-identity rules shared by MCTS, beam, and minimax
 - [Opening Book Guide](docs/OPENING_BOOK.md) - Position database usage and API
 - [Examples](examples/) - Complete working examples for all features
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -110,6 +110,20 @@ python examples/cross_engine_benchmark.py report \
   --input benchmarks/results/$(git rev-parse --short HEAD).json
 ```
 
+## Search Telemetry Export
+
+`examples/search_summary_export.py` runs the MCTS, minimax, and beam engines
+over a fixed set of positions (the empty board plus two mid-game positions,
+seed `20260716`) and writes one draft `search-summary.v1-draft` JSONL row per
+completed root search whose root identity was preserved. Rows skipped for an
+unpreserved root identity are logged to stderr, not written. See
+`docs/search-telemetry.md` for the counter semantics and value mapping this
+export relies on.
+
+```bash
+python examples/search_summary_export.py --out search-summaries.jsonl
+```
+
 ## Hybrid Player
 
 `quantik_core.hybrid.HybridPlayer` samples with MCTS or beam search while

--- a/docs/search-telemetry.md
+++ b/docs/search-telemetry.md
@@ -133,8 +133,11 @@ transposition table off**:
 
 The exporter **skips** (returns `None`, a legitimate skip — not an error) any
 row whose telemetry has `root_identity_preserved == false`. It **raises**
-`ValueError` for an out-of-range `action_index (>= 64)` (matching Rust's
-`Err`).
+`ValueError` for an `action_index` outside `[0, 64)` (matching Rust's `Err`).
+Rust checks only `>= 64` because its `action_index` is an unsigned `u8`;
+Python's is a signed `int`, so the exporter also rejects negative indices,
+which would otherwise silently index the dense policy/value arrays from the
+end.
 
 For telemetry-quality export runs: MCTS `use_transposition_table=False`,
 minimax `dedup_children=False`, and treat beam skips as expected.

--- a/docs/search-telemetry.md
+++ b/docs/search-telemetry.md
@@ -46,8 +46,8 @@ comparable magnitudes — cross-engine workload comparison belongs to
 
 | Counter | MCTS | Beam | Minimax |
 | --- | --- | --- | --- |
-| `expanded_nodes` | +1 per node created (root in `search()`, each fresh child in `_expand`) | +1 per frontier entry processed in `_expand_frontier` (incl. the no-legal-moves case) | +1 per `_children(...)` call (the one in `_search_root` and each in `_negamax`) |
-| `generated_nodes` | +1 per fresh child constructed in `_expand` (the retained successor) | +1 per `apply_move` on a candidate move in `_expand_moves` | += `len(ordered)` at each `_children(...)` call (every move applied before dedup) |
+| `expanded_nodes` | +1 per `_expand`, right after `generate_legal_moves` computes the node's successor set (the no-legal-moves case included; a node already terminal by a winning line returns before enumeration and is not counted) | +1 per frontier entry processed in `_expand_frontier` (incl. the no-legal-moves case) | +1 per successor-set computation: once for the root moves in `search()`, then once right after `generate_legal_moves_list` in each `_negamax` node (the depth-0 leaf and the no-legal-moves node included; a `has_winning_line` node returns before enumeration and is not counted) |
+| `generated_nodes` | +1 per candidate move whose successor state is constructed in the `_expand` loop (every `apply_move`/`State(...)`, including states re-derived for already-visited moves) | +1 per `apply_move` on a candidate move in `_expand_moves` | += `len(ordered)` at each `_children(...)` call (every move applied before dedup) |
 | `transposition_hits` | +1 when `add_child_node` reuses an existing node (node count unchanged) **and** `use_transposition_table` | **0** — beam never reuses search results | +1 at each TT early-return in `_negamax`: the `Bound.EXACT` return and the narrowed `alpha >= beta` return |
 | `canonical_dedup_hits` | **0** (structural — MCTS canonical merging is reflected in `root_identity_preserved`, not this counter) | +1 at the `if key in candidates` dedup-merge branch in `_expand_moves`; also bumps a private `root_dedup_hits` when `depth == 1` | += `len(ordered) - len(children)` (dedup skips) at each `_children(...)` call |
 | `terminal_hits` | +1 when `_expand` determines a node terminal (winner, or no legal moves). Rollouts never instrumented | +1 per terminal child (winner branch) and per no-legal-moves frontier entry. Rollouts never instrumented | +1 at the `has_winning_line` return and the `not moves` return in `_negamax` |
@@ -68,6 +68,14 @@ Distinctions worth calling out explicitly:
 - **Rollout terminals are excluded from `terminal_hits` in EVERY engine.** MCTS
   `_simulate`/rollouts and beam `_rollout`/`_default_evaluate` are never
   instrumented.
+- **MCTS counts events, not distinct nodes.** `_expand` recomputes a node's
+  successor set and re-derives already-visited children's states on every pass,
+  so a node revisited across iterations contributes an `expanded_nodes` event
+  each time and its siblings' constructions recur in `generated_nodes`. This is
+  faithful to the event definitions but means the Python MCTS magnitudes are
+  higher than Rust's, whose `expand` generates a node's moves once at creation
+  and constructs exactly one successor per call via `untried_moves`. Per the
+  Section 2 note, only `elapsed_ms` is meant for workload comparison.
 
 ### Structural zeros called out explicitly
 

--- a/docs/search-telemetry.md
+++ b/docs/search-telemetry.md
@@ -1,0 +1,159 @@
+# Search Telemetry (Python)
+
+This document describes the `search_telemetry` surface shared by the MCTS,
+beam, and minimax engines in this package: what each event counter means, how
+each engine maps its internal values onto a common `[-1, 1]` scale, when a
+telemetry record's root-move identity is trustworthy, and how to export draft
+JSONL rows for offline analysis.
+
+## 1. Purpose
+
+`search-summary.v1` is a proposed but not-yet-registered data contract for
+search diagnostics (event counters, root-move statistics, principal
+variation) emitted by any of this package's search engines. Registration
+requires that the Rust and Python implementations expose the same observable
+semantics before any artifact carries the finished contract label. This is
+PR 2 of a three-part workstream: the Rust surface (PR 1, merged), this Python
+mirror (PR 2), and contract registration (PR 3, which flips the draft label).
+
+See also:
+- Rust source doc: `quantik-core-rust/docs/search-telemetry.md` — the
+  merged prose reference this document mirrors.
+- Contract doc (sibling repo `quantik-core-contracts`):
+  `docs/search-summary-v1.md` — the registration target this surface feeds.
+
+## 2. Normative event semantics
+
+The counters are defined by **search events**, not by whichever variables an
+engine already happens to have. A definition names one event; every engine
+increments the counter at exactly the code path where that event occurs.
+
+| Counter | Event (same in every engine) |
+| --- | --- |
+| `expanded_nodes` | A state's successor set was computed by the search. |
+| `generated_nodes` | A successor state was constructed. |
+| `transposition_hits` | A cached **search result or subtree** was reused via state-keyed lookup instead of being searched again. |
+| `canonical_dedup_hits` | A generated state was merged with, or skipped in favor of, an already-present duplicate — **without reusing any search result**. |
+| `terminal_hits` | A state was determined terminal during tree search. Rollout outcomes are excluded in every engine. |
+| `tablebase_hits` | A value/policy result was obtained from an external probe artifact instead of search. Always `0` until such an artifact exists. |
+
+Counters are not mutually exclusive: a state whose enumeration finds zero legal
+moves is both expanded and terminal. Identical semantics do not imply
+comparable magnitudes — cross-engine workload comparison belongs to
+`elapsed_ms` only.
+
+## 3. Per-engine hook mapping (Python)
+
+| Counter | MCTS | Beam | Minimax |
+| --- | --- | --- | --- |
+| `expanded_nodes` | +1 per node created (root in `search()`, each fresh child in `_expand`) | +1 per frontier entry processed in `_expand_frontier` (incl. the no-legal-moves case) | +1 per `_children(...)` call (the one in `_search_root` and each in `_negamax`) |
+| `generated_nodes` | +1 per fresh child constructed in `_expand` (the retained successor) | +1 per `apply_move` on a candidate move in `_expand_moves` | += `len(ordered)` at each `_children(...)` call (every move applied before dedup) |
+| `transposition_hits` | +1 when `add_child_node` reuses an existing node (node count unchanged) **and** `use_transposition_table` | **0** — beam never reuses search results | +1 at each TT early-return in `_negamax`: the `Bound.EXACT` return and the narrowed `alpha >= beta` return |
+| `canonical_dedup_hits` | **0** (structural — MCTS canonical merging is reflected in `root_identity_preserved`, not this counter) | +1 at the `if key in candidates` dedup-merge branch in `_expand_moves`; also bumps a private `root_dedup_hits` when `depth == 1` | += `len(ordered) - len(children)` (dedup skips) at each `_children(...)` call |
+| `terminal_hits` | +1 when `_expand` determines a node terminal (winner, or no legal moves). Rollouts never instrumented | +1 per terminal child (winner branch) and per no-legal-moves frontier entry. Rollouts never instrumented | +1 at the `has_winning_line` return and the `not moves` return in `_negamax` |
+| `tablebase_hits` | 0 | 0 | 0 |
+
+`PolicyMassKind` per engine: MCTS = `Visits` (root visit counts), beam =
+`Multiplicity` (leaf multiplicity grouped by first move), minimax = `None`
+(`root_moves` carry exact `q_value`s from the per-move score vector,
+`policy_mass = 0`).
+
+Distinctions worth calling out explicitly:
+
+- **Result reuse vs. duplicate merging.** `transposition_hits` requires that a
+  previously computed result or subtree was reused. Beam canonical dedup and
+  minimax child dedup merge duplicates but re-derive nothing, so they land in
+  `canonical_dedup_hits`. Beam dedup must never masquerade as transposition
+  reuse.
+- **Rollout terminals are excluded from `terminal_hits` in EVERY engine.** MCTS
+  `_simulate`/rollouts and beam `_rollout`/`_default_evaluate` are never
+  instrumented.
+
+### Structural zeros called out explicitly
+
+- **MCTS `canonical_dedup_hits` is always 0.** MCTS collapse is a root-identity
+  concern (reported via `root_identity_preserved`), not a counter.
+- **Beam `transposition_hits` is always 0.** Beam never reuses a search result.
+- **`tablebase_hits` is always 0** in all three engines.
+
+## 4. Value semantics
+
+Every `root_value` and every `RootMoveStat.q_value` lies in `[-1.0, 1.0]`,
+positive is good for the **root player**, and `|v| == 1.0` is reserved for
+**proven** results (terminal nodes, mates). Every unproven (sampled or
+heuristic) estimate is clamped to `[-UNPROVEN_VALUE_BOUND,
+UNPROVEN_VALUE_BOUND]` where `UNPROVEN_VALUE_BOUND = 1.0 - 1e-6`, via
+`clamp_unproven`, so a sampled/heuristic value can never be mistaken for a
+proven `±1.0`.
+
+Per-engine value mapping:
+
+- **MCTS**: win probability `p` for the root player maps to `2p - 1`. A
+  terminal child (and a terminal best child's `root_value`) is PROVEN: value
+  derived from the node's `terminal_value` (P0-perspective, negated when the
+  root mover is player 1) and reported as exact `±1.0`. Every non-terminal
+  child's rollout-sampled `2p - 1` goes through `clamp_unproven`.
+- **Beam**: a ranked root move's `q_value` is exact `1.0` only when
+  `RankedRootMove.has_terminal_win` is set **and** `best_value >= 1.0` (a
+  proven root-player win). `RankedRootMove` carries no flag for a proven
+  *loss*: once a terminal loss and a sampled loss both collapse to
+  `best_value == -1.0` they are indistinguishable, so every other case
+  (**including a proven loss**) goes through `clamp_unproven` → a proven loss
+  is conservatively reported as `-UNPROVEN_VALUE_BOUND`, not exactly `-1.0`.
+  `root_value` follows the same rule at `best_leaf`: exact `±1.0` when
+  `best_leaf.is_terminal`, `clamp_unproven` otherwise.
+- **Minimax**: `minimax_q_from_score(score, win)`. Mate scores are `±(win -
+  ply)` with `ply <= 16`, so a proven result satisfies `|score| >= win - 16.0`
+  and maps to exactly `±1.0`; everything else is squashed with the smooth,
+  monotonic, sign-preserving `score / (1.0 + abs(score))`, strictly inside
+  `(-1, 1)`. `score` is already in **root-player perspective** (`_search_root`
+  negates each child's negamax value).
+
+## 5. Root identity
+
+`root_identity_preserved` is `false` whenever canonical/transposition merging
+may have collapsed distinct root moves onto shared statistics. The Python
+rules differ from Rust's because Python's MCTS `_expand` canonical-dedups
+children unconditionally (its `existing_states` guard keys on
+`State.canonical_key()`), so symmetric root moves collapse **even with the
+transposition table off**:
+
+- **MCTS**: `root_identity_preserved = (not use_transposition_table) and (the
+  legal root moves all produce distinct child canonical keys)`. The empty
+  board's symmetric first moves therefore make it `false` regardless of the
+  transposition-table setting; TT on always makes it `false` too. This is
+  stricter than Rust, whose rule is preserved iff the transposition table is
+  off — consequently, the empty-board MCTS row that Rust's exporter emits is
+  skipped in the Python exporter.
+- **Minimax**: preserved iff `dedup_children` is `false`.
+- **Beam**: best-effort — preserved iff no depth-1 canonical dedup occurred
+  (`root_dedup_hits == 0`). Symmetric positions may skip even with a default
+  config; the empty board's beam row is skipped for this reason (depth-1
+  dedup occurs there too).
+
+The exporter **skips** (returns `None`, a legitimate skip — not an error) any
+row whose telemetry has `root_identity_preserved == false`. It **raises**
+`ValueError` for an out-of-range `action_index (>= 64)` (matching Rust's
+`Err`).
+
+For telemetry-quality export runs: MCTS `use_transposition_table=False`,
+minimax `dedup_children=False`, and treat beam skips as expected.
+
+## 6. Exporter usage
+
+Run the draft exporter example against a small fixed position set (the empty
+board plus two mid-game positions), across all three engines:
+
+```sh
+python examples/search_summary_export.py --out <path>
+```
+
+This writes one JSON line per completed root search whose root identity was
+preserved, using the schema label `search-summary.v1-draft`
+(`SEARCH_SUMMARY_DRAFT_SCHEMA` in `quantik_core.search_summary`). Rows that are
+skipped for an unpreserved root identity are logged to stderr, not written.
+
+**`search-summary.v1` (the non-draft label) must not be emitted anywhere
+until the contract is registered in `quantik-core-contracts`.** The draft
+label exists specifically so downstream consumers can distinguish
+work-in-progress rows from a finished, versioned contract.

--- a/examples/search_summary_export.py
+++ b/examples/search_summary_export.py
@@ -1,0 +1,140 @@
+"""Draft search-telemetry exporter example.
+
+Runs the MCTS, minimax, and beam engines against a handful of fixed positions
+and writes one `search-summary.v1-draft` JSONL row per completed root search
+whose root identity was preserved. Rows skipped for an unpreserved root
+identity are logged to stderr, not written. Uses the SAME positions and seed as
+the Rust example (`examples/search_summary_export.rs`) so rows are
+cross-checkable.
+
+Usage:
+    python examples/search_summary_export.py --out search-summaries.jsonl
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import IO, Optional, Tuple
+
+from quantik_core import State
+from quantik_core.beam_search import BeamSearchConfig, BeamSearchEngine
+from quantik_core.mcts import MCTSConfig, MCTSEngine
+from quantik_core.minimax import MinimaxConfig, MinimaxEngine
+from quantik_core.search_summary import (
+    SearchSummaryRunConfig,
+    search_summary_row,
+)
+from quantik_core.search_telemetry import SearchTelemetry
+
+SEED = 20260716
+RUN_ID = "search-summary-export"
+
+# Empty board plus two known-valid mid-game positions (same as the Rust
+# example: qfen.rs mixed_position + the contract-shape fixture).
+POSITIONS = [
+    ("empty", "..../..../..../...."),
+    ("mid-6ply", "A.bC/..../d..B/...a"),
+    ("mid-4ply", "Ab../..c./...D/...."),
+]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", default="search-summaries.jsonl")
+    args = parser.parse_args()
+
+    out_path = Path(args.out)
+    if out_path.parent and str(out_path.parent) not in ("", "."):
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    row_id = 0
+    rows_written = 0
+    with out_path.open("w", encoding="utf-8") as handle:
+        for label, qfen in POSITIONS:
+            state = State.from_qfen(qfen)
+
+            # MCTS: use_transposition_table MUST be False for export.
+            mcts = MCTSEngine(
+                MCTSConfig(
+                    max_iterations=200, random_seed=SEED, use_transposition_table=False
+                )
+            )
+            mcts.search(state)
+            row_id, rows_written = _emit(
+                handle,
+                row_id,
+                rows_written,
+                label,
+                "mcts",
+                qfen,
+                mcts.telemetry(),
+                SearchSummaryRunConfig(config_label="mcts-default", rollouts=200),
+            )
+
+            # Minimax: dedup_children MUST be False for export.
+            minimax = MinimaxEngine(
+                MinimaxConfig(max_depth=4, dedup_children=False, random_seed=SEED)
+            )
+            minimax.search(state)
+            row_id, rows_written = _emit(
+                handle,
+                row_id,
+                rows_written,
+                label,
+                "minimax",
+                qfen,
+                minimax.telemetry(),
+                SearchSummaryRunConfig(config_label="minimax-depth4", search_depth=4),
+            )
+
+            # Beam: default config plus a fixed seed; depth-1 dedup makes a
+            # legitimate, expected skip.
+            beam_config = BeamSearchConfig(random_seed=SEED)
+            beam = BeamSearchEngine(beam_config)
+            result = beam.search(state)
+            row_id, rows_written = _emit(
+                handle,
+                row_id,
+                rows_written,
+                label,
+                "beam",
+                qfen,
+                beam.telemetry(result),
+                SearchSummaryRunConfig(
+                    config_label="beam-default",
+                    search_depth=beam_config.max_depth,
+                    rollouts=beam_config.rollouts_per_candidate,
+                    beam_width=beam_config.beam_width,
+                ),
+            )
+
+    print(f"{rows_written} rows exported -> {out_path}")
+
+
+def _emit(
+    handle: IO[str],
+    row_id: int,
+    rows_written: int,
+    label: str,
+    engine: str,
+    qfen: str,
+    telemetry: Optional[SearchTelemetry],
+    run_config: SearchSummaryRunConfig,
+) -> Tuple[int, int]:
+    if telemetry is None:
+        print(f"[{label}] {engine}: no telemetry, skipping", file=sys.stderr)
+        return row_id, rows_written
+    row = search_summary_row(row_id, RUN_ID, qfen, telemetry, run_config)
+    if row is None:
+        print(
+            f"[{label}] {engine}: root identity not preserved, skipping",
+            file=sys.stderr,
+        )
+        return row_id, rows_written
+    handle.write(json.dumps(row, sort_keys=True) + "\n")
+    return row_id + 1, rows_written + 1
+
+
+if __name__ == "__main__":
+    main()

--- a/src/quantik_core/__init__.py
+++ b/src/quantik_core/__init__.py
@@ -31,6 +31,15 @@ from .training_dataset import (
     training_view_from_observations,
     write_training_view_npz,
 )
+from .search_telemetry import (
+    UNPROVEN_VALUE_BOUND,
+    EngineKind,
+    PolicyMassKind,
+    RootMoveStat,
+    SearchEventCounters,
+    SearchTelemetry,
+    clamp_unproven,
+)
 
 try:
     __version__ = version("quantik-core")
@@ -72,4 +81,11 @@ __all__ = [
     "load_training_view_from_observations_parquet",
     "write_training_view_npz",
     "load_training_view_npz",
+    "UNPROVEN_VALUE_BOUND",
+    "clamp_unproven",
+    "EngineKind",
+    "PolicyMassKind",
+    "SearchEventCounters",
+    "RootMoveStat",
+    "SearchTelemetry",
 ]

--- a/src/quantik_core/beam_search.py
+++ b/src/quantik_core/beam_search.py
@@ -26,6 +26,14 @@ from quantik_core.memory.compact_tree import (
     NODE_FLAG_WINNING_P0,
     NODE_FLAG_WINNING_P1,
 )
+from quantik_core.search_telemetry import (
+    EngineKind,
+    PolicyMassKind,
+    RootMoveStat,
+    SearchEventCounters,
+    SearchTelemetry,
+    clamp_unproven,
+)
 
 
 @dataclass
@@ -273,6 +281,10 @@ class BeamSearchEngine:
             else CompactGameTree(initial_capacity=config.initial_tree_capacity)
         )
         self._rng = random.Random(config.random_seed)
+        self._counters = SearchEventCounters()
+        self._root_dedup_hits = 0
+        self._elapsed_ms = 0
+        self._seed = config.random_seed
 
     def search(self, initial_state: State) -> BeamSearchResult:
         """Run beam search from `initial_state`.
@@ -289,6 +301,10 @@ class BeamSearchEngine:
                 legal moves.
         """
         root_player = self._require_non_terminal_root(initial_state)
+
+        self._counters = SearchEventCounters()
+        self._root_dedup_hits = 0
+        _start = time.monotonic()
 
         root_id = self.tree.create_root_node(initial_state)
         stats: Dict[str, int] = {
@@ -321,6 +337,7 @@ class BeamSearchEngine:
             frontier = self._score_and_prune(candidates, stats, beam_width, rollouts)
             max_depth_reached = depth
 
+        self._elapsed_ms = int(round((time.monotonic() - _start) * 1000))
         stats["memory_usage"] = self.tree.memory_usage()
 
         def root_perspective(leaf: BeamLeaf) -> float:
@@ -402,6 +419,7 @@ class BeamSearchEngine:
         candidates: Dict[bytes, _Candidate] = {}
 
         for node_id, bb, moves, _, multiplicity in frontier:
+            self._counters.expanded_nodes += 1
             current_player, moves_by_shape = generate_legal_moves(bb)
             all_moves = [
                 m for shape_moves in moves_by_shape.values() for m in shape_moves
@@ -425,6 +443,7 @@ class BeamSearchEngine:
                         multiplicity=multiplicity,
                     )
                 )
+                self._counters.terminal_hits += 1
                 continue
 
             stats["candidates_generated"] += len(all_moves)
@@ -465,6 +484,7 @@ class BeamSearchEngine:
         unaffected by it.
         """
         for move in all_moves:
+            self._counters.generated_nodes += 1
             new_bb: Bitboard = apply_move(bb, move)  # type: ignore[assignment]
             new_state = State(new_bb)
             child_moves = moves + (move,)
@@ -500,11 +520,15 @@ class BeamSearchEngine:
                         multiplicity=multiplicity,
                     )
                 )
+                self._counters.terminal_hits += 1
                 continue
 
             key = new_state.canonical_key()
             if key in candidates:
                 stats["candidates_deduped"] += 1
+                self._counters.canonical_dedup_hits += 1
+                if depth == 1:
+                    self._root_dedup_hits += 1
                 (
                     existing_node_id,
                     existing_bb,
@@ -627,3 +651,37 @@ class BeamSearchEngine:
             "memory_usage": self.tree.memory_usage(),
             "tree_stats": self.tree.get_stats(),
         }
+
+    def telemetry(self, result: BeamSearchResult) -> SearchTelemetry:
+        """Derive telemetry from a completed `BeamSearchResult`."""
+        root_moves: List[RootMoveStat] = []
+        for r in result.ranked_root_moves(None):
+            if r.has_terminal_win and r.best_value >= 1.0:
+                q = 1.0  # proven root-player win
+            else:
+                # Includes proven losses (best_value == -1.0 with no loss flag):
+                # conservatively reported as -UNPROVEN_VALUE_BOUND.
+                q = clamp_unproven(r.best_value)
+            root_moves.append(RootMoveStat.from_move(r.move, r.total_multiplicity, q))
+
+        best = result.best_leaf
+        if best is None:
+            root_value = 0.0
+            pv: List[Move] = []
+        else:
+            v = best.value if result.root_player == 0 else -best.value
+            root_value = v if best.is_terminal else clamp_unproven(v)
+            pv = list(best.moves)
+
+        return SearchTelemetry(
+            engine_kind=EngineKind.BEAM,
+            root_value=root_value,
+            policy_mass_kind=PolicyMassKind.MULTIPLICITY,
+            root_moves=root_moves,
+            root_identity_preserved=self._root_dedup_hits == 0,
+            principal_variation=pv,
+            counters=self._counters,
+            elapsed_ms=self._elapsed_ms,
+            depth_reached=result.max_depth_reached,
+            seed=self._seed,
+        )

--- a/src/quantik_core/mcts.py
+++ b/src/quantik_core/mcts.py
@@ -8,7 +8,7 @@ integration into the compact game tree structure.
 import math
 import random
 import time
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 from dataclasses import dataclass
 import numpy as np
 
@@ -19,10 +19,19 @@ from quantik_core.game_utils import check_game_winner, has_winning_line, WinStat
 from quantik_core.move import generate_legal_moves_list
 from quantik_core.memory.compact_tree import (
     CompactGameTree,
+    CompactGameTreeNode,
     NODE_FLAG_TERMINAL,
     NODE_FLAG_WINNING_P0,
     NODE_FLAG_WINNING_P1,
     NODE_FLAG_EXPANDED,
+)
+from quantik_core.search_telemetry import (
+    EngineKind,
+    PolicyMassKind,
+    RootMoveStat,
+    SearchEventCounters,
+    SearchTelemetry,
+    clamp_unproven,
 )
 
 
@@ -78,6 +87,10 @@ class MCTSEngine:
         self.tree = CompactGameTree(initial_capacity=100_000)
         self.root_id: Optional[int] = None
         self.iterations_performed = 0
+        self._counters = SearchEventCounters()
+        self._elapsed_ms = 0
+        self._max_depth_reached = 0
+        self._searched = False
 
     def search(self, initial_state: State) -> Tuple[Move, float]:
         """
@@ -92,6 +105,11 @@ class MCTSEngine:
         # Create or find root node
         self.root_id = self.tree.create_root_node(initial_state)
         self.iterations_performed = 0
+        self._counters = SearchEventCounters()
+        self._max_depth_reached = 0
+        self._searched = True
+        self._counters.expanded_nodes += 1  # root node created
+        _start = time.monotonic()
 
         deadline = (
             time.monotonic() + self.config.time_limit_s
@@ -121,6 +139,8 @@ class MCTSEngine:
 
             if deadline is not None and time.monotonic() >= deadline:
                 break
+
+        self._elapsed_ms = int(round((time.monotonic() - _start) * 1000))
 
         # Extract best move
         return self._get_best_move()
@@ -239,6 +259,7 @@ class MCTSEngine:
 
             node.flags = np.uint8(flags)
             self.tree.storage.store_node(node_id, node)
+            self._counters.terminal_hits += 1
             return None
 
         # Generate legal moves
@@ -257,6 +278,7 @@ class MCTSEngine:
                 node.flags = np.uint8(node.flags | NODE_FLAG_WINNING_P0)
                 node.terminal_value = np.float32(1.0)
             self.tree.storage.store_node(node_id, node)
+            self._counters.terminal_hits += 1
             return None
 
         # Get existing children to find unvisited move
@@ -272,12 +294,13 @@ class MCTSEngine:
             new_state = State(new_bb)
 
             if new_state.canonical_key() not in existing_states:
-                # Add this child
+                nodes_before = self.tree.storage.node_count
                 child_id = self.tree.add_child_node(
                     node_id,
                     new_state,
                     use_transposition_table=self.config.use_transposition_table,
                 )
+                self._count_child_addition(child_id, nodes_before)
 
                 # Mark parent as expanded if all moves tried
                 if len(existing_children) + 1 == len(all_moves):
@@ -290,6 +313,19 @@ class MCTSEngine:
         node.flags = np.uint8(node.flags | NODE_FLAG_EXPANDED)
         self.tree.storage.store_node(node_id, node)
         return None
+
+    def _count_child_addition(self, child_id: int, nodes_before: int) -> None:
+        """Update event counters after `add_child_node` (instrumentation only)."""
+        if self.tree.storage.node_count > nodes_before:
+            # A fresh successor state was constructed and retained.
+            self._counters.expanded_nodes += 1
+            self._counters.generated_nodes += 1
+            child_depth = int(self.tree.get_node(child_id).depth)
+            self._max_depth_reached = max(self._max_depth_reached, child_depth)
+        elif self.config.use_transposition_table:
+            # add_child_node reused an existing node: a cached subtree
+            # was reused via state-keyed lookup.
+            self._counters.transposition_hits += 1
 
     def _select_rollout_move(
         self, bb: Bitboard, current_player: int, all_moves: List[Move]
@@ -480,6 +516,132 @@ class MCTSEngine:
 
         # Fallback (should not happen)
         return all_moves[0], 0.5
+
+    def telemetry(self) -> Optional[SearchTelemetry]:
+        """Derive a `SearchTelemetry` from the completed root search.
+
+        Returns None before any search, or when the root has no children.
+        """
+        if not self._searched or self.root_id is None:
+            return None
+        root = self.tree.get_node(self.root_id)
+        root_state = self.tree.get_state(self.root_id)
+        children = self.tree.get_children(self.root_id)
+        if not children:
+            return None
+        mover = int(root.player_turn)
+
+        legal = generate_legal_moves_list(root_state.bb)
+        # First legal move that reaches each canonical child (root_identity
+        # preserved => this mapping is injective).
+        key_to_move: Dict[bytes, Move] = {}
+        child_keys = []
+        for mv in legal:
+            key = State(apply_move(root_state.bb, mv)).canonical_key()
+            child_keys.append(key)
+            key_to_move.setdefault(key, mv)
+
+        root_identity_preserved = not self.config.use_transposition_table and len(
+            set(child_keys)
+        ) == len(legal)
+
+        root_moves = []
+        for child_id in children:
+            child = self.tree.get_node(child_id)
+            ckey = self.tree.get_state(child_id).canonical_key()
+            matched_mv = key_to_move.get(ckey)
+            if matched_mv is None:
+                continue
+            root_moves.append(
+                RootMoveStat.from_move(
+                    matched_mv, int(child.visit_count), self._child_q(child, mover)
+                )
+            )
+
+        return SearchTelemetry(
+            engine_kind=EngineKind.MCTS,
+            root_value=self._root_value(children, mover),
+            policy_mass_kind=PolicyMassKind.VISITS,
+            root_moves=root_moves,
+            root_identity_preserved=root_identity_preserved,
+            principal_variation=self._principal_variation(),
+            counters=self._counters,
+            elapsed_ms=self._elapsed_ms,
+            depth_reached=self._max_depth_reached,
+            seed=self.config.random_seed,
+        )
+
+    def _child_q(self, child: CompactGameTreeNode, mover: int) -> Optional[float]:
+        """Root-player q_value for a root child; exact +/-1.0 iff terminal."""
+        if int(child.flags) & NODE_FLAG_TERMINAL:
+            tv = float(child.terminal_value)  # P0 perspective
+            return tv if mover == 0 else -tv
+        if int(child.visit_count) == 0:
+            return None
+        wins = int(child.win_count_p0) if mover == 0 else int(child.win_count_p1)
+        p = wins / int(child.visit_count)
+        return clamp_unproven(2.0 * p - 1.0)
+
+    def _root_value(self, children: List[int], mover: int) -> float:
+        """Value of the most-visited root child (Robust-child), root
+        perspective; exact +/-1.0 iff that child is terminal."""
+        best_id = children[0]
+        best_visits = -1
+        for child_id in children:
+            v = int(self.tree.get_node(child_id).visit_count)
+            if v > best_visits:
+                best_visits = v
+                best_id = child_id
+        best = self.tree.get_node(best_id)
+        if int(best.flags) & NODE_FLAG_TERMINAL:
+            tv = float(best.terminal_value)
+            return tv if mover == 0 else -tv
+        if int(best.visit_count) == 0:
+            return 0.0
+        wins = int(best.win_count_p0) if mover == 0 else int(best.win_count_p1)
+        return clamp_unproven(2.0 * (wins / int(best.visit_count)) - 1.0)
+
+    def _principal_variation(self) -> List[Move]:
+        """Max-visit descent from the root; ties break on lowest action index.
+        Bounded by 16 plies (a full game)."""
+        pv: List[Move] = []
+        node_id = self.root_id
+        for _ in range(16):
+            if node_id is None:
+                break
+            children = self.tree.get_children(node_id)
+            if not children:
+                break
+            node_state = self.tree.get_state(node_id)
+            key_to_move: Dict[bytes, Move] = {}
+            for mv in generate_legal_moves_list(node_state.bb):
+                key = State(apply_move(node_state.bb, mv)).canonical_key()
+                key_to_move.setdefault(key, mv)
+            candidates = []
+            for child_id in children:
+                child = self.tree.get_node(child_id)
+                if int(child.visit_count) == 0:
+                    continue
+                ckey = self.tree.get_state(child_id).canonical_key()
+                matched_mv = key_to_move.get(ckey)
+                if matched_mv is None:
+                    continue
+                # sort key: most visits first, then lowest action index
+                candidates.append(
+                    (
+                        -int(child.visit_count),
+                        matched_mv.shape * 16 + matched_mv.position,
+                        child_id,
+                        matched_mv,
+                    )
+                )
+            if not candidates:
+                break
+            candidates.sort()
+            _, _, best_child_id, best_mv = candidates[0]
+            pv.append(best_mv)
+            node_id = best_child_id
+        return pv
 
     def get_statistics(self) -> dict:
         """Get MCTS statistics."""

--- a/src/quantik_core/mcts.py
+++ b/src/quantik_core/mcts.py
@@ -108,7 +108,9 @@ class MCTSEngine:
         self._counters = SearchEventCounters()
         self._max_depth_reached = 0
         self._searched = True
-        self._counters.expanded_nodes += 1  # root node created
+        # expanded_nodes is counted where a node's successor set is actually
+        # computed (inside _expand), not at node creation -- creating the root
+        # node enumerates nothing yet.
         _start = time.monotonic()
 
         deadline = (
@@ -268,6 +270,10 @@ class MCTSEngine:
         for shape_moves in moves_by_shape.values():
             all_moves.extend(shape_moves)
 
+        # The node's successor set was just computed, so it is expanded --
+        # including the no-legal-moves case below, which is then also terminal.
+        self._counters.expanded_nodes += 1
+
         if not all_moves:
             # No legal moves - the player who cannot move loses (opponent wins)
             node.flags = np.uint8(node.flags | NODE_FLAG_TERMINAL)
@@ -292,6 +298,10 @@ class MCTSEngine:
         for move in all_moves:
             new_bb = apply_move(state.bb, move)
             new_state = State(new_bb)
+            # A successor state was constructed for this candidate move; count
+            # it whether or not it is retained (already-visited moves are
+            # re-derived here on each _expand pass).
+            self._counters.generated_nodes += 1
 
             if new_state.canonical_key() not in existing_states:
                 nodes_before = self.tree.storage.node_count
@@ -315,11 +325,16 @@ class MCTSEngine:
         return None
 
     def _count_child_addition(self, child_id: int, nodes_before: int) -> None:
-        """Update event counters after `add_child_node` (instrumentation only)."""
+        """Track tree depth and transposition reuse after `add_child_node`.
+
+        The move-generation (`expanded_nodes`) and successor-construction
+        (`generated_nodes`) events are counted at their own sites in `_expand`;
+        this hook only records the retained child's depth and flags a
+        transposition-table reuse, keeping each event localized to the code
+        path where it occurs.
+        """
         if self.tree.storage.node_count > nodes_before:
-            # A fresh successor state was constructed and retained.
-            self._counters.expanded_nodes += 1
-            self._counters.generated_nodes += 1
+            # A fresh successor node was retained; track tree depth.
             child_depth = int(self.tree.get_node(child_id).depth)
             self._max_depth_reached = max(self._max_depth_reached, child_depth)
         elif self.config.use_transposition_table:

--- a/src/quantik_core/minimax.py
+++ b/src/quantik_core/minimax.py
@@ -233,6 +233,11 @@ class MinimaxEngine:
         root_moves = generate_legal_moves_list(bb)
         if not root_moves:
             raise ValueError("Cannot search from a state with no legal moves.")
+        # The root's successor set is computed once here and reused across every
+        # iterative-deepening pass, so count the root expansion exactly once
+        # (not per depth). Interior nodes regenerate their moves on each visit
+        # and are counted in `_negamax`.
+        self._counters.expanded_nodes += 1
 
         result: Optional[MinimaxResult] = None
         for depth in range(1, self.config.max_depth + 1):
@@ -294,7 +299,6 @@ class MinimaxEngine:
         """
         ordered = self._order_root_moves(moves)
         children = _children(bb, ordered, self.config.dedup_children)
-        self._counters.expanded_nodes += 1
         self._counters.generated_nodes += len(ordered)
         if self.config.dedup_children:
             self._counters.canonical_dedup_hits += len(ordered) - len(children)
@@ -355,6 +359,10 @@ class MinimaxEngine:
             return -(win - ply)
 
         moves = generate_legal_moves_list(bb)
+        # The successor set was just computed, so this node is expanded --
+        # including the no-legal-moves case below (which is then ALSO terminal)
+        # and the depth-0 leaf case, which returns before any child is built.
+        self._counters.expanded_nodes += 1
         if not moves:
             # No legal moves: the side to move also loses.
             self._counters.terminal_hits += 1
@@ -396,7 +404,6 @@ class MinimaxEngine:
 
         ordered = sorted(moves, key=_move_sort_key)
         children = _children(bb, ordered, self.config.dedup_children)
-        self._counters.expanded_nodes += 1
         self._counters.generated_nodes += len(ordered)
         if self.config.dedup_children:
             self._counters.canonical_dedup_hits += len(ordered) - len(children)

--- a/src/quantik_core/minimax.py
+++ b/src/quantik_core/minimax.py
@@ -49,6 +49,26 @@ from .evaluation import EvalConfig, evaluate
 from .game_utils import count_total_pieces, get_current_player_from_counts
 from .game_utils import has_winning_line
 from .move import Move, apply_move, generate_legal_moves_list
+from .search_telemetry import (
+    EngineKind,
+    PolicyMassKind,
+    RootMoveStat,
+    SearchEventCounters,
+    SearchTelemetry,
+)
+
+
+def minimax_q_from_score(score: float, win: float) -> float:
+    """Map a negamax score (root-player perspective) into [-1, 1].
+
+    Proven results (mate scores, |score| >= win - 16) map to exactly +/-1.0;
+    heuristic scores squash smoothly into (-1, 1) via score / (1 + |score|).
+    """
+    if score >= win - 16.0:
+        return 1.0
+    if score <= -(win - 16.0):
+        return -1.0
+    return score / (1.0 + abs(score))
 
 
 class Bound(IntEnum):
@@ -152,6 +172,12 @@ class MinimaxEngine:
             else None
         )
         self._pv_hint: List[Move] = []
+        self._counters = SearchEventCounters()
+        self._last_root_scored: List[Tuple[Move, float]] = []
+        self._last_root_value = 0.0
+        self._last_pv: List[Move] = []
+        self._last_depth = 0
+        self._last_elapsed_ms = 0
 
     def solve(self, state: State) -> MinimaxResult:
         """Exact solve: `search` with `max_depth=16` and no time limit.
@@ -191,6 +217,12 @@ class MinimaxEngine:
         self._nodes = 0
         self._tt = {}
         self._pv_hint = []
+        self._counters = SearchEventCounters()
+        self._last_root_scored = []
+        self._last_root_value = 0.0
+        self._last_pv = []
+        self._last_depth = 0
+        self._last_elapsed_ms = 0
         self._deadline = (
             start + self.config.time_limit_s
             if self.config.time_limit_s is not None
@@ -209,6 +241,9 @@ class MinimaxEngine:
             except _TimeUp:
                 break
             self._pv_hint = pv
+            self._last_pv = pv
+            self._last_depth = depth
+            self._last_elapsed_ms = int(round((time.monotonic() - start) * 1000))
             result = MinimaxResult(
                 best_move=best_move,
                 score=score,
@@ -259,6 +294,10 @@ class MinimaxEngine:
         """
         ordered = self._order_root_moves(moves)
         children = _children(bb, ordered, self.config.dedup_children)
+        self._counters.expanded_nodes += 1
+        self._counters.generated_nodes += len(ordered)
+        if self.config.dedup_children:
+            self._counters.canonical_dedup_hits += len(ordered) - len(children)
 
         best_value = float("-inf")
         scored: List[Tuple[Move, float, List[Move]]] = []
@@ -276,6 +315,8 @@ class MinimaxEngine:
         move, child_pv = (
             self._rng.choice(candidates) if self._rng is not None else candidates[0]
         )
+        self._last_root_scored = [(m, v) for m, v, _ in scored]
+        self._last_root_value = best_value
         return best_value, move, [move, *child_pv]
 
     def _check_time(self) -> None:
@@ -310,11 +351,13 @@ class MinimaxEngine:
             # The previous mover completed a line: the side to move here
             # has just lost. `ply` makes a sooner loss/win score more
             # extremely than a deeper one (shallower mates score higher).
+            self._counters.terminal_hits += 1
             return -(win - ply)
 
         moves = generate_legal_moves_list(bb)
         if not moves:
             # No legal moves: the side to move also loses.
+            self._counters.terminal_hits += 1
             return -(win - ply)
 
         if depth == 0:
@@ -334,6 +377,7 @@ class MinimaxEngine:
                 stored_depth, stored_value, bound = entry
                 if stored_depth >= depth:
                     if bound == Bound.EXACT:
+                        self._counters.transposition_hits += 1
                         return stored_value
                     # LOWER/UPPER entries only narrow the window (and can
                     # trigger the early-return cutoff below) when
@@ -347,10 +391,15 @@ class MinimaxEngine:
                         elif bound == Bound.UPPER:
                             beta = min(beta, stored_value)
                         if alpha >= beta:
+                            self._counters.transposition_hits += 1
                             return stored_value
 
         ordered = sorted(moves, key=_move_sort_key)
         children = _children(bb, ordered, self.config.dedup_children)
+        self._counters.expanded_nodes += 1
+        self._counters.generated_nodes += len(ordered)
+        if self.config.dedup_children:
+            self._counters.canonical_dedup_hits += len(ordered) - len(children)
         # Move ordering: try immediate winning replies first. A move that
         # completes a line makes this node a forced win (child is terminal,
         # value -(win-ply) negated to +(win-ply)), so exploring it first
@@ -395,3 +444,28 @@ class MinimaxEngine:
             self._tt[tt_key] = (depth, best_value, bound)
 
         return best_value
+
+    def telemetry(self) -> Optional[SearchTelemetry]:
+        """Derive telemetry from the last completed root search.
+
+        Returns None before any search completes.
+        """
+        if not self._last_root_scored:
+            return None
+        win = self.config.eval_config.win
+        root_moves = [
+            RootMoveStat.from_move(mv, 0, minimax_q_from_score(score, win))
+            for mv, score in self._last_root_scored
+        ]
+        return SearchTelemetry(
+            engine_kind=EngineKind.MINIMAX,
+            root_value=minimax_q_from_score(self._last_root_value, win),
+            policy_mass_kind=PolicyMassKind.NONE,
+            root_moves=root_moves,
+            root_identity_preserved=not self.config.dedup_children,
+            principal_variation=list(self._last_pv),
+            counters=self._counters,
+            elapsed_ms=self._last_elapsed_ms,
+            depth_reached=self._last_depth,
+            seed=self.config.random_seed,
+        )

--- a/src/quantik_core/search_summary.py
+++ b/src/quantik_core/search_summary.py
@@ -50,8 +50,11 @@ def search_summary_row(
 
     Skips (returns None) rows whose telemetry has
     root_identity_preserved == False -- a legitimate skip, not an error.
-    Raises ValueError for an out-of-range action_index (>= 64), matching the
-    Rust exporter's Err.
+    Raises ValueError for an action_index outside [0, 64), matching the Rust
+    exporter's Err. Unlike Rust (whose action_index is an unsigned u8, so a
+    ``>= 64`` check suffices), Python's action_index is a signed int: a
+    negative value would silently index policy_visits/root_q_values from the
+    end and corrupt the row, so the lower bound must be checked too.
     """
     if not telemetry.root_identity_preserved:
         return None
@@ -65,9 +68,9 @@ def search_summary_row(
     root_q_values: List[Optional[float]] = [None] * 64
     for stat in telemetry.root_moves:
         idx = stat.action_index
-        if idx >= 64:
+        if idx < 0 or idx >= 64:
             raise ValueError(
-                f"root move action_index {idx} out of range (must be < 64)"
+                f"root move action_index {idx} out of range (must be in [0, 64))"
             )
         policy_visits[idx] = stat.policy_mass
         if stat.q_value is not None:

--- a/src/quantik_core/search_summary.py
+++ b/src/quantik_core/search_summary.py
@@ -1,0 +1,114 @@
+"""Draft `search-summary.v1-draft` JSONL exporter.
+
+Mirrors `quantik-core-rust`'s `bench::contracts::search_summary_row`
+field-for-field. This is a DRAFT surface: the schema label is
+`search-summary.v1-draft` and the stable `search-summary.v1` label MUST NOT be
+emitted until the contract is registered in quantik-core-contracts.
+"""
+
+from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, version
+from typing import List, Optional
+
+from .artifact_data import _legal_action_mask
+from .core import State
+from .game_utils import count_total_pieces, get_current_player_from_counts
+from .search_telemetry import SearchTelemetry
+
+# Draft, unstable schema for per-search-call telemetry rows. NOT added to
+# contracts.SUPPORTED_CONTRACTS -- this is a draft surface, not a stabilized
+# cross-repository contract.
+SEARCH_SUMMARY_DRAFT_SCHEMA = "search-summary.v1-draft"
+SEARCH_SUMMARY_CONTRACT_VERSION = "1.1.0"
+
+try:
+    _ENGINE_VERSION = version("quantik-core")
+except PackageNotFoundError:  # pragma: no cover
+    _ENGINE_VERSION = "0+editable"
+
+
+@dataclass
+class SearchSummaryRunConfig:
+    """Engine run configuration echoed into a row; None fields map to null."""
+
+    config_label: str
+    search_depth: Optional[int] = None
+    rollouts: Optional[int] = None
+    beam_width: Optional[int] = None
+    node_budget: Optional[int] = None
+    time_budget_ms: Optional[int] = None
+
+
+def search_summary_row(
+    row_id: int,
+    run_id: str,
+    qfen: str,
+    telemetry: SearchTelemetry,
+    run_config: SearchSummaryRunConfig,
+) -> Optional[dict]:
+    """Build one draft row, or None when root identity was not preserved.
+
+    Skips (returns None) rows whose telemetry has
+    root_identity_preserved == False -- a legitimate skip, not an error.
+    Raises ValueError for an out-of-range action_index (>= 64), matching the
+    Rust exporter's Err.
+    """
+    if not telemetry.root_identity_preserved:
+        return None
+
+    state = State.from_qfen(qfen)
+    bb = state.bb
+    p0, p1 = count_total_pieces(bb)
+    side_to_move = get_current_player_from_counts(p0, p1)
+
+    policy_visits: List[int] = [0] * 64
+    root_q_values: List[Optional[float]] = [None] * 64
+    for stat in telemetry.root_moves:
+        idx = stat.action_index
+        if idx >= 64:
+            raise ValueError(
+                f"root move action_index {idx} out of range (must be < 64)"
+            )
+        policy_visits[idx] = stat.policy_mass
+        if stat.q_value is not None:
+            root_q_values[idx] = stat.q_value
+
+    principal_variation = [
+        mv.shape * 16 + mv.position for mv in telemetry.principal_variation
+    ]
+
+    return {
+        "schema": SEARCH_SUMMARY_DRAFT_SCHEMA,
+        "contract_version": SEARCH_SUMMARY_CONTRACT_VERSION,
+        "run_id": run_id,
+        "row_id": row_id,
+        "position_key": state.canonical_key().hex(),
+        "ply": p0 + p1,
+        "side_to_move": side_to_move,
+        "bitboards": list(bb),
+        "qfen": qfen,
+        "legal_action_mask": _legal_action_mask(bb),
+        "engine_kind": telemetry.engine_kind.as_str(),
+        "engine_version": _ENGINE_VERSION,
+        "engine_checkpoint": None,
+        "config_label": run_config.config_label,
+        "search_depth": run_config.search_depth,
+        "rollouts": run_config.rollouts,
+        "beam_width": run_config.beam_width,
+        "node_budget": run_config.node_budget,
+        "time_budget_ms": run_config.time_budget_ms,
+        "seed": telemetry.seed,
+        "root_value": telemetry.root_value,
+        "policy_mass_kind": telemetry.policy_mass_kind.as_str(),
+        "policy_visits": policy_visits,
+        "root_q_values": root_q_values,
+        "principal_variation": principal_variation,
+        "expanded_nodes": telemetry.counters.expanded_nodes,
+        "generated_nodes": telemetry.counters.generated_nodes,
+        "transposition_hits": telemetry.counters.transposition_hits,
+        "canonical_dedup_hits": telemetry.counters.canonical_dedup_hits,
+        "terminal_hits": telemetry.counters.terminal_hits,
+        "tablebase_hits": telemetry.counters.tablebase_hits,
+        "elapsed_ms": telemetry.elapsed_ms,
+        "depth_reached": telemetry.depth_reached,
+    }

--- a/src/quantik_core/search_telemetry.py
+++ b/src/quantik_core/search_telemetry.py
@@ -1,0 +1,111 @@
+"""Shared data types for search telemetry emitted by the MCTS, beam, and
+minimax engines.
+
+These definitions mirror `quantik-core-rust`'s
+`crates/quantik-core/src/search_telemetry.rs` and are normative for both
+stacks (see `docs/search-telemetry.md`).
+
+Six event counters (`SearchEventCounters`):
+
+- ``expanded_nodes``  -- a state's successor set was computed by the search.
+- ``generated_nodes`` -- a successor state was constructed.
+- ``transposition_hits`` -- a cached search result or subtree was reused via
+  state-keyed lookup instead of being searched again.
+- ``canonical_dedup_hits`` -- a generated state was merged with, or skipped in
+  favor of, an already-present duplicate, without reusing any search result.
+- ``terminal_hits`` -- a state was determined terminal during tree search.
+  Rollout outcomes are excluded in every engine.
+- ``tablebase_hits`` -- always 0 until an external probe artifact exists.
+
+Value invariant: every ``root_value`` and ``RootMoveStat.q_value`` lies in
+``[-1.0, 1.0]``, positive is good for the root player, and exact ``+/-1.0`` is
+reserved for proven results. Unproven (sampled/heuristic) estimates are clamped
+to ``[-UNPROVEN_VALUE_BOUND, UNPROVEN_VALUE_BOUND]`` via ``clamp_unproven``.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+
+from .move import Move
+
+# Largest magnitude an UNPROVEN (sampled/heuristic) value may take. Exact
+# +/-1.0 is reserved for proven results (terminal nodes, mates).
+UNPROVEN_VALUE_BOUND: float = 1.0 - 1e-6
+
+
+def clamp_unproven(v: float) -> float:
+    """Clamp a sampled/heuristic estimate into the proven-exclusive range."""
+    return max(-UNPROVEN_VALUE_BOUND, min(UNPROVEN_VALUE_BOUND, v))
+
+
+class EngineKind(Enum):
+    """Which engine produced a `SearchTelemetry`."""
+
+    MCTS = "mcts"
+    BEAM = "beam"
+    MINIMAX = "minimax"
+
+    def as_str(self) -> str:
+        return self.value
+
+
+class PolicyMassKind(Enum):
+    """What `policy_mass` means for this engine's `RootMoveStat`s."""
+
+    VISITS = "visits"
+    MULTIPLICITY = "multiplicity"
+    NONE = "none"
+
+    def as_str(self) -> str:
+        return self.value
+
+
+@dataclass
+class SearchEventCounters:
+    """The six event counters; each field carries its normative definition
+    from the module docstring."""
+
+    expanded_nodes: int = 0
+    generated_nodes: int = 0
+    transposition_hits: int = 0
+    canonical_dedup_hits: int = 0
+    terminal_hits: int = 0
+    tablebase_hits: int = 0
+
+
+@dataclass
+class RootMoveStat:
+    """Per-root-move statistics."""
+
+    mv: Move
+    action_index: int  # shape * 16 + position (action-index.v1)
+    policy_mass: int  # semantics per PolicyMassKind; 0 when NONE
+    q_value: Optional[float]  # [-1, 1] root-player perspective; None if unknown
+
+    @classmethod
+    def from_move(
+        cls, mv: Move, policy_mass: int, q_value: Optional[float]
+    ) -> "RootMoveStat":
+        return cls(
+            mv=mv,
+            action_index=mv.shape * 16 + mv.position,
+            policy_mass=policy_mass,
+            q_value=q_value,
+        )
+
+
+@dataclass
+class SearchTelemetry:
+    """One telemetry record for one completed root search."""
+
+    engine_kind: EngineKind
+    root_value: float
+    policy_mass_kind: PolicyMassKind
+    root_moves: List[RootMoveStat]
+    root_identity_preserved: bool
+    principal_variation: List[Move]
+    counters: SearchEventCounters = field(default_factory=SearchEventCounters)
+    elapsed_ms: int = 0
+    depth_reached: int = 0
+    seed: Optional[int] = None

--- a/tests/test_beam_telemetry.py
+++ b/tests/test_beam_telemetry.py
@@ -1,0 +1,50 @@
+"""Telemetry tests for BeamSearchEngine."""
+
+from quantik_core import State
+from quantik_core.beam_search import BeamSearchConfig, BeamSearchEngine
+from quantik_core.search_telemetry import (
+    UNPROVEN_VALUE_BOUND,
+    EngineKind,
+    PolicyMassKind,
+)
+
+
+def test_beam_telemetry_shape_and_counters() -> None:
+    state = State.from_qfen("A.bC/..../d..B/...a")
+    engine = BeamSearchEngine(BeamSearchConfig(random_seed=20260716))
+    result = engine.search(state)
+    t = engine.telemetry(result)
+    assert t.engine_kind is EngineKind.BEAM
+    assert t.policy_mass_kind is PolicyMassKind.MULTIPLICITY
+    assert t.counters.transposition_hits == 0
+    assert t.counters.tablebase_hits == 0
+    assert t.counters.expanded_nodes > 0
+    assert t.counters.generated_nodes > 0
+    assert t.depth_reached == result.max_depth_reached
+    assert -1.0 <= t.root_value <= 1.0
+    for stat in t.root_moves:
+        assert stat.policy_mass >= 1  # total_multiplicity
+        assert stat.q_value is not None
+        assert -1.0 <= stat.q_value <= 1.0
+
+
+def test_beam_root_identity_tracks_depth1_dedup() -> None:
+    # Empty board: the 64 legal first moves collapse onto canonical
+    # representatives, so depth-1 dedup MUST occur and identity MUST be
+    # reported as not preserved. This is deterministic (canonical keys do
+    # not depend on the seed).
+    engine = BeamSearchEngine(BeamSearchConfig(random_seed=20260716))
+    result = engine.search(State.empty())
+    t = engine.telemetry(result)
+    assert t.counters.canonical_dedup_hits > 0
+    assert t.root_identity_preserved is False
+
+
+def test_beam_non_terminal_values_stay_within_unproven_bound() -> None:
+    state = State.from_qfen("A.bC/..../d..B/...a")
+    engine = BeamSearchEngine(BeamSearchConfig(random_seed=20260716))
+    result = engine.search(state)
+    t = engine.telemetry(result)
+    for stat in t.root_moves:
+        if stat.q_value is not None and abs(stat.q_value) != 1.0:
+            assert abs(stat.q_value) <= UNPROVEN_VALUE_BOUND

--- a/tests/test_mcts_telemetry.py
+++ b/tests/test_mcts_telemetry.py
@@ -62,6 +62,44 @@ def test_telemetry_identity_preserved_on_asymmetric_position() -> None:
         assert len(keys) == len(legal)
 
 
+def test_mcts_expanded_counted_once_per_expand_not_at_root_creation() -> None:
+    # One iteration expands the root exactly once (its successor set is computed
+    # in _expand) and constructs one successor state, so expanded == 1 and
+    # generated == 1. Before the fix the root increment fired at node creation
+    # (before any enumeration) AND again in _count_child_addition, giving 2.
+    state = State.from_qfen("A.bC/..../d..B/...a")
+    engine = MCTSEngine(
+        MCTSConfig(
+            max_iterations=1, random_seed=20260716, use_transposition_table=False
+        )
+    )
+    engine.search(state)
+    t = engine.telemetry()
+    assert t is not None
+    assert t.counters.expanded_nodes == 1
+    assert t.counters.generated_nodes == 1
+
+
+def test_mcts_generated_counts_every_constructed_successor() -> None:
+    # Two iterations both expand the root (K > 1 legal moves, so it is never
+    # flagged fully expanded after one child). The second _expand re-derives
+    # the already-visited child's state before constructing the new one, so
+    # generated counts BOTH constructions: expanded == 2, generated == 3.
+    # Before the fix, generated only counted retained children (== 2) and
+    # expanded double-counted at creation + retention (== 3).
+    state = State.from_qfen("A.bC/..../d..B/...a")
+    engine = MCTSEngine(
+        MCTSConfig(
+            max_iterations=2, random_seed=20260716, use_transposition_table=False
+        )
+    )
+    engine.search(state)
+    t = engine.telemetry()
+    assert t is not None
+    assert t.counters.expanded_nodes == 2
+    assert t.counters.generated_nodes == 3
+
+
 def test_telemetry_invariants_and_counters() -> None:
     state = State.from_qfen("A.bC/..../d..B/...a")
     engine = MCTSEngine(

--- a/tests/test_mcts_telemetry.py
+++ b/tests/test_mcts_telemetry.py
@@ -1,0 +1,93 @@
+"""Telemetry tests for MCTSEngine."""
+
+from quantik_core import State, apply_move, generate_legal_moves_list
+from quantik_core.mcts import MCTSConfig, MCTSEngine
+from quantik_core.search_telemetry import (
+    UNPROVEN_VALUE_BOUND,
+    EngineKind,
+    PolicyMassKind,
+)
+
+
+def _empty() -> State:
+    return State.empty()
+
+
+def test_telemetry_none_before_search() -> None:
+    engine = MCTSEngine(MCTSConfig(max_iterations=10, random_seed=1))
+    assert engine.telemetry() is None
+
+
+def test_telemetry_tt_off_empty_board_collapses_identity() -> None:
+    # Symmetric first moves collapse to distinct canonical children even with
+    # the transposition table off, so root identity is NOT preserved.
+    engine = MCTSEngine(
+        MCTSConfig(
+            max_iterations=200, random_seed=20260716, use_transposition_table=False
+        )
+    )
+    engine.search(_empty())
+    t = engine.telemetry()
+    assert t is not None
+    assert t.engine_kind is EngineKind.MCTS
+    assert t.policy_mass_kind is PolicyMassKind.VISITS
+    assert t.root_identity_preserved is False
+
+
+def test_telemetry_tt_on_empty_board_flags_identity_false() -> None:
+    engine = MCTSEngine(
+        MCTSConfig(max_iterations=200, random_seed=7, use_transposition_table=True)
+    )
+    engine.search(_empty())
+    t = engine.telemetry()
+    assert t is not None
+    assert t.root_identity_preserved is False
+
+
+def test_telemetry_identity_preserved_on_asymmetric_position() -> None:
+    # A mid-game position whose legal first moves all reach distinct canonical
+    # states preserves root identity (TT off).
+    state = State.from_qfen("A.bC/..../d..B/...a")
+    engine = MCTSEngine(
+        MCTSConfig(
+            max_iterations=200, random_seed=20260716, use_transposition_table=False
+        )
+    )
+    engine.search(state)
+    t = engine.telemetry()
+    assert t is not None
+    if t.root_identity_preserved:
+        legal = generate_legal_moves_list(state.bb)
+        keys = {State(apply_move(state.bb, m)).canonical_key() for m in legal}
+        assert len(keys) == len(legal)
+
+
+def test_telemetry_invariants_and_counters() -> None:
+    state = State.from_qfen("A.bC/..../d..B/...a")
+    engine = MCTSEngine(
+        MCTSConfig(
+            max_iterations=200, random_seed=20260716, use_transposition_table=False
+        )
+    )
+    engine.search(state)
+    t = engine.telemetry()
+    assert t is not None
+    assert t.counters.expanded_nodes > 0
+    assert t.counters.canonical_dedup_hits == 0  # structural for MCTS
+    assert t.counters.tablebase_hits == 0
+    assert t.counters.transposition_hits == 0  # TT off
+    assert -1.0 <= t.root_value <= 1.0
+    legal_mask = {
+        m.shape * 16 + m.position for m in generate_legal_moves_list(state.bb)
+    }
+    for stat in t.root_moves:
+        assert stat.action_index in legal_mask  # mass only on legal actions
+        if stat.q_value is not None:
+            assert -1.0 <= stat.q_value <= 1.0
+    # PV starts from the root's best move and is non-empty when moves exist.
+    assert t.principal_variation
+    assert len(t.principal_variation) <= 16
+    # Non-terminal sampled values never reach exact +/-1.0.
+    for stat in t.root_moves:
+        if stat.q_value is not None and abs(stat.q_value) != 1.0:
+            assert abs(stat.q_value) <= UNPROVEN_VALUE_BOUND

--- a/tests/test_minimax_telemetry.py
+++ b/tests/test_minimax_telemetry.py
@@ -73,4 +73,4 @@ def test_minimax_transposition_hits_with_tt_on() -> None:
     engine.search(state)
     t = engine.telemetry()
     assert t is not None
-    assert t.counters.transposition_hits >= 0  # non-negative; >0 when TT reused
+    assert t.counters.transposition_hits > 0  # TT must be reused on this fixture

--- a/tests/test_minimax_telemetry.py
+++ b/tests/test_minimax_telemetry.py
@@ -1,0 +1,76 @@
+"""Telemetry tests for MinimaxEngine."""
+
+from quantik_core import State
+from quantik_core.minimax import (
+    MinimaxConfig,
+    MinimaxEngine,
+    minimax_q_from_score,
+)
+from quantik_core.search_telemetry import EngineKind, PolicyMassKind
+
+
+def test_minimax_q_from_score_proven_and_squash() -> None:
+    win = 10_000.0
+    assert minimax_q_from_score(win - 1.0, win) == 1.0  # mate: proven win
+    assert minimax_q_from_score(-(win - 1.0), win) == -1.0  # proven loss
+    # heuristic scores squash strictly inside (-1, 1), sign-preserving
+    assert minimax_q_from_score(0.0, win) == 0.0
+    assert 0.0 < minimax_q_from_score(3.0, win) < 1.0
+    assert -1.0 < minimax_q_from_score(-3.0, win) < 0.0
+
+
+def test_telemetry_none_before_search() -> None:
+    engine = MinimaxEngine(MinimaxConfig(max_depth=2, dedup_children=False))
+    assert engine.telemetry() is None
+
+
+def test_minimax_telemetry_shape_and_counters() -> None:
+    state = State.from_qfen("A.bC/..../d..B/...a")
+    engine = MinimaxEngine(
+        MinimaxConfig(max_depth=4, dedup_children=False, random_seed=20260716)
+    )
+    engine.search(state)
+    t = engine.telemetry()
+    assert t is not None
+    assert t.engine_kind is EngineKind.MINIMAX
+    assert t.policy_mass_kind is PolicyMassKind.NONE
+    assert t.root_identity_preserved is True  # dedup off
+    assert t.counters.expanded_nodes > 0
+    assert t.counters.generated_nodes > 0
+    assert t.counters.tablebase_hits == 0
+    assert t.depth_reached == 4
+    assert -1.0 <= t.root_value <= 1.0
+    for stat in t.root_moves:
+        assert stat.policy_mass == 0
+        assert stat.q_value is not None
+        assert -1.0 <= stat.q_value <= 1.0
+    assert t.principal_variation
+    assert t.principal_variation[0] == t.root_moves[0].mv or True  # PV is legal
+
+
+def test_minimax_dedup_on_flags_identity_false() -> None:
+    state = State.empty()
+    engine = MinimaxEngine(
+        MinimaxConfig(max_depth=2, dedup_children=True, random_seed=1)
+    )
+    engine.search(state)
+    t = engine.telemetry()
+    assert t is not None
+    assert t.root_identity_preserved is False
+
+
+def test_minimax_transposition_hits_with_tt_on() -> None:
+    # A position reachable by two move orders yields TT reuse when the TT is on.
+    state = State.from_qfen("Ab../..c./...D/....")
+    engine = MinimaxEngine(
+        MinimaxConfig(
+            max_depth=6,
+            dedup_children=False,
+            use_transposition_table=True,
+            random_seed=1,
+        )
+    )
+    engine.search(state)
+    t = engine.telemetry()
+    assert t is not None
+    assert t.counters.transposition_hits >= 0  # non-negative; >0 when TT reused

--- a/tests/test_minimax_telemetry.py
+++ b/tests/test_minimax_telemetry.py
@@ -78,9 +78,7 @@ def test_minimax_expanded_counted_at_move_generation() -> None:
     state = State.empty()
     k = len(generate_legal_moves_list(state.bb))
     engine = MinimaxEngine(
-        MinimaxConfig(
-            max_depth=1, dedup_children=False, use_transposition_table=False
-        )
+        MinimaxConfig(max_depth=1, dedup_children=False, use_transposition_table=False)
     )
     engine.search(state)
     t = engine.telemetry()
@@ -95,9 +93,7 @@ def test_minimax_no_legal_moves_node_is_expanded_and_terminal() -> None:
     # normative counter semantics). A full single-shape board has no winning
     # line and no legal moves; negamax on it must bump both counters.
     engine = MinimaxEngine(
-        MinimaxConfig(
-            max_depth=2, dedup_children=False, use_transposition_table=False
-        )
+        MinimaxConfig(max_depth=2, dedup_children=False, use_transposition_table=False)
     )
     engine._counters = SearchEventCounters()
     engine._nodes = 0

--- a/tests/test_minimax_telemetry.py
+++ b/tests/test_minimax_telemetry.py
@@ -1,12 +1,18 @@
 """Telemetry tests for MinimaxEngine."""
 
 from quantik_core import State
+from quantik_core.core import State as CoreState
 from quantik_core.minimax import (
     MinimaxConfig,
     MinimaxEngine,
     minimax_q_from_score,
 )
-from quantik_core.search_telemetry import EngineKind, PolicyMassKind
+from quantik_core.move import generate_legal_moves_list
+from quantik_core.search_telemetry import (
+    EngineKind,
+    PolicyMassKind,
+    SearchEventCounters,
+)
 
 
 def test_minimax_q_from_score_proven_and_squash() -> None:
@@ -57,6 +63,50 @@ def test_minimax_dedup_on_flags_identity_false() -> None:
     t = engine.telemetry()
     assert t is not None
     assert t.root_identity_preserved is False
+
+
+def test_minimax_expanded_counted_at_move_generation() -> None:
+    # `expanded_nodes` is the "successor set was computed" event, so it fires
+    # once per `generate_legal_moves_list` call: once for the root moves, and
+    # once for every negamax node -- INCLUDING the depth-0 leaf children, which
+    # compute their successor set before the leaf evaluation short-circuits.
+    # A depth-1 search over K non-terminal root moves therefore yields
+    # expanded_nodes == K + 1 and generated_nodes == K (the root's K children
+    # are constructed once; the leaves construct nothing). Before the fix,
+    # expanded was counted at the `_children(...)` sites, so the depth-0 leaves
+    # were never counted and expanded_nodes was just 1.
+    state = State.empty()
+    k = len(generate_legal_moves_list(state.bb))
+    engine = MinimaxEngine(
+        MinimaxConfig(
+            max_depth=1, dedup_children=False, use_transposition_table=False
+        )
+    )
+    engine.search(state)
+    t = engine.telemetry()
+    assert t is not None
+    assert t.counters.expanded_nodes == k + 1
+    assert t.counters.generated_nodes == k
+
+
+def test_minimax_no_legal_moves_node_is_expanded_and_terminal() -> None:
+    # A no-legal-moves node computed its (empty) successor set before being
+    # ruled terminal, so it must be BOTH expanded and terminal (per the
+    # normative counter semantics). A full single-shape board has no winning
+    # line and no legal moves; negamax on it must bump both counters.
+    engine = MinimaxEngine(
+        MinimaxConfig(
+            max_depth=2, dedup_children=False, use_transposition_table=False
+        )
+    )
+    engine._counters = SearchEventCounters()
+    engine._nodes = 0
+    engine._deadline = None
+    no_moves_bb = CoreState((0xFFFF, 0, 0, 0, 0, 0, 0, 0)).bb
+    assert generate_legal_moves_list(no_moves_bb) == []
+    engine._negamax(no_moves_bb, 1, float("-inf"), float("inf"), 0, [], None)
+    assert engine._counters.terminal_hits == 1
+    assert engine._counters.expanded_nodes == 1
 
 
 def test_minimax_transposition_hits_with_tt_on() -> None:

--- a/tests/test_minimax_telemetry.py
+++ b/tests/test_minimax_telemetry.py
@@ -45,7 +45,7 @@ def test_minimax_telemetry_shape_and_counters() -> None:
         assert stat.q_value is not None
         assert -1.0 <= stat.q_value <= 1.0
     assert t.principal_variation
-    assert t.principal_variation[0] == t.root_moves[0].mv or True  # PV is legal
+    assert t.principal_variation[0] in {s.mv for s in t.root_moves}
 
 
 def test_minimax_dedup_on_flags_identity_false() -> None:

--- a/tests/test_search_summary.py
+++ b/tests/test_search_summary.py
@@ -85,6 +85,23 @@ def test_out_of_range_action_index_raises() -> None:
         search_summary_row(0, "r", "..../..../..../....", t, _run_config())
 
 
+def test_negative_action_index_raises() -> None:
+    # A negative action_index would otherwise silently index policy_visits /
+    # root_q_values from the end and corrupt the row; it must raise instead.
+    bad = RootMoveStat(mv=Move(0, 0, 0), action_index=-1, policy_mass=1, q_value=0.0)
+    t = SearchTelemetry(
+        engine_kind=EngineKind.MCTS,
+        root_value=0.0,
+        policy_mass_kind=PolicyMassKind.VISITS,
+        root_moves=[bad],
+        root_identity_preserved=True,
+        principal_variation=[],
+        counters=SearchEventCounters(),
+    )
+    with pytest.raises(ValueError):
+        search_summary_row(0, "r", "..../..../..../....", t, _run_config())
+
+
 def test_mcts_row_populates_policy_visits() -> None:
     # An asymmetric position preserves identity -> a row is emitted.
     qfen = "A.bC/..../d..B/...a"

--- a/tests/test_search_summary.py
+++ b/tests/test_search_summary.py
@@ -1,0 +1,112 @@
+"""Tests for the draft search-summary.v1-draft exporter."""
+
+import json
+
+import pytest
+
+from quantik_core import State
+from quantik_core.mcts import MCTSConfig, MCTSEngine
+from quantik_core.minimax import MinimaxConfig, MinimaxEngine
+from quantik_core.move import Move
+from quantik_core.search_summary import (
+    SEARCH_SUMMARY_CONTRACT_VERSION,
+    SEARCH_SUMMARY_DRAFT_SCHEMA,
+    SearchSummaryRunConfig,
+    search_summary_row,
+)
+from quantik_core.search_telemetry import (
+    EngineKind,
+    PolicyMassKind,
+    RootMoveStat,
+    SearchEventCounters,
+    SearchTelemetry,
+)
+
+
+def _run_config() -> SearchSummaryRunConfig:
+    return SearchSummaryRunConfig(config_label="test", search_depth=4)
+
+
+def test_draft_schema_label_is_exact() -> None:
+    assert SEARCH_SUMMARY_DRAFT_SCHEMA == "search-summary.v1-draft"
+    # The non-draft label must not appear anywhere in the module output.
+    assert "search-summary.v1" != SEARCH_SUMMARY_DRAFT_SCHEMA
+
+
+def test_row_shape_and_mask_consistency() -> None:
+    qfen = "..../..../..../...."
+    engine = MinimaxEngine(
+        MinimaxConfig(max_depth=4, dedup_children=False, random_seed=7)
+    )
+    engine.search(State.from_qfen(qfen))
+    t = engine.telemetry()
+    assert t is not None
+    row = search_summary_row(0, "run-test", qfen, t, _run_config())
+    assert row is not None
+    assert row["schema"] == SEARCH_SUMMARY_DRAFT_SCHEMA
+    assert row["contract_version"] == SEARCH_SUMMARY_CONTRACT_VERSION
+    assert row["engine_kind"] == "minimax"
+    assert len(row["policy_visits"]) == 64
+    assert len(row["root_q_values"]) == 64
+    # mass only on legal actions
+    mask = row["legal_action_mask"]
+    for i, v in enumerate(row["policy_visits"]):
+        if v > 0:
+            assert (mask >> i) & 1
+    # row is JSON-serializable (None -> null)
+    json.dumps(row)
+
+
+def test_skips_unpreserved_identity() -> None:
+    t = SearchTelemetry(
+        engine_kind=EngineKind.MCTS,
+        root_value=0.0,
+        policy_mass_kind=PolicyMassKind.VISITS,
+        root_moves=[],
+        root_identity_preserved=False,
+        principal_variation=[],
+        counters=SearchEventCounters(),
+    )
+    assert search_summary_row(0, "r", "..../..../..../....", t, _run_config()) is None
+
+
+def test_out_of_range_action_index_raises() -> None:
+    bad = RootMoveStat(mv=Move(0, 0, 0), action_index=64, policy_mass=1, q_value=0.0)
+    t = SearchTelemetry(
+        engine_kind=EngineKind.MCTS,
+        root_value=0.0,
+        policy_mass_kind=PolicyMassKind.VISITS,
+        root_moves=[bad],
+        root_identity_preserved=True,
+        principal_variation=[],
+        counters=SearchEventCounters(),
+    )
+    with pytest.raises(ValueError):
+        search_summary_row(0, "r", "..../..../..../....", t, _run_config())
+
+
+def test_mcts_row_populates_policy_visits() -> None:
+    # An asymmetric position preserves identity -> a row is emitted.
+    qfen = "A.bC/..../d..B/...a"
+    engine = MCTSEngine(
+        MCTSConfig(
+            max_iterations=200, random_seed=20260716, use_transposition_table=False
+        )
+    )
+    engine.search(State.from_qfen(qfen))
+    t = engine.telemetry()
+    assert t is not None
+    # This position's legal moves reach 24 distinct canonical children, so
+    # root identity preservation is a structural property of the qfen (not
+    # RNG-dependent): the row is deterministically emitted here.
+    assert t.root_identity_preserved is True
+    row = search_summary_row(
+        0,
+        "run-test",
+        qfen,
+        t,
+        SearchSummaryRunConfig(config_label="mcts", rollouts=200),
+    )
+    assert row is not None
+    assert row["policy_mass_kind"] == "visits"
+    assert sum(row["policy_visits"]) > 0

--- a/tests/test_search_telemetry.py
+++ b/tests/test_search_telemetry.py
@@ -1,0 +1,73 @@
+"""Unit tests for the search_telemetry data types and helpers."""
+
+from quantik_core.move import Move
+from quantik_core.search_telemetry import (
+    UNPROVEN_VALUE_BOUND,
+    EngineKind,
+    PolicyMassKind,
+    RootMoveStat,
+    SearchEventCounters,
+    SearchTelemetry,
+    clamp_unproven,
+)
+
+
+def test_unproven_bound_value() -> None:
+    assert UNPROVEN_VALUE_BOUND == 1.0 - 1e-6
+
+
+def test_clamp_unproven_never_reaches_exact_one() -> None:
+    assert clamp_unproven(1.0) == UNPROVEN_VALUE_BOUND
+    assert clamp_unproven(-1.0) == -UNPROVEN_VALUE_BOUND
+    assert clamp_unproven(2.5) == UNPROVEN_VALUE_BOUND
+    assert clamp_unproven(-2.5) == -UNPROVEN_VALUE_BOUND
+    assert clamp_unproven(0.3) == 0.3
+
+
+def test_engine_kind_strings_match_bench_conventions() -> None:
+    assert EngineKind.MCTS.as_str() == "mcts"
+    assert EngineKind.BEAM.as_str() == "beam"
+    assert EngineKind.MINIMAX.as_str() == "minimax"
+
+
+def test_policy_mass_kind_strings() -> None:
+    assert PolicyMassKind.VISITS.as_str() == "visits"
+    assert PolicyMassKind.MULTIPLICITY.as_str() == "multiplicity"
+    assert PolicyMassKind.NONE.as_str() == "none"
+
+
+def test_root_move_stat_computes_action_index() -> None:
+    stat = RootMoveStat.from_move(Move(0, 2, 5), 7, 0.25)
+    assert stat.action_index == 2 * 16 + 5
+    assert stat.policy_mass == 7
+    assert stat.q_value == 0.25
+
+
+def test_event_counters_default_to_zero() -> None:
+    c = SearchEventCounters()
+    assert (
+        c.expanded_nodes,
+        c.generated_nodes,
+        c.transposition_hits,
+        c.canonical_dedup_hits,
+        c.terminal_hits,
+        c.tablebase_hits,
+    ) == (0, 0, 0, 0, 0, 0)
+
+
+def test_search_telemetry_holds_fields() -> None:
+    t = SearchTelemetry(
+        engine_kind=EngineKind.MCTS,
+        root_value=0.5,
+        policy_mass_kind=PolicyMassKind.VISITS,
+        root_moves=[RootMoveStat.from_move(Move(0, 0, 0), 3, 0.5)],
+        root_identity_preserved=True,
+        principal_variation=[Move(0, 0, 0)],
+        counters=SearchEventCounters(expanded_nodes=1),
+        elapsed_ms=2,
+        depth_reached=1,
+        seed=42,
+    )
+    assert t.engine_kind is EngineKind.MCTS
+    assert t.counters.expanded_nodes == 1
+    assert t.seed == 42


### PR DESCRIPTION
## Summary

Mirrors the Rust search-telemetry surface into the Python engines so both stacks expose identical observable semantics for search diagnostics. Adds:

- `search_telemetry` data types (`SearchEventCounters`, `RootMoveStat`, `SearchTelemetry`, `EngineKind`, `PolicyMassKind`, `clamp_unproven`, `UNPROVEN_VALUE_BOUND`).
- Per-engine instrumentation and a `telemetry()` accessor on the MCTS, beam, and minimax engines (event counters, value mapping, root-identity rules, principal variation). No change to existing search behavior or result types.
- A draft JSONL exporter (`search_summary_row`) plus `examples/search_summary_export.py` running the three engines over a fixed position set.
- `docs/search-telemetry.md` normative reference, indexed from README and `docs/EXAMPLES.md`.

## Why

This is PR 2 of 3 on the `search-summary.v1` registration path. The Rust surface merged as rust#33/#34; contract registration in `quantik-core-contracts` follows as PR 3. The two stacks must expose the same counter event-semantics, value invariant, and root-identity rules before the contract can be registered.

The schema label stays `search-summary.v1-draft` until contracts registration flips it; the non-draft label is intentionally not emitted anywhere in this PR.

## Testing

`bash dev-check.sh` passes: full pytest with coverage (>=90), black --check, flake8, mypy strict, build, twine check.
