### PR TITLE
Adopt registered search-summary.v1 schema label

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -114,7 +114,7 @@ python examples/cross_engine_benchmark.py report \
 
 `examples/search_summary_export.py` runs the MCTS, minimax, and beam engines
 over a fixed set of positions (the empty board plus two mid-game positions,
-seed `20260716`) and writes one draft `search-summary.v1-draft` JSONL row per
+seed `20260716`) and writes one `search-summary.v1` JSONL row per
 completed root search whose root identity was preserved. Rows skipped for an
 unpreserved root identity are logged to stderr, not written. See
 `docs/search-telemetry.md` for the counter semantics and value mapping this

--- a/docs/search-telemetry.md
+++ b/docs/search-telemetry.md
@@ -3,8 +3,8 @@
 This document describes the `search_telemetry` surface shared by the MCTS,
 beam, and minimax engines in this package: what each event counter means, how
 each engine maps its internal values onto a common `[-1, 1]` scale, when a
-telemetry record's root-move identity is trustworthy, and how to export draft
-JSONL rows for offline analysis.
+telemetry record's root-move identity is trustworthy, and how to export
+`search-summary.v1` JSONL rows for offline analysis.
 
 ## 1. Purpose
 
@@ -151,7 +151,7 @@ minimax `dedup_children=False`, and treat beam skips as expected.
 
 ## 6. Exporter usage
 
-Run the draft exporter example against a small fixed position set (the empty
+Run the exporter example against a small fixed position set (the empty
 board plus two mid-game positions), across all three engines:
 
 ```sh

--- a/docs/search-telemetry.md
+++ b/docs/search-telemetry.md
@@ -8,13 +8,12 @@ JSONL rows for offline analysis.
 
 ## 1. Purpose
 
-`search-summary.v1` is a proposed but not-yet-registered data contract for
-search diagnostics (event counters, root-move statistics, principal
-variation) emitted by any of this package's search engines. Registration
-requires that the Rust and Python implementations expose the same observable
-semantics before any artifact carries the finished contract label. This is
-PR 2 of a three-part workstream: the Rust surface (PR 1, merged), this Python
-mirror (PR 2), and contract registration (PR 3, which flips the draft label).
+`search-summary.v1` is a registered data contract
+(`quantik-core-contracts` `schemas/search-summary-v1.json`) for search
+diagnostics (event counters, root-move statistics, principal variation) emitted
+by any of this package's search engines. The Rust surface, this Python mirror,
+and the contract registration all landed; this exporter emits the stable
+`search-summary.v1` schema label.
 
 See also:
 - Rust source doc: `quantik-core-rust/docs/search-telemetry.md` — the
@@ -160,11 +159,11 @@ python examples/search_summary_export.py --out <path>
 ```
 
 This writes one JSON line per completed root search whose root identity was
-preserved, using the schema label `search-summary.v1-draft`
-(`SEARCH_SUMMARY_DRAFT_SCHEMA` in `quantik_core.search_summary`). Rows that are
+preserved, using the registered schema label `search-summary.v1`
+(`SEARCH_SUMMARY_SCHEMA` in `quantik_core.search_summary`). Rows that are
 skipped for an unpreserved root identity are logged to stderr, not written.
 
-**`search-summary.v1` (the non-draft label) must not be emitted anywhere
-until the contract is registered in `quantik-core-contracts`.** The draft
-label exists specifically so downstream consumers can distinguish
-work-in-progress rows from a finished, versioned contract.
+The contract is registered in `quantik-core-contracts`
+(`schemas/search-summary-v1.json`, and `search_summary` in
+`SUPPORTED_CONTRACTS`), so downstream consumers can rely on the stable
+`search-summary.v1` label.

--- a/examples/search_summary_export.py
+++ b/examples/search_summary_export.py
@@ -1,7 +1,7 @@
 """Draft search-telemetry exporter example.
 
 Runs the MCTS, minimax, and beam engines against a handful of fixed positions
-and writes one `search-summary.v1-draft` JSONL row per completed root search
+and writes one `search-summary.v1` JSONL row per completed root search
 whose root identity was preserved. Rows skipped for an unpreserved root
 identity are logged to stderr, not written. Uses the SAME positions and seed as
 the Rust example (`examples/search_summary_export.rs`) so rows are

--- a/examples/search_summary_export.py
+++ b/examples/search_summary_export.py
@@ -1,4 +1,4 @@
-"""Draft search-telemetry exporter example.
+"""Search-telemetry exporter example.
 
 Runs the MCTS, minimax, and beam engines against a handful of fixed positions
 and writes one `search-summary.v1` JSONL row per completed root search

--- a/src/quantik_core/contracts.py
+++ b/src/quantik_core/contracts.py
@@ -15,4 +15,5 @@ SUPPORTED_CONTRACTS = {
     "observation": "observation.v1",
     "game_result": "game-result.v1",
     "model_checkpoint": "model-checkpoint.v1",
+    "search_summary": "search-summary.v1",
 }

--- a/src/quantik_core/search_summary.py
+++ b/src/quantik_core/search_summary.py
@@ -1,9 +1,9 @@
-"""Draft `search-summary.v1-draft` JSONL exporter.
+"""`search-summary.v1` JSONL exporter.
 
 Mirrors `quantik-core-rust`'s `bench::contracts::search_summary_row`
-field-for-field. This is a DRAFT surface: the schema label is
-`search-summary.v1-draft` and the stable `search-summary.v1` label MUST NOT be
-emitted until the contract is registered in quantik-core-contracts.
+field-for-field. The contract is registered in quantik-core-contracts
+(`schemas/search-summary-v1.json`), so this exporter emits the stable
+`search-summary.v1` schema label.
 """
 
 from dataclasses import dataclass
@@ -15,10 +15,9 @@ from .core import State
 from .game_utils import count_total_pieces, get_current_player_from_counts
 from .search_telemetry import SearchTelemetry
 
-# Draft, unstable schema for per-search-call telemetry rows. NOT added to
-# contracts.SUPPORTED_CONTRACTS -- this is a draft surface, not a stabilized
-# cross-repository contract.
-SEARCH_SUMMARY_DRAFT_SCHEMA = "search-summary.v1-draft"
+# Registered schema label for per-search-call telemetry rows
+# (contracts.SUPPORTED_CONTRACTS["search_summary"]).
+SEARCH_SUMMARY_SCHEMA = "search-summary.v1"
 SEARCH_SUMMARY_CONTRACT_VERSION = "1.1.0"
 
 try:
@@ -81,7 +80,7 @@ def search_summary_row(
     ]
 
     return {
-        "schema": SEARCH_SUMMARY_DRAFT_SCHEMA,
+        "schema": SEARCH_SUMMARY_SCHEMA,
         "contract_version": SEARCH_SUMMARY_CONTRACT_VERSION,
         "run_id": run_id,
         "row_id": row_id,

--- a/src/quantik_core/search_summary.py
+++ b/src/quantik_core/search_summary.py
@@ -45,7 +45,7 @@ def search_summary_row(
     telemetry: SearchTelemetry,
     run_config: SearchSummaryRunConfig,
 ) -> Optional[dict]:
-    """Build one draft row, or None when root identity was not preserved.
+    """Build one row, or None when root identity was not preserved.
 
     Skips (returns None) rows whose telemetry has
     root_identity_preserved == False -- a legitimate skip, not an error.

--- a/tests/test_search_summary.py
+++ b/tests/test_search_summary.py
@@ -1,16 +1,17 @@
-"""Tests for the draft search-summary.v1-draft exporter."""
+"""Tests for the search-summary.v1 exporter."""
 
 import json
 
 import pytest
 
 from quantik_core import State
+from quantik_core.contracts import SUPPORTED_CONTRACTS
 from quantik_core.mcts import MCTSConfig, MCTSEngine
 from quantik_core.minimax import MinimaxConfig, MinimaxEngine
 from quantik_core.move import Move
 from quantik_core.search_summary import (
     SEARCH_SUMMARY_CONTRACT_VERSION,
-    SEARCH_SUMMARY_DRAFT_SCHEMA,
+    SEARCH_SUMMARY_SCHEMA,
     SearchSummaryRunConfig,
     search_summary_row,
 )
@@ -27,10 +28,10 @@ def _run_config() -> SearchSummaryRunConfig:
     return SearchSummaryRunConfig(config_label="test", search_depth=4)
 
 
-def test_draft_schema_label_is_exact() -> None:
-    assert SEARCH_SUMMARY_DRAFT_SCHEMA == "search-summary.v1-draft"
-    # The non-draft label must not appear anywhere in the module output.
-    assert "search-summary.v1" != SEARCH_SUMMARY_DRAFT_SCHEMA
+def test_schema_label_is_registered() -> None:
+    assert SEARCH_SUMMARY_SCHEMA == "search-summary.v1"
+    # The registered label is listed in the supported-contracts manifest.
+    assert SUPPORTED_CONTRACTS["search_summary"] == "search-summary.v1"
 
 
 def test_row_shape_and_mask_consistency() -> None:
@@ -43,7 +44,7 @@ def test_row_shape_and_mask_consistency() -> None:
     assert t is not None
     row = search_summary_row(0, "run-test", qfen, t, _run_config())
     assert row is not None
-    assert row["schema"] == SEARCH_SUMMARY_DRAFT_SCHEMA
+    assert row["schema"] == SEARCH_SUMMARY_SCHEMA
     assert row["contract_version"] == SEARCH_SUMMARY_CONTRACT_VERSION
     assert row["engine_kind"] == "minimax"
     assert len(row["policy_visits"]) == 64


### PR DESCRIPTION
## Summary

`search-summary.v1` is now registered in `quantik-core-contracts` (`schemas/search-summary-v1.json`, contracts #18), so the exporter adopts the stable label:

- `SEARCH_SUMMARY_DRAFT_SCHEMA` → **`SEARCH_SUMMARY_SCHEMA = "search-summary.v1"`**; the row's `schema` field now emits `search-summary.v1`.
- Add `"search_summary": "search-summary.v1"` to `SUPPORTED_CONTRACTS`.
- Drop the draft/not-registered framing in the module docstring, example, `EXAMPLES.md`, and `search-telemetry.md`.
- Tests assert the registered label + its `SUPPORTED_CONTRACTS` entry.

Version metadata (package version, `SUPPORTED_CONTRACTS_RELEASE`, `contract_version`) is intentionally **unchanged** — the coordinated `1.2.0` bump across contracts/py/rust lands with the release (make-release), not here.

Pairs with the rust flip (`quantik-core-rust`) landing in lockstep.

## Verification
34 telemetry/example tests + 112 artifact/ml tests pass; `black`/`flake8`/`mypy` clean.